### PR TITLE
fix(dashboard): focus trap on modals + stale-data race in useApiData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Accessibility
+
+- **Focus trap on dashboard modals.** New `useFocusTrap` hook (`dashboard/src/components/shared/useFocusTrap.ts`) applied to `MakeRuleModal`, `WelcomeTour`, and the `EvalListPage` evaluation-detail dialog. Tab cycles inside the modal panel; focus is restored to the trigger element on close. Closes the keyboard / screen-reader gap where users could Tab into background page content while a modal was open. Tests: `dashboard/tests/components/shared/useFocusTrap.test.tsx`.
+
 ### Changed
 
+- **Dashboard rapid-navigation race fix.** `useApiData` (`dashboard/src/api/hooks.ts`) now tags each fetch with a monotonic request id and discards stale resolutions. Previously, a slow earlier fetch could resolve AFTER a newer fetch and overwrite the user-visible data with the previous page's results. Closes the race where filter/route changes during in-flight requests showed wrong data. Also discards stale errors so a failed older request can't flip error state after a newer success. `HealthView`'s "Retry now" button now skips the call while still inside an active rate-limit window (was triggering an immediate fail-loop with no spinner). Tests: `dashboard/tests/components/shared/useApiData-race.test.tsx`.
 - **`CustomRuleStore` API now accepts `TenantId` as the first argument on every public method (`list` / `get` / `deploy` / `delete` / `setEnabled` / `enabledRules`).** OSS deployments are unaffected — the tenant middleware always resolves to `LOCAL_TENANT`, and the default file path for `LOCAL_TENANT` remains `~/.iris/custom-rules.json` (zero migration). Cloud tenants get per-tenant file partition (`~/.iris/custom-rules-<sanitized-tenantId>.json`) so one tenant's data can never poison another's. The constructor now accepts `pathFor: (tenantId) => string` instead of `rulesPath: string` so Cloud orchestrators can inject their own routing. Audit log entries now carry the resolved `tenantId` instead of a hardcoded `'local'`. `src/custom-rule-store.ts`. Internal API change — no public package consumer affected.
 
 ### Security

--- a/dashboard/src/api/hooks.ts
+++ b/dashboard/src/api/hooks.ts
@@ -62,20 +62,34 @@ export interface UseApiDataResult<T> {
   refetch: () => Promise<void>;
 }
 
-function useApiData<T>(fetcher: () => Promise<T>, pollInterval?: number): UseApiDataResult<T> {
+// Exported only for tests — every production caller goes through a
+// purpose-named wrapper (useTraces / useSummary / etc.) that pre-applies
+// the right cadence + fetcher. The bare hook is exposed so the
+// stale-data race regression test can drive it directly without
+// mocking the entire api client surface.
+export function useApiData<T>(fetcher: () => Promise<T>, pollInterval?: number): UseApiDataResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null);
   const resumeTimer = useRef<number | null>(null);
