### PR TITLE
fix(ux): dashboard discoverability + retention guard + env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,25 @@ Add Iris to your MCP config. Works with Claude Desktop, Cursor, Windsurf, and an
 
 That's it. Your agent discovers Iris and starts logging traces automatically.
 
-Want the dashboard?
+### Turn on the dashboard
+
+Iris ships with a real-time web dashboard showing traces, eval results, cost breakdowns, and rule pass-rates. It's off by default so the MCP server stays lightweight — flip it on with a flag.
+
+```json
+{
+  "mcpServers": {
+    "iris-eval": {
+      "command": "npx",
+      "args": ["@iris-eval/mcp-server", "--dashboard"]
+    }
+  }
+}
+```
+
+Then open **http://localhost:6920** after your agent runs a trace. The same dashboard is available via CLI:
 
 ```bash
 npx @iris-eval/mcp-server --dashboard
-# Open http://localhost:6920
 ```
 
 <details>
@@ -120,9 +134,10 @@ Self-hosted Iris runs on your machine with SQLite. As your team's eval needs gro
 ## Examples
 
 - [Claude Desktop setup](examples/claude-desktop/) — MCP config for stdio and HTTP modes
-- [TypeScript](examples/typescript/basic-usage.ts) — MCP SDK client usage
-- [LangChain](examples/langchain/observe-agent.py) — Agent instrumentation
-- [CrewAI](examples/crewai/observe-crew.py) — Crew observability
+- [TypeScript — MCP SDK client](examples/typescript/basic-usage.ts) — connect and invoke tools
+- [HTTP transport (TS + Python)](examples/http-transport/) — full client code for REST-style integration
+- [LangChain instrumentation (Python, conceptual)](examples/langchain/observe-agent.py) — scaffold showing the shape; needs your agent code to be runnable
+- [CrewAI instrumentation (Python, conceptual)](examples/crewai/observe-crew.py) — scaffold; same caveat
 
 ## Community
 
@@ -150,13 +165,17 @@ Self-hosted Iris runs on your machine with SQLite. As your team's eval needs gro
 
 | Variable | Description |
 |----------|-------------|
-| `IRIS_TRANSPORT` | Transport type |
-| `IRIS_PORT` | HTTP port |
-| `IRIS_DB_PATH` | Database path |
-| `IRIS_LOG_LEVEL` | Log level: debug, info, warn, error |
-| `IRIS_DASHBOARD` | Enable dashboard (true/false) |
+| `IRIS_TRANSPORT` | Transport type (`stdio` or `http`) |
+| `IRIS_PORT` | HTTP transport port |
+| `IRIS_HOST` | HTTP transport host (default `127.0.0.1`) |
+| `IRIS_DB_PATH` | SQLite database path |
+| `IRIS_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` |
+| `IRIS_DASHBOARD` | Enable web dashboard (`true`/`false`) |
+| `IRIS_DASHBOARD_PORT` | Dashboard port (default `6920`) |
 | `IRIS_API_KEY` | API key for HTTP authentication |
 | `IRIS_ALLOWED_ORIGINS` | Comma-separated allowed CORS origins |
+
+CLI flags take precedence over environment variables when both are set.
 
 ### Security
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,13 @@ async function main(): Promise<void> {
 
   // Run data retention cleanup on startup
   if (config.retention.days > 0) {
-    const deleted = await storage.deleteTracesOlderThan(config.retention.days);
-    if (deleted > 0) {
-      logger.info(`Retention cleanup: deleted ${deleted} trace(s) older than ${config.retention.days} days`);
+    try {
+      const deleted = await storage.deleteTracesOlderThan(config.retention.days);
+      if (deleted > 0) {
+        logger.info(`Retention cleanup: deleted ${deleted} trace(s) older than ${config.retention.days} days`);
+      }
+    } catch (err) {
+      logger.warn(`Retention cleanup skipped: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -84,6 +88,9 @@ async function main(): Promise<void> {
     const transport = createStdioTransport();
     await mcpServer.connect(transport);
     logger.info('Stdio transport connected');
+    if (!config.dashboard.enabled) {
+      logger.info(`Tip: run with --dashboard to open the web dashboard on port ${config.dashboard.port}`);
+    }
   }
 
   if (config.dashboard.enabled || config.transport.type === 'http') {

--- a/website/src/components/nav.tsx
+++ b/website/src/components/nav.tsx
@@ -31,7 +31,7 @@ export function Nav(): React.ReactElement {
       {/* Event banner */}
       <div className="relative z-50 border-b border-border-subtle bg-iris-600/8 px-4 py-2.5 text-center">
         <a href="https://github.com/iris-eval/mcp-server" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm text-text-secondary transition-colors hover:text-text-primary">
-          <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v0.2</span>
+          <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v0.2.1</span>
           <span>Iris — The agent eval standard for MCP. 12 eval rules, open source</span>
           <span className="text-text-accent">&rarr;</span>
         </a>


### PR DESCRIPTION
## Summary

Addresses founder feedback from live v0.2.1 testing: *"if I didn't know it had a dashboard I wouldn't have known, although it's in the README it needs to be more intuitive."*

Plus two adjacent fixes that came out of the Session 31 full-lattice audit.

## Changes

### Dashboard discoverability (the main fix)

- **Startup log tip.** In stdio mode when `--dashboard` isn't passed, server now logs:
  ```
  Stdio transport connected
  Tip: run with --dashboard to open the web dashboard on port 6920
  ```
  So anyone running the binary sees the affordance immediately — not buried in docs.

- **README restructure.** Dashboard promoted to its own `### Turn on the dashboard` section with a copy-paste MCP config that already includes `--dashboard`. Previously this lived under a throwaway "Want the dashboard?" line.

### Retention cleanup resilience

- Wrap `storage.deleteTracesOlderThan()` at startup in try/catch. Corrupt DB or disk-full conditions now log a warning and continue instead of silently crashing the server.

### Docs + env vars

- Add `IRIS_HOST` and `IRIS_DASHBOARD_PORT` to README env var table (both were undocumented in source).
- Note CLI flags take precedence over env vars when both are set.
- Relabel LangChain/CrewAI examples as "(conceptual scaffold)" to match actual state. Add http-transport to examples list.

### Version coherence

- Nav banner badge `v0.2` → `v0.2.1` for full alignment across all surfaces post-v0.2.1 release.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 120/120 passing
- [x] stdio test verifies new tip line in logs
- [ ] Vercel preview: verify banner reads `v0.2.1` on iris-eval.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)