### PR TITLE
fix(a11y): reveal-on-focus for chart drill-through lists

### DIFF
--- a/dashboard/src/components/dashboard/charts/PassRateAreaChart.tsx
+++ b/dashboard/src/components/dashboard/charts/PassRateAreaChart.tsx
@@ -135,32 +135,18 @@ const styles = {
     gap: '6px',
     flexShrink: 0,
   } as const,
-  /*
-   * Visually-hidden text alternatives surface the SVG's information
-   * to screen-reader + keyboard users WITHOUT affecting the sighted
-   * visual. Standard "sr-only" technique: zero-size offscreen absolutely
-   * positioned element that is still reachable by AT.
-   *
-   * This is the a11y fallback path — the SVG markers stay decorative
-   * for sighted users, the hidden list carries the Links for AT users.
-   * That resolves the #4a nested-interactive waiver cleanly: no
-   * interactive elements live inside the SVG anymore.
-   */
-  srOnly: {
-    position: 'absolute' as const,
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap' as const,
-    border: 0,
-  },
-  srOnlyListItem: {
-    listStyle: 'none' as const,
-  },
 };
+
+/*
+ * The visually-hidden chart drill-through list uses the .iris-sr-reveal
+ * utility (globals.css). Default state: zero-size clip-rect, AT-readable
+ * and tab-reachable. On :focus-within the container expands into a
+ * visible card so sighted keyboard users see the focus indicator and
+ * surrounding choices instead of focus appearing to vanish. The SVG
+ * markers stay decorative (aria-hidden) for sighted users — no
+ * interactive elements live inside the SVG, retiring the #4a
+ * nested-interactive waiver.
+ */
 
 interface MergedMarker {
   /** Stable key. */
@@ -570,7 +556,7 @@ export function PassRateAreaChart({
          * covers the "no audit events yet" narrative for both paths.
          */}
         {plotMarkers.length > 0 && (
-          <ol style={styles.srOnly as React.CSSProperties} aria-label="Audit events in view">
+          <ol className="iris-sr-reveal" aria-label="Audit events in view">
             {plotMarkers.map((marker) => {
               const isCluster = marker.entries.length > 1;
               const focusEntry = marker.entries[0];
@@ -581,7 +567,7 @@ export function PassRateAreaChart({
                 ? `${marker.entries.length} audit events around ${formatDayShort(marker.ts)}`
                 : `${focusEntry.action.replace('rule.', '')} ${focusEntry.ruleName ?? focusEntry.ruleId} at ${formatDayShort(marker.ts)}`;
               return (
-                <li key={marker.id} style={styles.srOnlyListItem}>
+                <li key={marker.id}>
                   <Link to={href}>{label}</Link>
                 </li>
               );

--- a/dashboard/src/components/dashboard/charts/StackedBarByDay.tsx
+++ b/dashboard/src/components/dashboard/charts/StackedBarByDay.tsx
@@ -82,21 +82,13 @@ const styles = {
     textAlign: 'center',
     padding: 'var(--space-6)',
   } as const,
-  /* Visually-hidden list used as the keyboard/screen-reader access
-   * path for per-day drill-through. Same "sr-only" technique used in
-   * PassRateAreaChart. Mouse users continue to click the SVG bars. */
-  srOnly: {
-    position: 'absolute' as const,
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap' as const,
-    border: 0,
-  },
 };
+
+/* The visually-hidden per-day drill-through list uses the
+ * .iris-sr-reveal utility (globals.css) — clip-rect by default,
+ * expands into a visible card on :focus-within so sighted keyboard
+ * users see where focus landed. Mouse users continue to click the
+ * SVG bars. */
 
 const VERDICT_ORDER: MomentVerdict[] = ['pass', 'partial', 'fail', 'unevaluated'];
 const formatDayShort = utcFormat('%a %d');
@@ -283,12 +275,12 @@ export function StackedBarByDay({ moments, days, periodLabel }: StackedBarByDayP
 
       {/* Keyboard/screen-reader path — Links for each day carrying the
        * same drill-through destinations the SVG bars navigate to. */}
-      <ol style={styles.srOnly as React.CSSProperties} aria-label="Per-day drill-through">
+      <ol className="iris-sr-reveal" aria-label="Per-day drill-through">
         {buckets.map((b) => {
           const dayStart = b.day.toISOString();
           const dayEnd = utcDay.offset(b.day, 1).toISOString();
           return (
-            <li key={b.day.getTime()} style={{ listStyle: 'none' }}>
+            <li key={b.day.getTime()}>
               <Link to={drillToMoments({ since: dayStart, until: dayEnd })}>
                 {formatDayShort(b.day)}: {b.total} moments — pass {b.pass}, partial {b.partial}, fail {b.fail}, unevaluated {b.unevaluated}
               </Link>

--- a/dashboard/src/styles/globals.css
+++ b/dashboard/src/styles/globals.css
@@ -67,6 +67,51 @@ select:focus-visible,
   border-radius: var(--radius-xs);
 }
 
+/*
+ * Visually-hidden container that reveals on :focus-within. Used by the
+ * decorative-SVG charts (PassRateAreaChart, StackedBarByDay) where the
+ * SVG markers are aria-hidden and the canonical keyboard / screen-reader
+ * path is a hidden <ol> of <Link>s. Default state: 1px clip-rect (still
+ * tab-reachable, AT-readable). On focus-within the container expands
+ * into a visible card so sighted keyboard users see the focus indicator
+ * and the surrounding choices, instead of focus appearing to vanish.
+ *
+ * Why a class and not inline style: pseudo-classes can't be expressed
+ * via inline style. The clip-rect default + focus-within reveal must
+ * live in CSS.
+ */
+.iris-sr-reveal {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.iris-sr-reveal:focus-within {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: var(--space-3) 0 0 0;
+  padding: var(--space-3) var(--space-4);
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--iris-500);
+  border-radius: var(--radius-sm);
+}
+
+.iris-sr-reveal:focus-within > li {
+  list-style: none;
+  padding: var(--space-1) 0;
+}
+
 ::selection { background: var(--iris-600); color: white; }
 
 ::-webkit-scrollbar {

--- a/dashboard/tests/a11y/charts.test.tsx
+++ b/dashboard/tests/a11y/charts.test.tsx
@@ -177,6 +177,18 @@ describe('a11y · chart primitives', () => {
       expect(links.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('drill-through list uses the focus-within reveal class', () => {
+      // The .iris-sr-reveal utility (globals.css) is clip-rect by default
+      // and expands on :focus-within so sighted keyboard users see the
+      // focus indicator when tabbing through the otherwise-hidden links.
+      const container = renderWithRouter(
+        <PassRateAreaChart trend={sampleTrend} auditEntries={sampleAudit} periodLabel="7d" />,
+      );
+      const hiddenList = container.querySelector('ol[aria-label="Audit events in view"]');
+      expect(hiddenList).not.toBeNull();
+      expect(hiddenList!.classList.contains('iris-sr-reveal')).toBe(true);
+    });
+
     it('skeleton empty state has no violations', async () => {
       const container = renderWithRouter(
         <PassRateAreaChart trend={[]} auditEntries={[]} periodLabel="7d" />,
@@ -237,6 +249,15 @@ describe('a11y · chart primitives', () => {
       expect(hiddenList).not.toBeNull();
       const links = hiddenList!.querySelectorAll('a[href*="/moments"]');
       expect(links.length).toBe(7); // one per day in the window
+    });
+
+    it('drill-through list uses the focus-within reveal class', () => {
+      const container = renderWithRouter(
+        <StackedBarByDay moments={[makeSampleMoment(1), makeSampleMoment(2), makeSampleMoment(3)]} days={7} periodLabel="7d" />,
+      );
+      const hiddenList = container.querySelector('ol[aria-label="Per-day drill-through"]');
+      expect(hiddenList).not.toBeNull();
+      expect(hiddenList!.classList.contains('iris-sr-reveal')).toBe(true);
     });
 
     it('empty state has no violations', async () => {


### PR DESCRIPTION
## Summary

Unblocks the chart keyboard a11y item deferred from PR #135 (Bundle 1). Adds a `.iris-sr-reveal` utility class that's clip-rect hidden by default and expands into a visible card on `:focus-within`, applied to the existing sr-only `<ol>` drill-through lists in `PassRateAreaChart` and `StackedBarByDay`.

## Why this fix and not the original plan

Bundle 1's plan proposed adding `tabIndex` / `role` / `onKeyDown` to the SVG `<g>` markers. That was rejected because it re-introduces the nested-interactive issue the Session 37 architecture explicitly retired (`PassRateAreaChart.tsx:144-147` + `511-522`):

> "Audit annotations — vertical ticks + glyphs. **DECORATIVE**: the SVG elements are aria-hidden; the keyboard/screen-reader path is the sr-only `<ol>` rendered after the SVG below. […] This arrangement retires the #4a nested-interactive waiver: no interactive elements live inside the SVG."

The actual gap was different: the sr-only list **was** tab-reachable (clip-rect doesn't remove from the focus chain), but the focus indicator landed on a 1×1 pixel element so sighted keyboard users saw focus appear to vanish.

This PR keeps the architecture intact and fixes the underlying signal — the list reveals on focus-within so the focused link becomes visible.

## Implementation

`dashboard/src/styles/globals.css` — new `.iris-sr-reveal` utility:

```css
.iris-sr-reveal {
  position: absolute;
  width: 1px; height: 1px;
  clip: rect(0, 0, 0, 0);
  /* …standard sr-only pattern */
}
.iris-sr-reveal:focus-within {
  position: static;
  width: auto; height: auto;
  margin: var(--space-3) 0 0 0;
  padding: var(--space-3) var(--space-4);
  background: var(--bg-card);
  border: 1px solid var(--iris-500);
  border-radius: var(--radius-sm);
  /* …visible card */
}
```

`PassRateAreaChart.tsx` + `StackedBarByDay.tsx`:
- Replace inline `style={styles.srOnly}` with `className="iris-sr-reveal"`
- Drop now-dead `srOnly` + `srOnlyListItem` style entries
- Update the docstring at the top of each styles object to point at the utility class

## Test extension

`dashboard/tests/a11y/charts.test.tsx` — two new tests assert the `iris-sr-reveal` className is present on each list. The `:focus-within` reveal is a CSS responsibility (jsdom doesn't compute pseudo-class layout); the className assertion is the contract.

Existing tests — drill-through links exist, axe clean on populated + empty, hidden list selectable by `aria-label` — continue to pass.

## Verification

| Gate | Result |
|---|---|
| `cd dashboard && npm run typecheck` | clean |
| `cd dashboard && npm run build` | clean (CSS 6.19 → 6.71 KB, +0.5 KB for the new class + reveal block) |
| `cd dashboard && npm test` | **111 passed** (109 → 111, +2 className-assertion tests) |
| `cd dashboard && npm run build-storybook` | clean |

## Test plan

- [x] dashboard typecheck + build + vitest + build-storybook green
- [x] axe smoke tests still pass on both charts populated + empty
- [ ] Post-merge: manual keyboard test on iris-eval.com /dashboard — Tab into a chart, verify the drill-through list appears with a visible focus ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)