+  // Monotonic request id. Each fetchData() call captures its own id; if a
+  // newer call has started by the time the response resolves, the older
+  // call discards its result. Closes the stale-data race where a slow
+  // earlier fetch could overwrite the newer fetch's data after a rapid
+  // filter/route change.
+  const requestIdRef = useRef(0);
 
   const fetchData = useCallback(async () => {
+    const myId = ++requestIdRef.current;
     try {
       const result = await fetcher();
+      if (myId !== requestIdRef.current) return; // stale — newer call superseded us
       setData(result);
       setError(null);
       setRateLimitedUntil(null);
     } catch (err) {
+      if (myId !== requestIdRef.current) return; // stale — drop the error too
       if (err instanceof RateLimitError) {
         const until = Date.now() + err.retryAfterMs;
         setRateLimitedUntil(until);
@@ -93,7 +107,12 @@ function useApiData<T>(fetcher: () => Promise<T>, pollInterval?: number): UseApi
         setError(err instanceof Error ? err.message : 'Unknown error');
       }
     } finally {
-      setLoading(false);
+      // Only the latest call clears the loading flag — prevents a stale
+      // resolution from flipping loading to false while a newer request
+      // is still in flight.
+      if (myId === requestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [fetcher]);
 

--- a/dashboard/src/components/dashboard/HealthView.tsx
+++ b/dashboard/src/components/dashboard/HealthView.tsx
@@ -145,6 +145,11 @@ export function HealthView() {
     .filter((v): v is number => typeof v === 'number')
     .reduce<number | null>((min, v) => (min === null || v < min ? v : min), null);
   const retryAll = () => {
+    // Skip if any source is still in its rate-limit window. Without this
+    // guard, clicking "Retry now" while rate-limited just immediately
+    // re-throws RateLimitError on every fetcher; the user sees a stuck
+    // banner with no spinner. Wait for the soonest reset to pass.
+    if (rateLimitedUntil !== null && Date.now() < rateLimitedUntil) return;
     statsRes.refetch();
     trendRes.refetch();
     auditRes.refetch();

--- a/dashboard/src/components/evals/EvalListPage.tsx
+++ b/dashboard/src/components/evals/EvalListPage.tsx
@@ -5,6 +5,7 @@ import { EvalTable } from './EvalTable';
 import { EvalDetailCard } from './EvalDetailCard';
 import { Pagination } from '../shared/Pagination';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
+import { useFocusTrap } from '../shared/useFocusTrap';
 import type { EvalResult } from '../../api/types';
 
 export function EvalListPage() {
@@ -25,6 +26,7 @@ export function EvalListPage() {
   const { data, loading } = useEvals(params);
 
   const closeModal = useCallback(() => setSelectedEval(null), []);
+  const trapRef = useFocusTrap<HTMLDivElement>(selectedEval !== null);
 
   useEffect(() => {
     if (!selectedEval) return;
@@ -70,6 +72,7 @@ export function EvalListPage() {
           }}
         >
           <div
+            ref={trapRef}
             onClick={(e) => e.stopPropagation()}
             role="dialog"
             aria-modal="true"

--- a/dashboard/src/components/moments/MakeRuleModal.tsx
+++ b/dashboard/src/components/moments/MakeRuleModal.tsx
@@ -21,6 +21,7 @@ import type {
   DeployRuleRequest,
 } from '../../api/types';
 import { api } from '../../api/client';
+import { useFocusTrap } from '../shared/useFocusTrap';
 
 const RULE_TYPE_OPTIONS: Array<{
   value: CustomRuleType;
@@ -344,8 +345,11 @@ export function MakeRuleModal({ moment, onClose, onDeployed }: Props) {
     }
   };
 
+  const trapRef = useFocusTrap<HTMLDivElement>(true);
+
   return (
     <div
+      ref={trapRef}
       style={styles.backdrop}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();

--- a/dashboard/src/components/onboarding/WelcomeTour.tsx
+++ b/dashboard/src/components/onboarding/WelcomeTour.tsx
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePreferences } from '../../hooks/usePreferences';
 import { useCommandPalette } from '../command/CommandPaletteProvider';
+import { useFocusTrap } from '../shared/useFocusTrap';
 
 const TOUR_ID = 'tour-welcome';
 
@@ -296,6 +297,8 @@ export function WelcomeTour({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
+  const trapRef = useFocusTrap<HTMLDivElement>(open);
+
   if (!open) return null;
 
   const step = steps[stepIndex];
@@ -330,6 +333,7 @@ export function WelcomeTour({
 
   return (
     <div
+      ref={trapRef}
       style={styles.backdrop}
       onClick={(e) => {
         if (e.target === e.currentTarget) handleSkip();

--- a/dashboard/src/components/shared/useFocusTrap.ts
+++ b/dashboard/src/components/shared/useFocusTrap.ts
@@ -1,0 +1,111 @@
+/*
+ * useFocusTrap — keyboard accessibility primitive for modal dialogs.
+ *
+ * Two responsibilities:
+ *   1. Trap Tab cycles inside the container so keyboard users can't
+ *      accidentally land on background page content while a modal is open.
+ *   2. Restore focus to the element that opened the modal when the
+ *      modal closes — so screen-reader/keyboard users land back where
+ *      they were instead of at <body>.
+ *
+ * Usage:
+ *   const containerRef = useFocusTrap(isOpen);
+ *   if (!isOpen) return null;
+ *   return <div ref={containerRef} role="dialog" aria-modal="true">...</div>;
+ *
+ * Notes:
+ *   - The hook auto-focuses the first focusable element in the container
+ *     on activation. If no focusable element exists, focus is unchanged.
+ *   - Tab from the LAST element wraps to the FIRST. Shift+Tab from the
+ *     FIRST wraps to the LAST.
+ *   - Restoration uses the focused element at the moment of activation.
+ *     If the opener was removed from the DOM by the time the modal closes,
+ *     the .focus() call is a no-op (graceful degradation).
+ *   - Esc-handling is left to the calling component — every modal has its
+ *     own dismissal semantics (cancel-vs-confirm, confirmation prompt, etc.)
+ *     so coupling that into the trap would over-reach.
+ */
+import { useEffect, useRef, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) =>
+      !el.hasAttribute('disabled') &&
+      !el.hasAttribute('hidden') &&
+      el.getAttribute('aria-hidden') !== 'true',
+  );
+}
+
+export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
+  active: boolean,
+): RefObject<T | null> {
+  const containerRef = useRef<T | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    // Snapshot the element that had focus when the trap activated, so we
+    // can restore on close. Falls back to null gracefully if document
+    // doesn't have an active element (jsdom edge case).
+    restoreFocusRef.current = (document.activeElement as HTMLElement) ?? null;
+
+    const container = containerRef.current;
+    if (container) {
+      const focusables = getFocusable(container);
+      const first = focusables[0];
+      if (first) {
+        first.focus();
+      }
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      if (!container) return;
+      const focusables = getFocusable(container);
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey) {
+        // Shift+Tab on first element wraps to last
+        if (active === first || !container.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab on last element wraps to first
+        if (active === last || !container.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // Restore focus to the original opener. Wrapped in try/catch because
+      // the element may have been removed from the DOM (e.g. the moment
+      // detail page that opened the modal navigated away).
+      try {
+        restoreFocusRef.current?.focus?.();
+      } catch {
+        // Graceful degradation — focus restoration is best-effort.
+      }
+    };
+  }, [active]);
+
+  return containerRef;
+}

--- a/dashboard/tests/components/shared/useApiData-race.test.tsx
+++ b/dashboard/tests/components/shared/useApiData-race.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * useApiData stale-data race regression test.
+ *
+ * Without the request-id discard, a slow earlier fetch could resolve
+ * AFTER a newer fetch and overwrite the user-visible data with the
+ * stale page's results. Reproduced by:
+ *   1. Mount useApiData; first fetch returns a slow promise (in flight).
+ *   2. Trigger a refetch; second fetch returns a fast promise.
+ *   3. Resolve the fast (newer) promise first → data becomes "new".
+ *   4. Resolve the slow (older) promise → MUST be discarded, data stays "new".
+ *
+ * Without the request-id guard the slow resolution would overwrite
+ * the data back to "old" after the user already saw "new".
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useApiData } from '../../../src/api/hooks';
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useApiData — stale-data race', () => {
+  it('discards a stale resolution that arrives after a newer one', async () => {
+    const slow = deferred<string>();
+    const fast = deferred<string>();
+
+    let callCount = 0;
+    const fetcher = () => {
+      callCount++;
+      return callCount === 1 ? slow.promise : fast.promise;
+    };
+
+    const { result } = renderHook(() => useApiData<string>(fetcher));
+
+    // First fetch is in flight (slow). Trigger a second fetch via refetch.
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    // Resolve the NEWER request first
+    await act(async () => {
+      fast.resolve('new');
+    });
+    await waitFor(() => expect(result.current.data).toBe('new'));
+
+    // Now resolve the OLDER request. Without the request-id guard, this
+    // would overwrite `data` back to 'old'. The guard discards it.
+    await act(async () => {
+      slow.resolve('old');
+    });
+
+    // Give microtasks a chance to flush, then assert the stale value
+    // didn't win.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe('new');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('discards a stale error too — a slow fetcher that throws after a newer success cannot flip error state', async () => {
+    const slow = deferred<string>();
+    const fast = deferred<string>();
+
+    let callCount = 0;
+    const fetcher = () => {
+      callCount++;
+      return callCount === 1 ? slow.promise : fast.promise;
+    };
+
+    const { result } = renderHook(() => useApiData<string>(fetcher));
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await act(async () => {
+      fast.resolve('ok');
+    });
+    await waitFor(() => expect(result.current.data).toBe('ok'));
+
+    await act(async () => {
+      slow.reject(new Error('stale failure'));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Error state must not flip — the failed older request is irrelevant
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBe('ok');
+  });
+});

--- a/dashboard/tests/components/shared/useFocusTrap.test.tsx
+++ b/dashboard/tests/components/shared/useFocusTrap.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * useFocusTrap — verifies the keyboard trap + focus-restore semantics
+ * for modal dialogs. Without this hook a Tab cycle could escape into
+ * the background page, and screen-reader users would land at <body>
+ * after dialog close instead of returning to the trigger.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import { useState } from 'react';
+import { useFocusTrap } from '../../../src/components/shared/useFocusTrap';
+
+function ModalHarness({ initialOpen = false }: { initialOpen?: boolean }) {
+  const [open, setOpen] = useState(initialOpen);
+  const trapRef = useFocusTrap<HTMLDivElement>(open);
+  return (
+    <>
+      <button data-testid="opener" onClick={() => setOpen(true)}>
+        Open
+      </button>
+      {open && (
+        <div ref={trapRef} role="dialog" aria-modal="true">
+          <button data-testid="first">first</button>
+          <button data-testid="middle">middle</button>
+          <button data-testid="last" onClick={() => setOpen(false)}>
+            close
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+describe('useFocusTrap', () => {
+  it('auto-focuses the first focusable element when activated', () => {
+    const { getByTestId } = render(<ModalHarness initialOpen />);
+    expect(document.activeElement).toBe(getByTestId('first'));
+  });
+
+  it('Tab from the last element wraps to the first', () => {
+    const { getByTestId } = render(<ModalHarness initialOpen />);
+    const last = getByTestId('last');
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(getByTestId('first'));
+  });
+
+  it('Shift+Tab from the first element wraps to the last', () => {
+    const { getByTestId } = render(<ModalHarness initialOpen />);
+    expect(document.activeElement).toBe(getByTestId('first'));
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(getByTestId('last'));
+  });
+
+  it('restores focus to the opener when the trap deactivates', () => {
+    const { getByTestId, queryByRole } = render(<ModalHarness />);
+    const opener = getByTestId('opener');
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+    // Open
+    act(() => fireEvent.click(opener));
+    expect(queryByRole('dialog')).not.toBeNull();
+    expect(document.activeElement).toBe(getByTestId('first'));
+    // Close (clicks the "last" button which sets open=false)
+    act(() => fireEvent.click(getByTestId('last')));
+    expect(queryByRole('dialog')).toBeNull();
+    // Focus is restored to the opener
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('does not interfere with keys other than Tab', () => {
+    const { getByTestId } = render(<ModalHarness initialOpen />);
+    expect(document.activeElement).toBe(getByTestId('first'));
+    // Pressing arrows / chars / Esc / etc. should be no-ops as far as the trap is concerned
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'a' });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.activeElement).toBe(getByTestId('first'));
+  });
+});


### PR DESCRIPTION
## Summary

Two a11y/UX issues from the codebase review.

### A11Y — focus trap on modals

Three modals (`MakeRuleModal`, `WelcomeTour`, `EvalListPage` detail dialog) were marked `role="dialog" aria-modal="true"` but did **not** trap Tab cycles, and did **not** restore focus to the trigger element on close. Keyboard + screen-reader users could land in background content while the modal was open, then end up at `<body>` after close.

New `useFocusTrap` hook (`dashboard/src/components/shared/useFocusTrap.ts`):
- Auto-focuses the first focusable element on activation
- Tab from last wraps to first; Shift+Tab from first wraps to last
- Restores focus to the original opener on deactivation (best-effort via try/catch — opener may have been removed from DOM)
- Filters by attribute (`disabled` / `hidden` / `aria-hidden`) NOT `offsetParent` because jsdom has no layout engine

Esc-handling stays per-modal — every modal has its own dismissal semantics (cancel-vs-confirm, confirmation prompt, etc.) so coupling that into the trap would over-reach.

### Race — stale-data discard in `useApiData`

A slow earlier fetch could resolve **after** a newer fetch and overwrite user-visible data with the previous page's results. Reproduced in test:
1. Mount `useApiData`; first fetch returns slow promise
2. Trigger refetch; second fetch returns fast promise
3. Resolve fast → `data='new'`
4. Resolve slow → without guard, `data` flips back to `'old'`

**Fix:** monotonic request-id ref. Each `fetchData()` call captures `myId = ++requestIdRef.current`. On resolve/reject, if `myId !== current id`, discard the result. Also gates `setLoading(false)` on id-match so a stale resolution can't flip loading off while a newer request is still in flight.

**Why request-id over AbortController:** avoids threading a signal through every fetcher's contract (`api.getTraces`, `api.getMoments`, etc.). Network savings of cancelling are negligible against the local dashboard server. The user-visible bug is fixed; full abort-controller plumbing can come later if observed network waste becomes a problem.

### `HealthView` "Retry now" button

Previously fired refetch on all 6 hooks unconditionally, even when `rateLimitedUntil` was in the future. Result: every fetcher immediately re-threw `RateLimitError`, banner stayed stuck with no spinner. Now skips the call while still inside the rate-limit window — banner auto-clears when the window passes via the existing `resumeTimer` logic.

## Out of scope (queued for follow-up)

- Chart keyboard interaction on `PassRateAreaChart`, `StackedBarByDay` SVG markers (mouse-only today). SR users have a path via the existing sr-only `<ol>`; the gap is mouse-free keyboard users.

## Test plan

- [x] dashboard unit tests: **22 files, 113 passed** (was 106; +7 new)
- [x] dashboard typecheck clean
- [x] dashboard storybook builds clean
- [x] iris root: 37 files, 398 passed (no regression)
- [x] `bash scripts/check-product-claims.sh`: PASSED
- [ ] CI green
- [ ] Post-merge: open the dashboard locally → MakeRuleModal — Tab cycles inside the panel; Esc/close returns focus to the opener button

PR 6 of 9 — plan: `plans/yes-lets-take-care-linear-elephant.md`. After this, only PR 5 (test gap closure + nightly real-LLM workflow) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)