### PR TITLE
feat(store): thread TenantId through CustomRuleStore (per-tenant file partition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`CustomRuleStore` API now accepts `TenantId` as the first argument on every public method (`list` / `get` / `deploy` / `delete` / `setEnabled` / `enabledRules`).** OSS deployments are unaffected — the tenant middleware always resolves to `LOCAL_TENANT`, and the default file path for `LOCAL_TENANT` remains `~/.iris/custom-rules.json` (zero migration). Cloud tenants get per-tenant file partition (`~/.iris/custom-rules-<sanitized-tenantId>.json`) so one tenant's data can never poison another's. The constructor now accepts `pathFor: (tenantId) => string` instead of `rulesPath: string` so Cloud orchestrators can inject their own routing. Audit log entries now carry the resolved `tenantId` instead of a hardcoded `'local'`. `src/custom-rule-store.ts`. Internal API change — no public package consumer affected.
+
 ### Security
 
 - **CORS allowlist now matches a single hostname/port label per `*` wildcard.** Previously `pattern.replace(/\*/g, '.*')` substituted `.*` (matches dots/colons/slashes), so an entry like `http://localhost:*` would also match a malicious origin like `http://localhost:8080.evil.com`. Substitution is now `[^.:/]+`. Any allowlist entry that previously matched origins crossing a label boundary will now be rejected — review your `security.allowedOrigins` config if you rely on multi-label subdomain matching (use multiple explicit entries instead). `src/middleware/cors.ts`.

--- a/src/custom-rule-store.ts
+++ b/src/custom-rule-store.ts
@@ -1,14 +1,27 @@
 /*
  * custom-rule-store — file-based persistence for deployed custom rules.
  *
- * Lives at ~/.iris/custom-rules.json with the schema in
- * src/types/custom-rule.ts. Audit log lives at ~/.iris/audit.log
- * (append-only JSONL). Both files are created on first write.
+ * Per-tenant file partition: each tenant's rules live in their own
+ * file. OSS single-tenant installs continue to use
+ * ~/.iris/custom-rules.json (the LOCAL_TENANT path) — zero migration
+ * for existing users. Cloud tenants get
+ * ~/.iris/custom-rules-<tenantId>.json (or whatever path the
+ * `pathFor` factory returns).
+ *
+ * Why per-file rather than top-level keys in one file or a tenant
+ * column on each rule:
+ *   - Zero migration: LOCAL_TENANT keeps the v0.4 file path/schema.
+ *   - Smallest blast radius for a corrupt write: one tenant's data
+ *     can't poison another's.
+ *   - Mirrors the existing audit-log per-file convention.
+ *
+ * Audit log stays SHARED across tenants: every entry already carries
+ * `tenantId` so readers can scope at query time.
  *
  * The v0.4 cut is single-user local. Concurrent writes from multiple
- * iris-mcp instances are not protected — that's a v0.5 concern when
- * multi-tenancy lands. For now we use atomic write-via-rename so a
- * crashed write doesn't leave a half-file.
+ * iris-mcp instances against the same tenant file are not protected.
+ * For now we use atomic write-via-rename so a crashed write doesn't
+ * leave a half-file.
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync, appendFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -22,6 +35,7 @@ import type {
   RuleSeverity,
 } from './types/custom-rule.js';
 import type { CustomRuleDefinition, EvalType } from './types/eval.js';
+import { LOCAL_TENANT, type TenantId } from './types/tenant.js';
 
 const SEVERITY_VALUES: RuleSeverity[] = ['low', 'medium', 'high', 'critical'];
 const EVAL_TYPE_VALUES: EvalType[] = ['completeness', 'relevance', 'safety', 'cost', 'custom'];
@@ -62,8 +76,19 @@ const FileSchema = z.object({
   rules: z.array(DeployedRuleSchema),
 });
 
-function defaultRulesPath(): string {
-  return join(homedir(), '.iris', 'custom-rules.json');
+/**
+ * Default file path for a tenant. LOCAL_TENANT keeps the v0.4 path
+ * (zero migration); others get a per-tenant suffix.
+ */
+function defaultPathFor(tenantId: TenantId): string {
+  if (tenantId === LOCAL_TENANT) {
+    return join(homedir(), '.iris', 'custom-rules.json');
+  }
+  // Sanitize tenant id for filesystem safety. TenantId is branded but
+  // could in principle contain odd chars on Cloud — limit to a known-safe
+  // alphabet so we never write outside the .iris directory.
+  const safe = String(tenantId).replace(/[^a-zA-Z0-9._-]/g, '_');
+  return join(homedir(), '.iris', `custom-rules-${safe}.json`);
 }
 
 function defaultAuditPath(): string {
@@ -71,15 +96,20 @@ function defaultAuditPath(): string {
 }
 
 export interface CustomRuleStore {
-  list(): DeployedCustomRule[];
-  get(id: string): DeployedCustomRule | undefined;
-  deploy(input: DeployRuleInput): DeployedCustomRule;
-  delete(id: string, user?: string): boolean;
-  setEnabled(id: string, enabled: boolean, user?: string): DeployedCustomRule | undefined;
-  /** All ENABLED rules in deploy order — what the engine should register. */
-  enabledRules(): DeployedCustomRule[];
-  /** Path on disk for diagnostics. */
-  filePath: string;
+  list(tenantId: TenantId): DeployedCustomRule[];
+  get(tenantId: TenantId, id: string): DeployedCustomRule | undefined;
+  deploy(tenantId: TenantId, input: DeployRuleInput): DeployedCustomRule;
+  delete(tenantId: TenantId, id: string, user?: string): boolean;
+  setEnabled(
+    tenantId: TenantId,
+    id: string,
+    enabled: boolean,
+    user?: string,
+  ): DeployedCustomRule | undefined;
+  /** All ENABLED rules for a tenant in deploy order — what the engine should register. */
+  enabledRules(tenantId: TenantId): DeployedCustomRule[];
+  /** Path on disk for diagnostics. Different per tenant. */
+  pathFor(tenantId: TenantId): string;
   auditPath: string;
 }
 
@@ -114,48 +144,66 @@ function writeAtomic(targetPath: string, contents: string): void {
   renameSync(tmp, targetPath);
 }
 
+function loadRulesFromDisk(rulesPath: string): DeployedCustomRule[] {
+  if (!existsSync(rulesPath)) return [];
+  try {
+    const raw = readFileSync(rulesPath, 'utf-8');
+    const parsed = FileSchema.safeParse(JSON.parse(raw));
+    if (parsed.success) return parsed.data.rules;
+    // Malformed: leave rules empty; do NOT overwrite the file.
+    return [];
+  } catch {
+    // Unreadable: leave rules empty.
+    return [];
+  }
+}
+
 export function createCustomRuleStore(opts?: {
-  rulesPath?: string;
+  /**
+   * Returns the file path for a tenant's rules. Defaults to
+   * `~/.iris/custom-rules.json` for LOCAL_TENANT (zero migration for OSS)
+   * and `~/.iris/custom-rules-<sanitized-tenantId>.json` for others.
+   * Cloud orchestrators can inject their own factory to e.g. write into
+   * a per-tenant data dir.
+   */
+  pathFor?: (tenantId: TenantId) => string;
   auditPath?: string;
 }): CustomRuleStore {
-  const rulesPath = opts?.rulesPath ?? defaultRulesPath();
+  const pathFor = opts?.pathFor ?? defaultPathFor;
   const auditPath = opts?.auditPath ?? defaultAuditPath();
 
-  // In-memory copy that mirrors the file. Writes update both.
-  let rules: DeployedCustomRule[] = [];
+  // In-memory cache keyed by tenant. Lazy-loaded on first access per
+  // tenant; subsequent calls hit the cache.
+  const tenantRules = new Map<TenantId, DeployedCustomRule[]>();
 
-  // Initial load
-  if (existsSync(rulesPath)) {
-    try {
-      const raw = readFileSync(rulesPath, 'utf-8');
-      const parsed = FileSchema.safeParse(JSON.parse(raw));
-      if (parsed.success) {
-        rules = parsed.data.rules;
-      }
-      // Malformed: leave rules empty; do NOT overwrite the file.
-    } catch {
-      // Unreadable: leave rules empty.
+  function load(tenantId: TenantId): DeployedCustomRule[] {
+    let rules = tenantRules.get(tenantId);
+    if (rules === undefined) {
+      rules = loadRulesFromDisk(pathFor(tenantId));
+      tenantRules.set(tenantId, rules);
     }
+    return rules;
   }
 
-  function persist(): void {
+  function persist(tenantId: TenantId): void {
+    const rules = tenantRules.get(tenantId) ?? [];
     const file: CustomRulesFile = { version: 1, rules };
-    writeAtomic(rulesPath, JSON.stringify(file, null, 2));
+    writeAtomic(pathFor(tenantId), JSON.stringify(file, null, 2));
   }
 
   return {
-    filePath: rulesPath,
     auditPath,
-    list(): DeployedCustomRule[] {
-      return [...rules];
+    pathFor,
+    list(tenantId: TenantId): DeployedCustomRule[] {
+      return [...load(tenantId)];
     },
-    get(id: string): DeployedCustomRule | undefined {
-      return rules.find((r) => r.id === id);
+    get(tenantId: TenantId, id: string): DeployedCustomRule | undefined {
+      return load(tenantId).find((r) => r.id === id);
     },
-    enabledRules(): DeployedCustomRule[] {
-      return rules.filter((r) => r.enabled);
+    enabledRules(tenantId: TenantId): DeployedCustomRule[] {
+      return load(tenantId).filter((r) => r.enabled);
     },
-    deploy(input: DeployRuleInput): DeployedCustomRule {
+    deploy(tenantId: TenantId, input: DeployRuleInput): DeployedCustomRule {
       const now = new Date().toISOString();
       const id = generateRuleId();
       const rule: DeployedCustomRule = {
@@ -173,15 +221,12 @@ export function createCustomRuleStore(opts?: {
       };
       // Validate before persisting.
       const validated = DeployedRuleSchema.parse(rule);
+      const rules = load(tenantId);
       rules.push(validated);
-      persist();
-      /* Tenant scoping: OSS single-tenant emits 'local'. Cloud replaces
-       * the entire custom-rule-store with a DB-backed service that reads
-       * the tenant from the authenticated session; that service will
-       * compute tenantId per-call. Hard-coded here for OSS. */
+      persist(tenantId);
       appendAudit(auditPath, {
         ts: now,
-        tenantId: 'local',
+        tenantId,
         action: 'rule.deploy',
         user: input.user ?? 'local',
         ruleId: id,
@@ -192,15 +237,16 @@ export function createCustomRuleStore(opts?: {
       });
       return validated;
     },
-    delete(id: string, user = 'local'): boolean {
+    delete(tenantId: TenantId, id: string, user = 'local'): boolean {
+      const rules = load(tenantId);
       const idx = rules.findIndex((r) => r.id === id);
       if (idx === -1) return false;
       const removed = rules[idx];
       rules.splice(idx, 1);
-      persist();
+      persist(tenantId);
       appendAudit(auditPath, {
         ts: new Date().toISOString(),
-        tenantId: 'local',
+        tenantId,
         action: 'rule.delete',
         user,
         ruleId: id,
@@ -208,16 +254,22 @@ export function createCustomRuleStore(opts?: {
       });
       return true;
     },
-    setEnabled(id: string, enabled: boolean, user = 'local'): DeployedCustomRule | undefined {
+    setEnabled(
+      tenantId: TenantId,
+      id: string,
+      enabled: boolean,
+      user = 'local',
+    ): DeployedCustomRule | undefined {
+      const rules = load(tenantId);
       const rule = rules.find((r) => r.id === id);
       if (!rule) return undefined;
       if (rule.enabled === enabled) return rule;
       rule.enabled = enabled;
       rule.updatedAt = new Date().toISOString();
-      persist();
+      persist(tenantId);
       appendAudit(auditPath, {
         ts: rule.updatedAt,
-        tenantId: 'local',
+        tenantId,
         action: 'rule.toggle',
         user,
         ruleId: id,

--- a/src/dashboard/routes/rules.ts
+++ b/src/dashboard/routes/rules.ts
@@ -58,25 +58,23 @@ export function registerRuleRoutes(
   opts: RoutesOptions,
 ): void {
   /*
-   * Tenant gate. Every /rules/custom route asserts a tenant has been
-   * resolved by the middleware before acting. In OSS this always passes
-   * (tenant middleware sets LOCAL_TENANT for every request); in Cloud
-   * the gate refuses to run on unauthenticated requests that bypass
-   * the auth+tenant middleware. The resolved id is currently NOT
-   * threaded into customRuleStore — that lands in PR 3b. Today the
-   * store hardcodes 'local'; the gate is the route-level prerequisite
-   * for the store-level fix.
+   * Every /rules/custom route resolves the tenant via requireTenant(req)
+   * and threads it through to the store. In OSS the tenant middleware
+   * always sets LOCAL_TENANT, so all rules continue to live at
+   * ~/.iris/custom-rules.json (the v0.4 path — zero migration). In Cloud,
+   * each tenant's rules will live in their own file (per-tenant partition)
+   * and writes will only ever touch the resolved tenant's data.
    */
 
   router.get('/rules/custom', (req, res) => {
-    requireTenant(req);
-    const rules = opts.customRuleStore.list();
+    const tenantId = requireTenant(req);
+    const rules = opts.customRuleStore.list(tenantId);
     res.json({ rules });
   });
 
   router.post('/rules/custom', async (req, res) => {
     try {
-      requireTenant(req);
+      const tenantId = requireTenant(req);
       const input = DeploySchema.parse(req.body);
 
       // Server overrides the inner definition's `name` so it always matches the
@@ -87,7 +85,7 @@ export function registerRuleRoutes(
         name: input.name,
       };
 
-      const rule = opts.customRuleStore.deploy({
+      const rule = opts.customRuleStore.deploy(tenantId, {
         name: input.name,
         description: input.description,
         evalType: input.evalType,
@@ -97,7 +95,9 @@ export function registerRuleRoutes(
       });
 
       // Register the new rule with the live engine so it fires on subsequent
-      // evaluate_output calls without requiring a server restart.
+      // evaluate_output calls without requiring a server restart. The engine
+      // is process-global in v0.4 — Cloud multi-tenant engine wiring is a
+      // v0.5 architectural item.
       opts.evalEngine.registerRule(rule.evalType, createCustomRule(rule.definition));
 
       res.status(201).json({ rule });
@@ -111,8 +111,8 @@ export function registerRuleRoutes(
   });
 
   router.delete('/rules/custom/:id', (req, res) => {
-    requireTenant(req);
-    const removed = opts.customRuleStore.delete(req.params.id);
+    const tenantId = requireTenant(req);
+    const removed = opts.customRuleStore.delete(tenantId, req.params.id);
     if (!removed) {
       res.status(404).json({ error: 'Rule not found' });
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,13 +143,16 @@ async function main(): Promise<void> {
   // Load deployed custom rules from ~/.iris/custom-rules.json (B3 — workflow inversion).
   // Each enabled rule is registered with the engine under its evalType so it fires on
   // every evaluate_output call of that category. Persistence via custom-rule-store.
-  const enabled = customRuleStore.enabledRules();
+  // OSS single-tenant: register rules under LOCAL_TENANT only. Cloud multi-tenant
+  // engine wiring is a v0.5 architectural item (the engine is a process singleton
+  // and would need per-tenant rule registration).
+  const enabled = customRuleStore.enabledRules(LOCAL_TENANT);
   for (const rule of enabled) {
     evalEngine.registerRule(rule.evalType, createCustomRule(rule.definition));
   }
   if (enabled.length > 0) {
     logger.info(
-      `Loaded ${enabled.length} deployed custom rule(s) from ${customRuleStore.filePath}`,
+      `Loaded ${enabled.length} deployed custom rule(s) from ${customRuleStore.pathFor(LOCAL_TENANT)}`,
     );
   }
 

--- a/src/tools/delete-rule.ts
+++ b/src/tools/delete-rule.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CustomRuleStore } from '../custom-rule-store.js';
+import { LOCAL_TENANT } from '../types/tenant.js';
 
 const inputSchema = {
   rule_id: z
@@ -54,7 +55,8 @@ export function registerDeleteRuleTool(
       },
     },
     async (args) => {
-      const deleted = customRuleStore.delete(args.rule_id, 'mcp');
+      // OSS: MCP tools operate under LOCAL_TENANT. See list-rules.ts for context.
+      const deleted = customRuleStore.delete(LOCAL_TENANT, args.rule_id, 'mcp');
       return {
         content: [
           {

--- a/src/tools/deploy-rule.ts
+++ b/src/tools/deploy-rule.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CustomRuleStore } from '../custom-rule-store.js';
 import type { CustomRuleDefinition } from '../types/eval.js';
+import { LOCAL_TENANT } from '../types/tenant.js';
 
 const CustomRuleDefinitionSchema = z.object({
   name: z.string(),
@@ -86,7 +87,8 @@ export function registerDeployRuleTool(
       },
     },
     async (args) => {
-      const rule = customRuleStore.deploy({
+      // OSS: MCP tools operate under LOCAL_TENANT. See list-rules.ts for context.
+      const rule = customRuleStore.deploy(LOCAL_TENANT, {
         name: args.name,
         description: args.description,
         evalType: args.evalType,

--- a/src/tools/list-rules.ts
+++ b/src/tools/list-rules.ts
@@ -13,6 +13,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CustomRuleStore } from '../custom-rule-store.js';
+import { LOCAL_TENANT } from '../types/tenant.js';
 
 const inputSchema = {
   eval_type: z
@@ -59,7 +60,10 @@ export function registerListRulesTool(
       },
     },
     async (args) => {
-      let rules = customRuleStore.list();
+      // OSS: MCP tools operate under LOCAL_TENANT. Cloud multi-tenant
+      // exposure is a v0.5 architectural item (MCP SDK doesn't pass
+      // session/tenant context to tool handlers).
+      let rules = customRuleStore.list(LOCAL_TENANT);
       if (args.eval_type) {
         rules = rules.filter((r) => r.evalType === args.eval_type);
       }

--- a/tests/unit/custom-rule-store-tenant.test.ts
+++ b/tests/unit/custom-rule-store-tenant.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Tenant isolation tests for CustomRuleStore.
+ *
+ * In OSS the store sees only LOCAL_TENANT — these tests prove the
+ * per-tenant partition keeps Cloud SKU data isolated when multiple
+ * tenant ids are used. Sets up a single store with a per-tenant file
+ * factory; deploys distinct rules under tenant-A and tenant-B; asserts:
+ *   - list/enabledRules return only the caller's tenant's rules
+ *   - delete only removes the caller's tenant's rule
+ *   - on-disk files are separate and don't see each other's data
+ *   - audit log entries carry the resolved tenant id (no hardcoded 'local')
+ *
+ * Regression catcher: any future change that re-introduces shared
+ * in-memory state across tenants will break these tests.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createCustomRuleStore } from '../../src/custom-rule-store.js';
+import { LOCAL_TENANT, asTenantId, type TenantId } from '../../src/types/tenant.js';
+
+let tmpDir: string;
+let auditPath: string;
+const TENANT_A = asTenantId('tenant-a');
+const TENANT_B = asTenantId('tenant-b');
+
+function pathForTenant(tenantId: TenantId): string {
+  if (tenantId === LOCAL_TENANT) return join(tmpDir, 'custom-rules.json');
+  return join(tmpDir, `custom-rules-${tenantId}.json`);
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'iris-tenant-'));
+  auditPath = join(tmpDir, 'audit.log');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('CustomRuleStore — tenant isolation', () => {
+  it('list() only returns the caller-tenant rules', () => {
+    const store = createCustomRuleStore({ pathFor: pathForTenant, auditPath });
+    store.deploy(TENANT_A, {
+      name: 'a-rule',
+      evalType: 'safety',
+      definition: { name: 'a-rule', type: 'regex_no_match', config: { pattern: 'x' } },
+    });
+    store.deploy(TENANT_B, {
+      name: 'b-rule',
+      evalType: 'safety',
+      definition: { name: 'b-rule', type: 'regex_no_match', config: { pattern: 'y' } },
+    });
+
+    expect(store.list(TENANT_A).map((r) => r.name)).toEqual(['a-rule']);
+    expect(store.list(TENANT_B).map((r) => r.name)).toEqual(['b-rule']);
+    expect(store.list(LOCAL_TENANT)).toEqual([]);
+  });
+
+  it('on-disk files are separate per tenant (no cross-pollination)', () => {
+    const store = createCustomRuleStore({ pathFor: pathForTenant, auditPath });
+    store.deploy(TENANT_A, {
+      name: 'a-rule',
+      evalType: 'safety',
+      definition: { name: 'a-rule', type: 'regex_no_match', config: { pattern: 'x' } },
+    });
+    store.deploy(TENANT_B, {
+      name: 'b-rule',
+      evalType: 'safety',
+      definition: { name: 'b-rule', type: 'regex_no_match', config: { pattern: 'y' } },
+    });
+
+    const aFile = JSON.parse(readFileSync(pathForTenant(TENANT_A), 'utf-8'));
+    const bFile = JSON.parse(readFileSync(pathForTenant(TENANT_B), 'utf-8'));
+    expect(aFile.rules).toHaveLength(1);
+    expect(aFile.rules[0].name).toBe('a-rule');
+    expect(bFile.rules).toHaveLength(1);
+    expect(bFile.rules[0].name).toBe('b-rule');
+    expect(existsSync(pathForTenant(LOCAL_TENANT))).toBe(false);
+  });
+
+  it("delete cannot remove another tenant's rule", () => {
+    const store = createCustomRuleStore({ pathFor: pathForTenant, auditPath });
+    const ruleA = store.deploy(TENANT_A, {
+      name: 'a-only',
+      evalType: 'safety',
+      definition: { name: 'a-only', type: 'regex_no_match', config: { pattern: 'x' } },
+    });
+
+    // Tenant-B can't see or delete tenant-A's rule.
+    expect(store.get(TENANT_B, ruleA.id)).toBeUndefined();
+    expect(store.delete(TENANT_B, ruleA.id)).toBe(false);
+    // Tenant-A still has the rule intact.
+    expect(store.get(TENANT_A, ruleA.id)?.name).toBe('a-only');
+  });
+
+  it("setEnabled cannot toggle another tenant's rule", () => {
+    const store = createCustomRuleStore({ pathFor: pathForTenant, auditPath });
+    const ruleA = store.deploy(TENANT_A, {
+      name: 'a-toggle',
+      evalType: 'safety',
+      definition: { name: 'a-toggle', type: 'regex_no_match', config: { pattern: 'x' } },
+    });
+
+    expect(store.setEnabled(TENANT_B, ruleA.id, false)).toBeUndefined();
+    expect(store.enabledRules(TENANT_A).map((r) => r.name)).toEqual(['a-toggle']);
+  });
+
+  it('enabledRules respects tenant scope', () => {
+    const store = createCustomRuleStore({ pathFor: pathForTenant, auditPath });
+    const ruleA = store.deploy(TENANT_A, {
+      name: 'a',
+      evalType: 'safety',
+      definition: { name: 'a', type: 'regex_no_match', config: { pattern: 'x' } },
+    });
+    store.deploy(TENANT_B, {
+      name: 'b',
+      evalType: 'safety',
+      definition: { name: 'b', type: 'regex_no_match', config: { pattern: 'y' } },
+    });
+    store.setEnabled(TENANT_A, ruleA.id, false);
+
+    expect(store.enabledRules(TENANT_A)).toEqual([]);
+    expect(store.enabledRules(TENANT_B).map((r) => r.name)).toEqual(['b']);
+  });
+
+  it('audit log entries carry the resolved tenant id (not hardcoded "local")', () => {
+    const store = createCustomRuleStore({ pathFor: pathForTenant, auditPath });
+    store.deploy(TENANT_A, {
+      name: 'audit-a',
+      evalType: 'safety',
+      definition: { name: 'audit-a', type: 'regex_no_match', config: { pattern: 'x' } },
+    });
+    store.deploy(TENANT_B, {
+      name: 'audit-b',
+      evalType: 'safety',
+      definition: { name: 'audit-b', type: 'regex_no_match', config: { pattern: 'y' } },
+    });
+
+    const lines = readFileSync(auditPath, 'utf-8').trim().split('\n');
+    const entryA = JSON.parse(lines[0]);
+    const entryB = JSON.parse(lines[1]);
+    expect(entryA.tenantId).toBe('tenant-a');
+    expect(entryA.ruleName).toBe('audit-a');
+    expect(entryB.tenantId).toBe('tenant-b');
+    expect(entryB.ruleName).toBe('audit-b');
+  });
+
+  it('LOCAL_TENANT continues to use the v0.4 file path (zero migration)', () => {
+    // Spot-check the default `defaultPathFor` semantics by NOT passing
+    // a `pathFor` factory — uses the production default which lives in
+    // ~/.iris/. Verify it resolves to a path with `/.iris/custom-rules.json`
+    // for LOCAL_TENANT and `/.iris/custom-rules-<id>.json` otherwise.
+    const store = createCustomRuleStore({ auditPath });
+    expect(store.pathFor(LOCAL_TENANT)).toMatch(/[\\/]\.iris[\\/]custom-rules\.json$/);
+    expect(store.pathFor(TENANT_A)).toMatch(/[\\/]\.iris[\\/]custom-rules-tenant-a\.json$/);
+  });
+
+  it('sanitizes tenant ids to prevent directory traversal', () => {
+    const store = createCustomRuleStore({ auditPath });
+    // The TenantId brand doesn't enforce a charset; the store does.
+    const evil = asTenantId('../../etc/passwd');
+    const path = store.pathFor(evil);
+    // Path must NOT escape ~/.iris/ — the slashes/dots get sanitized to underscores.
+    expect(path).toMatch(/[\\/]\.iris[\\/]custom-rules-[a-zA-Z0-9._]+\.json$/);
+    expect(path).not.toContain('etc/passwd');
+    expect(path).not.toMatch(/\.\.[\\/]/);
+  });
+});

--- a/tests/unit/custom-rule-store.test.ts
+++ b/tests/unit/custom-rule-store.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createCustomRuleStore } from '../../src/custom-rule-store.js';
+import { LOCAL_TENANT } from '../../src/types/tenant.js';
 
 let tmpDir: string;
 let rulesPath: string;
@@ -18,16 +19,16 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe('createCustomRuleStore', () => {
+describe('createCustomRuleStore (single-tenant / OSS)', () => {
   it('starts with no rules when file does not exist', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    expect(store.list()).toEqual([]);
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    expect(store.list(LOCAL_TENANT)).toEqual([]);
     expect(existsSync(rulesPath)).toBe(false);
   });
 
   it('deploy persists a rule + writes audit entry', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    const rule = store.deploy({
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    const rule = store.deploy(LOCAL_TENANT, {
       name: 'no_pricing',
       description: 'Sales agent must not quote prices',
       evalType: 'safety',
@@ -57,77 +58,78 @@ describe('createCustomRuleStore', () => {
     expect(audit).toContain('"action":"rule.deploy"');
     expect(audit).toContain('"ruleId":"' + rule.id + '"');
     expect(audit).toContain('"sourceMomentId":"trace-abc"');
+    expect(audit).toContain('"tenantId":"local"');
   });
 
   it('list returns all deployed rules in deploy order', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    store.deploy({
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    store.deploy(LOCAL_TENANT, {
       name: 'rule_a',
       evalType: 'safety',
       definition: { name: 'rule_a', type: 'regex_no_match', config: { pattern: 'foo' } },
     });
-    store.deploy({
+    store.deploy(LOCAL_TENANT, {
       name: 'rule_b',
       evalType: 'completeness',
       definition: { name: 'rule_b', type: 'min_length', config: { min_length: 100 } },
     });
-    expect(store.list()).toHaveLength(2);
-    expect(store.list().map((r) => r.name)).toEqual(['rule_a', 'rule_b']);
+    expect(store.list(LOCAL_TENANT)).toHaveLength(2);
+    expect(store.list(LOCAL_TENANT).map((r) => r.name)).toEqual(['rule_a', 'rule_b']);
   });
 
   it('rules persist across store re-creation', () => {
-    const first = createCustomRuleStore({ rulesPath, auditPath });
-    first.deploy({
+    const first = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    first.deploy(LOCAL_TENANT, {
       name: 'persistent',
       evalType: 'safety',
       definition: { name: 'persistent', type: 'regex_no_match', config: { pattern: 'x' } },
     });
 
-    const second = createCustomRuleStore({ rulesPath, auditPath });
-    expect(second.list()).toHaveLength(1);
-    expect(second.list()[0].name).toBe('persistent');
+    const second = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    expect(second.list(LOCAL_TENANT)).toHaveLength(1);
+    expect(second.list(LOCAL_TENANT)[0].name).toBe('persistent');
   });
 
   it('delete removes the rule + writes audit entry', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    const rule = store.deploy({
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    const rule = store.deploy(LOCAL_TENANT, {
       name: 'doomed',
       evalType: 'safety',
       definition: { name: 'doomed', type: 'regex_no_match', config: { pattern: 'x' } },
     });
-    expect(store.delete(rule.id)).toBe(true);
-    expect(store.list()).toEqual([]);
-    expect(store.delete(rule.id)).toBe(false); // already gone
+    expect(store.delete(LOCAL_TENANT, rule.id)).toBe(true);
+    expect(store.list(LOCAL_TENANT)).toEqual([]);
+    expect(store.delete(LOCAL_TENANT, rule.id)).toBe(false); // already gone
     expect(readFileSync(auditPath, 'utf-8')).toContain('"action":"rule.delete"');
   });
 
   it('setEnabled toggles enabled state and audits', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    const rule = store.deploy({
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    const rule = store.deploy(LOCAL_TENANT, {
       name: 'toggle_me',
       evalType: 'safety',
       definition: { name: 'toggle_me', type: 'regex_no_match', config: { pattern: 'x' } },
     });
-    const updated = store.setEnabled(rule.id, false);
+    const updated = store.setEnabled(LOCAL_TENANT, rule.id, false);
     expect(updated?.enabled).toBe(false);
-    expect(store.enabledRules()).toEqual([]);
+    expect(store.enabledRules(LOCAL_TENANT)).toEqual([]);
     expect(readFileSync(auditPath, 'utf-8')).toContain('"action":"rule.toggle"');
   });
 
   it('enabledRules returns only enabled rules', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    const a = store.deploy({
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    const a = store.deploy(LOCAL_TENANT, {
       name: 'a',
       evalType: 'safety',
       definition: { name: 'a', type: 'regex_no_match', config: { pattern: 'x' } },
     });
-    store.deploy({
+    store.deploy(LOCAL_TENANT, {
       name: 'b',
       evalType: 'safety',
       definition: { name: 'b', type: 'regex_no_match', config: { pattern: 'y' } },
     });
-    store.setEnabled(a.id, false);
-    const enabled = store.enabledRules();
+    store.setEnabled(LOCAL_TENANT, a.id, false);
+    const enabled = store.enabledRules(LOCAL_TENANT);
     expect(enabled).toHaveLength(1);
     expect(enabled[0].name).toBe('b');
   });
@@ -136,19 +138,19 @@ describe('createCustomRuleStore', () => {
     const fs = require('node:fs') as typeof import('node:fs');
     fs.mkdirSync(tmpDir, { recursive: true });
     fs.writeFileSync(rulesPath, 'not valid json{{{');
-    const store = createCustomRuleStore({ rulesPath, auditPath });
-    expect(store.list()).toEqual([]);
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    expect(store.list(LOCAL_TENANT)).toEqual([]);
     // File untouched — operator can fix manually
     expect(readFileSync(rulesPath, 'utf-8')).toBe('not valid json{{{');
   });
 
   it('rejects rule with invalid name characters', () => {
-    const store = createCustomRuleStore({ rulesPath, auditPath });
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
     // The store itself doesn't validate name characters — that's the API
     // route's job. The store accepts any string up to its zod max length.
     // This test documents that boundary — see rules.ts route for the
     // user-input validation layer.
-    const rule = store.deploy({
+    const rule = store.deploy(LOCAL_TENANT, {
       name: 'short',
       evalType: 'safety',
       definition: { name: 'short', type: 'regex_no_match', config: { pattern: 'x' } },


### PR DESCRIPTION
## Summary

Every public `CustomRuleStore` method now takes `tenantId: TenantId` as its first argument. The default file factory routes:
- `LOCAL_TENANT` → `~/.iris/custom-rules.json` (v0.4 path; **zero migration** for OSS)
- other tenants → `~/.iris/custom-rules-<sanitized-tenantId>.json`

In-memory state changed from a single rules array to a per-tenant `Map`, lazy-loaded on first access. Audit log stays single-file (entries already carry `tenantId`).

## ADR — design call: per-tenant file partition

| Option | Pros | Cons |
|---|---|---|
| Top-level key in single file | One file to back up | Hot-write contention; OSS schema breaking change |
| **Per-tenant file** (chosen) | Zero migration for OSS; matches audit-log convention; smallest blast radius (a corrupted write on tenant A's file can't poison tenant B's data) | More files |
| Tenant column on each rule | Most ergonomic in code | OSS schema breaking change; no isolation if file is shared |

Per-tenant file wins on the OSS migration cost (zero) and the isolation guarantee.

## Tenant-id sanitization

The `TenantId` brand only rejects empty strings. The store's `defaultPathFor()` sanitizes any non-`[a-zA-Z0-9._-]` character to `_` to prevent directory traversal via crafted ids (e.g. `../../etc/passwd`). Test: `custom-rule-store-tenant.test.ts:'sanitizes tenant ids'`.

## Callers updated

- **`src/index.ts:146-153`** — engine startup loads `enabledRules(LOCAL_TENANT)`; diagnostic log uses `pathFor(LOCAL_TENANT)`. Cloud multi-tenant engine wiring is a v0.5 architectural item (engine is process-global; needs per-tenant rule registration).
- **`src/tools/{list,deploy,delete}-rule.ts`** — MCP tools pass `LOCAL_TENANT` (documented v0.5 limitation; MCP SDK doesn't pass session/tenant context to tool handlers).
- **`src/dashboard/routes/rules.ts`** — threads `tenantId` from `requireTenant(req)` into `store.list/deploy/delete`. Closes the "store hardcodes 'local'" gap that PR 3a only fixed at the route gate.

## Tests

- **`tests/unit/custom-rule-store.test.ts`** — updated all calls to use `LOCAL_TENANT` + `pathFor` factory. Asserts audit `"tenantId":"local"`.
- **`tests/unit/custom-rule-store-tenant.test.ts`** (new, **8 tests**):
  - `list/get/delete/setEnabled/enabledRules` all respect tenant scope
  - On-disk files separate per tenant (no cross-pollination)
  - Audit entries carry resolved tenant id (not hardcoded `'local'`)
  - `LOCAL_TENANT` keeps v0.4 file path
  - Tenant-id sanitization prevents directory traversal

## What's NOT in this PR

The 9 MCP tools still operate under `LOCAL_TENANT`. The SDK doesn't pass session/tenant context to tool handlers — the architectural fix needs an MCP SDK design call (custom transport adapter or session context store). Tracked as v0.5 Cloud SKU work; not a regression.

## Risk

**Medium** — touches storage layer. Mitigations:
- OSS users see no file-path change (LOCAL_TENANT special case preserves `~/.iris/custom-rules.json`).
- Audit log shape is backward-compatible (`tenantId` was already optional in the schema).
- Existing `e2e/make-rule.spec.ts` exercises the full stack with `LOCAL_TENANT` — passes unchanged.

## Test plan

- [x] `npx vitest run`: **37 files, 398 passed** (was 390; +8 tenant-isolation tests)
- [x] `npm run test:integration`: 75 passed
- [x] `npm run typecheck`: clean
- [x] `bash scripts/check-product-claims.sh`: PASSED
- [ ] CI green
- [ ] Post-merge: `npx @iris-eval/mcp-server` on a fresh install — `~/.iris/custom-rules.json` is created at the same v0.4 path; no migration needed

PR 3b of 9 — plan: `plans/yes-lets-take-care-linear-elephant.md`. Unblocks PR 5 (test gap closure including E2E tenant-isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)