### PR TITLE
fix(tests): charts.test.tsx time-flake — use relative dates in StackedBarByDay fixtures

### DIFF
--- a/dashboard/tests/a11y/charts.test.tsx
+++ b/dashboard/tests/a11y/charts.test.tsx
@@ -66,17 +66,29 @@ const sampleAudit: AuditLogEntry[] = [
   { ts: '2026-04-17T12:00:00Z', action: 'rule.deploy', user: 'local', ruleId: 'r1', ruleName: 'no-pii-strict' },
 ];
 
-const sampleMoment: DecisionMoment = {
-  id: 'm1',
-  traceId: 't1',
-  agentName: 'agent-alpha',
-  timestamp: '2026-04-18T10:00:00Z',
-  verdict: 'pass',
-  overallScore: 0.9,
-  evalCount: 3,
-  ruleSnapshot: { failed: [], skipped: [], passedCount: 3, totalCount: 3 },
-  significance: { kind: 'normal-pass', score: 0.1, label: 'Pass', reason: 'all rules passed' },
-};
+/*
+ * Factory — returns a moment dated N days ago at noon UTC. Tests against
+ * components with rolling windows (StackedBarByDay's 7-day bucketing)
+ * must use relative dates; a hardcoded fixture date silently falls out
+ * of the window as time passes and the component renders its empty state
+ * — a time-flake we hit when CI ran 15 days after the fixture date.
+ */
+function makeSampleMoment(daysAgo: number = 1): DecisionMoment {
+  const ts = new Date();
+  ts.setUTCHours(12, 0, 0, 0);
+  ts.setUTCDate(ts.getUTCDate() - daysAgo);
+  return {
+    id: `m-${daysAgo}`,
+    traceId: `t-${daysAgo}`,
+    agentName: 'agent-alpha',
+    timestamp: ts.toISOString(),
+    verdict: 'pass',
+    overallScore: 0.9,
+    evalCount: 3,
+    ruleSnapshot: { failed: [], skipped: [], passedCount: 3, totalCount: 3 },
+    significance: { kind: 'normal-pass', score: 0.1, label: 'Pass', reason: 'all rules passed' },
+  };
+}
 
 function renderWithRouter(ui: React.ReactElement): HTMLElement {
   const { container } = render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -201,7 +213,7 @@ describe('a11y · chart primitives', () => {
   describe('StackedBarByDay', () => {
     it('populated state has no violations', async () => {
       const container = renderWithRouter(
-        <StackedBarByDay moments={[sampleMoment, sampleMoment, sampleMoment]} days={7} periodLabel="7d" />,
+        <StackedBarByDay moments={[makeSampleMoment(1), makeSampleMoment(2), makeSampleMoment(3)]} days={7} periodLabel="7d" />,
       );
       const results = await runAxe(container);
       expect(results.violations).toEqual([]);
@@ -209,7 +221,7 @@ describe('a11y · chart primitives', () => {
 
     it('populated state exposes data summary in <desc>', () => {
       const container = renderWithRouter(
-        <StackedBarByDay moments={[sampleMoment, sampleMoment, sampleMoment]} days={7} periodLabel="7d" />,
+        <StackedBarByDay moments={[makeSampleMoment(1), makeSampleMoment(2), makeSampleMoment(3)]} days={7} periodLabel="7d" />,
       );
       const desc = container.querySelector('desc');
       expect(desc).not.toBeNull();
@@ -219,7 +231,7 @@ describe('a11y · chart primitives', () => {
 
     it('populated state exposes hidden drill-through list with day links', () => {
       const container = renderWithRouter(
-        <StackedBarByDay moments={[sampleMoment, sampleMoment, sampleMoment]} days={7} periodLabel="7d" />,
+        <StackedBarByDay moments={[makeSampleMoment(1), makeSampleMoment(2), makeSampleMoment(3)]} days={7} periodLabel="7d" />,
       );
       const hiddenList = container.querySelector('ol[aria-label="Per-day drill-through"]');
       expect(hiddenList).not.toBeNull();


### PR DESCRIPTION
## Summary

CI lint-and-typecheck started failing today (2026-05-03) on `tests/a11y/charts.test.tsx` — 2 tests in StackedBarByDay broke without any code change to the component.

## Root cause

`sampleMoment` had a hardcoded timestamp of `'2026-04-18T10:00:00Z'`. StackedBarByDay buckets moments into a rolling 7-day window via `utcDay.floor(new Date())`. 15 days after the fixture date:

- Every test moment fell outside the rolling window
- `bucketByDay` silently dropped them (`if (!bucket) continue;`)
- `totalAcrossPeriod === 0` triggered the empty-state early-return
- The empty state has no `<desc>` and no `<ol aria-label="Per-day drill-through">`
- Tests expecting those elements failed with `expected null not to be null`

Run ID: [25259473456](https://github.com/iris-eval/mcp-server/actions/runs/25259473456) (lint-and-typecheck job, 2026-05-02)

## Fix

Replace the const \`sampleMoment\` with a \`makeSampleMoment(daysAgo)\` factory. Each call computes the timestamp relative to the current date, pinned to noon UTC for \`utcDay.floor\` determinism.

Tests updated to pass \`daysAgo = 1, 2, 3\` — three distinct days that always fall within any 7-day window from "now," regardless of when CI runs.

No component code touched; this is a test-fixture-side fix only.

## Test plan

- [x] Local diff verified surgical (1 file, 4 changes — 1 fixture refactor + 3 usage updates)
- [ ] CI passes on this branch
- [ ] StackedBarByDay populated tests confirm \`<desc>\` and hidden \`<ol>\` are now in the rendered DOM
- [ ] Other StackedBarByDay tests (axe-no-violations, empty state) still pass

## Future hardening

Any other test fixtures with hardcoded dates against rolling-window components carry the same risk. A repo-wide grep for hardcoded \`'2026-...'\` timestamps used as fixtures would surface them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)