### PR TITLE
v0.2.3 — Mother Audit Wave 1 patches

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "author": {
     "name": "Iris",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-04-16
+
+Mother Audit Wave 1 patch checkpoint. Five small surface-correctness fixes surfaced by an end-to-end audit (product + external surface + diligence lens). No product behavior changes.
+
+### Fixed
+- Homepage stat counters now render their values on first paint instead of "0" until scrolled into view (`stats.tsx` flips MCP-tools / eval-rules / latency to `static: true`; AnimatedCounter unchanged for in-component playground reveals)
+- Sitemap now includes `/privacy` and `/terms` (the pages already existed; only the sitemap was missing them)
+
+### Changed
+- Nav banner badge bumped v0.2.1 → v0.2.3 (matches release tag)
+- `SECURITY.md` Supported Versions table updated: `0.2.x` Yes, `0.1.x` No (was showing `0.1.x` only)
+- `CHANGELOG.md` v0.2.2 entry: replaced "full-lattice audit" with "full-system audit" (carve-out hygiene; "Lattice" is reserved for parent-company IP terminology)
+
 ## [0.2.2] - 2026-04-16
 
-Pre-YC alignment checkpoint — UX fixes from Session 31 full-lattice audit. No product behavior changes beyond the dashboard-tip log and retention cleanup guard.
+Pre-YC alignment checkpoint — UX fixes from Session 31 full-system audit. No product behavior changes beyond the dashboard-tip log and retention cleanup guard.
 
 ### Added
 - stdio startup logs a Tip pointing at `--dashboard` flag when not enabled (directly addresses user feedback: "if I didn't know it had a dashboard I wouldn't have known")

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,9 +19,12 @@ This security policy applies to:
 
 ## Supported Versions
 
+Only the latest minor receives security fixes. Older minors do not — upgrade to the current `0.2.x` line.
+
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.2.x   | Yes       |
+| 0.1.x   | No        |
 
 ## What We Consider a Vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iris-eval/mcp-server",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "mcpName": "io.github.iris-eval/mcp-server",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/iris-eval/mcp-server",
     "source": "github"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@iris-eval/mcp-server",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "transport": {
         "type": "stdio"
       },

--- a/website/public/.well-known/mcp.json
+++ b/website/public/.well-known/mcp.json
@@ -4,7 +4,7 @@
   "homepage": "https://iris-eval.com",
   "repository": "https://github.com/iris-eval/mcp-server",
   "npm": "@iris-eval/mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "transport": [
     "stdio",

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -91,5 +91,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     ...compareEntries,
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/terms`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
   ];
 }

--- a/website/src/components/nav.tsx
+++ b/website/src/components/nav.tsx
@@ -31,7 +31,7 @@ export function Nav(): React.ReactElement {
       {/* Event banner */}
       <div className="relative z-50 border-b border-border-subtle bg-iris-600/8 px-4 py-2.5 text-center">
         <a href="https://github.com/iris-eval/mcp-server" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm text-text-secondary transition-colors hover:text-text-primary">
-          <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v0.2.1</span>
+          <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v0.2.3</span>
           <span>Iris — The agent eval standard for MCP. 12 eval rules, open source</span>
           <span className="text-text-accent">&rarr;</span>
         </a>

--- a/website/src/components/stats.tsx
+++ b/website/src/components/stats.tsx
@@ -3,9 +3,9 @@
 import { AnimatedCounter } from "./animated-counter";
 
 const STATS = [
-  { value: 3, suffix: "", label: "MCP tools", detail: "log_trace, evaluate_output, get_traces" },
-  { value: 12, suffix: "", label: "Built-in eval rules", detail: "Completeness, relevance, safety, cost" },
-  { prefix: "<", value: 1, suffix: "ms", label: "Eval latency", detail: "Heuristic rules. Fast and deterministic." },
+  { value: 3, suffix: "", label: "MCP tools", detail: "log_trace, evaluate_output, get_traces", static: true },
+  { value: 12, suffix: "", label: "Built-in eval rules", detail: "Completeness, relevance, safety, cost", static: true },
+  { prefix: "<", value: 1, suffix: "ms", label: "Eval latency", detail: "Heuristic rules. Fast and deterministic.", static: true },
   { value: 0, suffix: "", label: "Lines of code to integrate", detail: "Add to MCP config. You're done.", static: true },
 ];
 


### PR DESCRIPTION
## Summary

Five surface-correctness fixes from a full-system audit (product + external surface + diligence lens). No product behavior changes.

- `stats.tsx`: flip homepage hero counters to static (was rendering "0" first paint until scrolled-into-view; SEO + crawler + initial-paint fix; AnimatedCounter retained for in-view playground reveals)
- `sitemap.ts`: add `/privacy` + `/terms` (pages already existed; only the sitemap was missing them)
- `nav.tsx`: banner badge v0.2.1 → v0.2.3 (matches release tag)
- `SECURITY.md`: Supported Versions table updated (0.2.x Yes, 0.1.x No)
- `CHANGELOG.md` v0.2.2 entry: "full-lattice audit" → "full-system audit" (carve-out hygiene)

Version sync: `package.json` 0.2.2 → 0.2.3, propagated via `scripts/sync-versions.mjs` to `server.json`, `website/public/.well-known/mcp.json`, `.claude-plugin/plugin.json`.

## Test plan

- [x] typecheck clean (`npm run typecheck`)
- [x] build clean (`npm run build`)
- [x] 120/120 tests pass (`npm test`)
- [x] website typecheck clean (`cd website && npx tsc --noEmit`)
- [ ] CI passes on PR
- [ ] Vercel preview: nav shows v0.2.3, hero stat counters render 3 / 12 / <1ms / 0 (not all-zeros)
- [ ] After merge: tag v0.2.3 → npm publish + Docker push + GitHub Release
- [ ] Post-release: run mcp-publisher → MCP Registry 0.2.3 isLatest=true
- [ ] Cascade verify 24-48h post-publish: PulseMCP, mcpservers.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)