### PR TITLE
chore(supply-chain): SHA-pin GH Actions + Dockerfile base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,3 +90,14 @@ updates:
       github:
         patterns:
           - "actions/*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -38,8 +38,8 @@ jobs:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -64,8 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint-and-typecheck, test]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -90,8 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -107,7 +107,7 @@ jobs:
         run: npx playwright install --with-deps chromium firefox
       - name: Run Playwright E2E (Chromium + Firefox)
         run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,17 +22,17 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/devto-crosspost.yml
+++ b/.github/workflows/devto-crosspost.yml
@@ -24,9 +24,9 @@ jobs:
   crosspost:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,8 +20,8 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload Lighthouse report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: lighthouse-report
           path: .lighthouseci/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -38,8 +38,8 @@ jobs:
     outputs:
       sbom-path: ${{ steps.sbom.outputs.fileName }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -66,7 +66,7 @@ jobs:
       # so acquirers + enterprise procurement can verify supply chain.
       - name: Generate npm package SBOM
         id: sbom
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a  # v0.9.0
         with:
           path: .
           format: spdx-json
@@ -97,12 +97,12 @@ jobs:
       # --provenance` attestation — this one covers the checked-out source
       # tree and any extra artifacts we publish (SBOM).
       - name: Attest npm SBOM
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
         with:
           subject-path: iris-npm-sbom.spdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: npm-sbom
           path: iris-npm-sbom.spdx.json
@@ -114,10 +114,10 @@ jobs:
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build + push multi-arch image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile
@@ -166,7 +166,7 @@ jobs:
       #    --certificate-identity-regexp=https://github.com/iris-eval/mcp-server
       #    --certificate-oidc-issuer=https://token.actions.githubusercontent.com`.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
 
       - name: Sign Docker image by digest
         env:
@@ -180,7 +180,7 @@ jobs:
       # is what enterprise procurement usually asks for.
       - name: Generate Docker image SBOM
         id: sbom-docker
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a  # v0.9.0
         with:
           image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           format: spdx-json
@@ -189,14 +189,14 @@ jobs:
           artifact-name: iris-docker-${{ github.ref_name }}.spdx.json
 
       - name: Attest Docker SBOM
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
       - name: Upload Docker SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: docker-sbom
           path: iris-docker-sbom.spdx.json
@@ -206,15 +206,15 @@ jobs:
     needs: [publish-npm, publish-docker]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # Pull SBOMs from the publish jobs so the release page exposes them
       # as downloadable assets for security / procurement diligence.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: npm-sbom
           path: ./release-assets
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: docker-sbom
           path: ./release-assets
@@ -232,7 +232,7 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: true
           prerelease: ${{ steps.release-type.outputs.prerelease == 'true' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -14,7 +14,7 @@ RUN npm run build
 COPY dashboard/ dashboard/
 RUN cd dashboard && npm install && npm run build
 
-FROM node:20-alpine AS production
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS production
 
 RUN addgroup -g 1001 iris && adduser -u 1001 -G iris -s /bin/sh -D iris
 


### PR DESCRIPTION
## Summary

Every `uses:` line across the 5 workflow files was floating-tag-pinned (`@v6`, `@v4`, `@v0`, `@v3`, `@v7`). The release workflow holds `id-token: write` + `NPM_TOKEN`, so a tag move on any signing/publishing action would silently substitute new code into the publish pipeline. Dockerfile `FROM node:20-alpine` was unpinned too — Alpine security rebuilds replace the tag periodically.

## What changed

### 13 actions pinned to commit SHAs (with version comments preserved)

| Action | Old | New | Tag |
|---|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `actions/setup-node` | `@v6` | `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/download-artifact` | `@v4` | `@d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
| `actions/attest-build-provenance` | `@v2` | `@e8998f949152b193b063cb0ec769d69d929409be` | v2.4.0 |
| `anchore/sbom-action` | `@v0` | `@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a` | v0.9.0 |
| `docker/setup-qemu-action` | `@v4` | `@ce360397dd3f832beb865e1373c09c0e9f86d70a` | v4.0.0 |
| `docker/setup-buildx-action` | `@v4` | `@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` | v4.0.0 |
| `docker/login-action` | `@v4` | `@4907a6ddec9925e35a0a9e82d7399ccc52663121` | v4.1.0 |
| `docker/build-push-action` | `@v7` | `@bcafcacb16a39f128d818304e6c9c0c18556b85f` | v7.1.0 |
| `sigstore/cosign-installer` | `@v3` | `@d58896d6a1865668819e1d91763c7751a165e159` | v3.9.2 |
| `softprops/action-gh-release` | `@v3` | `@b4309332981a82ec1c5618f44dd2e27cc8bfbfda` | v3.0.0 |
| `github/codeql-action/{init,autobuild,analyze}` | `@v4` | `@e46ed2cbd01164d986452f91f178727624ae40d7` | v4.35.3 |

### Dockerfile pinned

Both stages (`builder` + `production`) of `FROM node:20-alpine` now pin to the multi-arch OCI index digest `@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293` (verified via `docker buildx imagetools inspect node:20-alpine`).

### Dependabot updated

Added `package-ecosystem: docker` so the Dockerfile digest gets weekly bumps. The existing `github-actions` ecosystem already covers the workflow SHAs; with this PR pinning to commit SHAs, Dependabot will surface PRs to bump them as new tags ship.

## Risk

**Low — deterministic substitution.** Every floating-tag swap maps to the latest released SHA matching the same major. CI is the validation gate.

## Test plan

- [ ] CI green (this PR's own CI is the smoke test — every action listed runs at least once)
- [x] All SHAs verified well-formed (40-char hex from `gh api repos/<owner>/<repo>/commits/<tag>`)
- [x] Docker digest verified via `docker buildx imagetools inspect` against the live Docker Hub manifest

PR 4a of 9 — plan: `plans/yes-lets-take-care-linear-elephant.md`. Blocks PR 5 (which adds a new nightly workflow that should be SHA-pinned from day one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)