### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Iris is an open-source [Model Context Protocol](https://modelcontextprotocol.io/
 
 ![Iris Dashboard](https://raw.githubusercontent.com/iris-eval/mcp-server/main/docs/assets/dashboard-overview.png)
 
+[![iris-eval/mcp-server MCP server](https://glama.ai/mcp/servers/iris-eval/mcp-server/badges/card.svg)](https://glama.ai/mcp/servers/iris-eval/mcp-server)
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [iris-eval/mcp-server](https://glama.ai/mcp/servers/iris-eval/mcp-server) server listing in Glama MCP server directory.

[![iris-eval/mcp-server MCP server](https://glama.ai/mcp/servers/iris-eval/mcp-server/badges/card.svg)](https://glama.ai/mcp/servers/iris-eval/mcp-server)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.