### PR TITLE
fix(blog): sort index by date, not filename

### DIFF
--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -78,9 +78,7 @@ function filenameToSlug(filename: string): string {
 
 export function getAllPosts(): BlogPost[] {
   const files = readdirSync(BLOG_DIR)
-    .filter((f) => f.endsWith(".md") && !f.startsWith(".") && /^\d{3}-/.test(f))
-    .sort()
-    .reverse();
+    .filter((f) => f.endsWith(".md") && !f.startsWith(".") && /^\d{3}-/.test(f));
 
   const now = new Date();
 
@@ -103,11 +101,11 @@ export function getAllPosts(): BlogPost[] {
       };
     })
     .filter((post) => {
-      // Hide posts with published: false or future dates
       if (!post.published) return false;
       const postDate = new Date(post.date);
       return postDate <= now;
-    });
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
 export function getPostBySlug(slug: string): BlogPost | undefined {


### PR DESCRIPTION
## Summary

`getAllPosts()` was sorting posts by filename descending, causing blog 026 (dated 2026-03-29) to appear above blog 019 (dated 2026-04-14) on the blog index.

Surfaced when blog 026 date was reconciled from 2026-04-22 → 2026-03-29 during v0.2.1 (to restore broken Dev.to canonical).

## Change

Move the sort after the filter + map pipeline, sort by `new Date(date).getTime()` descending. Now display order tracks actual recency regardless of the NNN- prefix.

## Test plan

- [ ] CI green
- [ ] Vercel preview: verify `/blog` lists post 019 (April 14) above post 026 (March 29)
- [ ] Verify newest post ("Closing the Eval Gap") is at top of index
- [ ] Verify older posts 001-002 are at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)