### PR TITLE
fix(website): hero GitHub stars badge rendered "stars: invalid"

### DIFF
--- a/website/src/components/hero.tsx
+++ b/website/src/components/hero.tsx
@@ -11,7 +11,7 @@ const BADGES = [
   { src: "https://img.shields.io/badge/Cursor_Directory-Listed-171717?style=flat-square", alt: "Cursor Directory", href: "https://cursor.directory/plugins/iris" },
   { src: "https://img.shields.io/npm/v/@iris-eval/mcp-server?style=flat-square&color=0d9488&label=npm", alt: "npm version", href: "https://www.npmjs.com/package/@iris-eval/mcp-server" },
   { src: "https://img.shields.io/npm/dt/@iris-eval/mcp-server?style=flat-square&color=0d9488&label=downloads", alt: "npm downloads", href: "https://www.npmjs.com/package/@iris-eval/mcp-server" },
-  { src: "https://img.shields.io/github/stars/iris-eval/mcp-server?style=flat-square&color=0d9488", alt: "GitHub stars", href: "https://github.com/iris-eval/mcp-server" },
+  { src: "https://img.shields.io/github/stars/iris-eval/mcp-server?style=flat-square&color=0d9488&label=stars", alt: "GitHub stars", href: "https://github.com/iris-eval/mcp-server" },
   { src: "https://img.shields.io/github/actions/workflow/status/iris-eval/mcp-server/ci.yml?style=flat-square&label=CI", alt: "CI status", href: "https://github.com/iris-eval/mcp-server/actions" },
   { src: "https://img.shields.io/badge/license-MIT-22c55e?style=flat-square", alt: "MIT License", href: "https://github.com/iris-eval/mcp-server/blob/main/LICENSE" },
 ];


### PR DESCRIPTION
## Summary
- The hero badge `https://img.shields.io/github/stars/iris-eval/mcp-server?style=flat-square&color=0d9488` was rendering as `stars: invalid` on the live site.
- Repo is healthy (public, 6 stars, not archived); other shields endpoints for the same repo (`/github/actions/...`, `/github/v/release`) work fine.
- Root cause is a shields.io rendering quirk: `/github/stars/<owner>/<repo>?style=flat-square` returns `invalid` unless an explicit `label=` or `logo=` parameter is supplied. Confirmed by isolating the parameter combos against the live shields.io endpoint.
- Fix: append `&label=stars` — matches the existing `&label=npm` / `&label=downloads` pattern on the adjacent npm badges (lines 12-13), so visual style stays uniform across the row.

## Test plan
- [x] Verified `https://img.shields.io/github/stars/iris-eval/mcp-server?style=flat-square&color=0d9488&label=stars` renders `stars 6` (real count from GH API).
- [ ] CI green (lint + typecheck).
- [ ] Post-merge: visit production hero, confirm badge shows `stars 6` (or current count) instead of `invalid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)