### PR TITLE
chore(docker): bump Node 20-alpine to 24-alpine (Active LTS)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,3 +101,10 @@ updates:
       - "docker"
     commit-message:
       prefix: "docker"
+    ignore:
+      # Node major bumps need manual review — Dependabot doesn't distinguish
+      # LTS (even majors) from Current (odd majors). Iris production runtime
+      # stays on the latest Active LTS. Patch + minor bumps within an LTS
+      # major still flow through Dependabot.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -14,7 +14,7 @@ RUN npm run build
 COPY dashboard/ dashboard/
 RUN cd dashboard && npm install && npm run build
 
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS production
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS production
 
 RUN addgroup -g 1001 iris && adduser -u 1001 -G iris -s /bin/sh -D iris
 


### PR DESCRIPTION
## Summary

Replaces the closed Dependabot PR #124 (which offered `node:25-alpine` — the Current non-LTS line). Iris production runtime stays on Active LTS only.

## Why this PR exists separately

Node 20 enters maintenance LTS in April 2025 and EOL April 2026. The bump IS necessary; only the target needed correcting:

| Track | Status (as of 2026-05) |
|---|---|
| Node 20 | Maintenance, EOL imminent |
| Node 22 | Active LTS, ends Oct 2027 |
| **Node 24** | **Active LTS** — preferred runtime target |
| Node 25 | Current (non-LTS) — declined |

Dependabot offered 25-alpine because it's the latest tag; the LTS-vs-Current distinction isn't part of its model. Manual selection of 24-alpine is correct here.

## Changes

- `Dockerfile` — both FROM stages: `node:20-alpine@sha256:fb4cd1...` → `node:24-alpine@sha256:d1b3b4...`. OCI manifest list digest fetched via `docker buildx imagetools inspect node:24-alpine` (per the SHA-pin discipline from PR #122).
- `.github/dependabot.yml` — adds `update-types: [version-update:semver-major]` ignore rule for the `node` dependency so future weekly Dependabot runs don't keep reopening jumps to the Current line. Patch + minor updates within the Active LTS major still flow through Dependabot automatically.

## Verification

| Gate | Notes |
|---|---|
| Local `docker build` | Skipped — Docker Desktop not running locally; relying on CI's `build` job |
| CI `build` job | Validates the image builds cleanly with the new base |
| CI `test (20)` + `test (22)` | Node 20 + 22 still in test matrix; image change doesn't affect those |
| CI all 11 checks | Standard PR cycle gate |

## Test plan

- [ ] CI `build` green (Docker image builds on the new base)
- [ ] All 11 PR CI checks green
- [ ] Post-merge: GHCR digest published; container starts cleanly with the dashboard on port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)