### PR TITLE
fix(build): tenant.ts type augmentation works under pnpm strict layout

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -24,10 +24,22 @@ import { LOCAL_TENANT } from '../types/tenant.js';
 /*
  * Express request type augmentation. Every request that has been
  * through the tenant middleware has a non-optional tenantId.
+ *
+ * Pattern note: we augment the global `Express.Request` namespace
+ * rather than `'express-serve-static-core'`. Both work under npm's
+ * flat-hoisted node_modules, but pnpm's strict isolated layout (used
+ * by Glama's build sandbox + many enterprise installs) doesn't expose
+ * `express-serve-static-core` as a directly-resolvable module — it
+ * lives nested under express's own node_modules. The Express global
+ * namespace pattern resolves through `@types/express` (a direct dep)
+ * without depending on the transitive package being hoisted.
  */
-declare module 'express-serve-static-core' {
-  interface Request {
-    tenantId?: TenantId;
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      tenantId?: TenantId;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Glama's build pipeline uses pnpm with strict node_modules isolation. Iris CI uses npm with flat hoisting. Both worked previously because tsc could resolve \`'express-serve-static-core'\` as a transitively hoisted module under npm. Under pnpm strict, that transitive package lives nested under express's own node_modules and is **not** directly resolvable.

## Glama build error (build id 019def86, against commit 5b53c83)

\`\`\`
src/middleware/tenant.ts(28,16): error TS2664: Invalid module name in augmentation, module 'express-serve-static-core' cannot be found.
src/middleware/tenant.ts(36,17): error TS2339: Property 'tenantId' does not exist on type 'Request<...>'.
src/middleware/tenant.ts(56,9): error TS2339: Property 'tenantId' does not exist on type 'Request<...>'.
\`\`\`

## Fix

Switched from:

\`\`\`ts
declare module 'express-serve-static-core' {
  interface Request { tenantId?: TenantId; }
}
\`\`\`

to the canonical Express global namespace pattern:

\`\`\`ts
declare global {
  namespace Express {
    interface Request { tenantId?: TenantId; }
  }
}
\`\`\`

Same semantic behavior — \`req.tenantId\` resolves via interface merging at the global Express namespace. Resolves through \`@types/express\` (a direct devDep) without requiring the transitive \`express-serve-static-core\` to be hoisted. Works under both npm flat hoisting AND pnpm strict isolation.

Added comment block explaining the pattern + why pnpm strict is the forcing function, so future contributors don't revert.

## Test plan

- [x] Local: \`npx tsc -p tsconfig.build.json --noEmit\` passes cleanly under iris's npm setup
- [ ] CI \`lint-and-typecheck\` passes (npm + tsc)
- [ ] CI \`test (20)\` and \`test (22)\` pass — runtime behavior unchanged
- [ ] CI \`integration\` passes
- [ ] After merge: founder retries Glama Build & Release at \`glama.ai/mcp/servers/iris-eval/mcp-server/admin/dockerfile\` — pnpm strict build should now succeed

## Why this was latent for so long

The bug existed since tenant isolation shipped (v0.4.0, commit 190c2a7). It was masked by npm flat hoisting, which makes transitive types directly resolvable. Glama's isolated build correctly surfaced it. Adding pnpm to iris CI is a separate hardening discussion (would catch this class of bug at PR time, not at Glama-rebuild time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)