### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-05-05T16:59:04.119Z",
-  "generatedFromCommit": "5863661",
+  "generatedAt": "2026-05-06T22:57:35.669Z",
+  "generatedFromCommit": "6ceaaa7",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -102,8 +102,8 @@
     ]
   },
   "release": {
-    "currentReleaseDate": "2026-04-24",
-    "currentReleaseVersion": "0.4.0",
+    "currentReleaseDate": "2026-05-06",
+    "currentReleaseVersion": "0.4.1",
     "nextPlannedScope": "Cloud SKU foundation",
     "nextPlannedVersion": "0.5.0"
   },
@@ -136,7 +136,7 @@
     "dashboardPackage": "0.1.0",
     "initPackage": "0.1.0",
     "langchainPackage": "0.1.0",
-    "mcpServer": "0.4.0",
+    "mcpServer": "0.4.1",
     "websitePackage": "0.1.0"
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "author": {
     "name": "Iris",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-06
+
+Hygiene release. Truthbase + claims-alignment CI guard close the bug class behind the hero `374→413` recurrence. Dashboard a11y + race-condition hardening. Three security fixes (CORS allowlist, DNS pre-resolve SSRF guard, tenant gate on /rules/custom). Cloud-tier groundwork (CustomRuleStore tenant API). Five dependency bumps. No breaking changes for OSS deployments.
+
 ### Added
 
 - **Truthbase — single source of truth for facts about Iris.** `iris/.claims.json` is regenerated from canonical artifacts (`package.json`, `vitest --reporter=json`, MCP tool registry, eval rule registry, LLM-judge templates, CHANGELOG headers) via `npm run claims:generate`. Reader modules at `src/lib/claims.ts`, `website/src/lib/claims.ts`, `dashboard/src/lib/claims.ts` expose typed constants (`VERSION_MCP_SERVER`, `TEST_COUNT_VITEST_ROOT`, `MCP_TOOL_COUNT`, `RULE_COUNT_BUILT_IN`, `LLM_JUDGE_TEMPLATE_COUNT`, `TAGLINE`, etc.) for surfaces to import instead of hardcoding. Hardcoded-claim scanner (`scripts/claims/check-no-hardcoded.mjs`) catches new drift; `.github/workflows/claims-alignment.yml` runs the scanner + verifies the regenerator output matches the committed `.claims.json` on every PR + push to main. Surface migrations in this PR: `website/src/components/hero.tsx` (test count claim) + `website/src/app/page.tsx` (JSON-LD `softwareVersion`). Allow-list (`scripts/claims/allow-list.json`) carries explicit exemptions for historical CHANGELOG entries, version-snapshot roadmap rows, and the seven website-component / docs sites flagged as migration candidates for follow-on PRs. Closes the bug class that produced the hero `374→413 tests` recurrence after the linear-elephant remediation. The `374` literal no longer exists; the surface reads `{TEST_COUNT_VITEST_ROOT}` from the regenerated truthbase. New scripts: `claims:capture-tests` (CI wrapper around `vitest --reporter=json`), `claims:generate`, `claims:check`, `claims:check-hardcoded`. Documented at `scripts/claims/README.md`.
@@ -25,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CORS allowlist now matches a single hostname/port label per `*` wildcard.** Previously `pattern.replace(/\*/g, '.*')` substituted `.*` (matches dots/colons/slashes), so an entry like `http://localhost:*` would also match a malicious origin like `http://localhost:8080.evil.com`. Substitution is now `[^.:/]+`. Any allowlist entry that previously matched origins crossing a label boundary will now be rejected — review your `security.allowedOrigins` config if you rely on multi-label subdomain matching (use multiple explicit entries instead). `src/middleware/cors.ts`.
 - **DNS pre-resolve guard against citation-verify SSRF via DNS rebinding.** `resolve.ts` now resolves every public hostname via `dns.lookup({all:true})` and re-checks every returned address against the IP blocklist before fetching, defeating the bypass where a public hostname (e.g. `*.localtest.me`) resolves to `127.0.0.1`. A residual TOCTOU window between the pre-resolve and the socket connect remains; closing it requires controlling the socket via a custom undici dispatcher and is queued for follow-up. `src/eval/citation-verify/resolve.ts`.
 - **Tenant gate on `/rules/custom` (GET, POST, DELETE).** All three handlers now call `requireTenant(req)` before acting. In OSS the tenant middleware always resolves to `LOCAL_TENANT`, so behavior is unchanged for self-hosted deployments. In Cloud (v0.5+), unauthenticated requests bypassing the auth+tenant middleware will now fail-closed at the route layer instead of operating on un-tenanted state. The actual storage threading (`CustomRuleStore` accepting a `TenantId`) lands in PR 3b. Regression test: `tests/unit/dashboard/routes/rules-tenant-gate.test.ts`. `src/dashboard/routes/rules.ts`.
+
+### Dependencies
+
+- `safe-regex2` 5.1.0 → 5.1.1 (#101).
+- `express-rate-limit` 8.3.2 → 8.5.0 (#126).
+- `anchore/sbom-action` 0.9.0 → 0.24.0 (CI; #127).
+- Testing group bump (#110).
+- Linting group bump (#107).
 
 ## [0.4.0] - 2026-04-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iris-eval/mcp-server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "mcpName": "io.github.iris-eval/mcp-server",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/iris-eval/mcp-server",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@iris-eval/mcp-server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       },

--- a/website/public/.well-known/mcp.json
+++ b/website/public/.well-known/mcp.json
@@ -4,7 +4,7 @@
   "homepage": "https://iris-eval.com",
   "repository": "https://github.com/iris-eval/mcp-server",
   "npm": "@iris-eval/mcp-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "transport": [
     "stdio",


### PR DESCRIPTION
## Summary

Hygiene release. v0.4.0 → v0.4.1 — promotes the [Unreleased] section (already on main from Session 43) to a dated 0.4.1 entry and bundles 5 Dependabot bumps merged this session.

## Substance (already on main, now released)

- Truthbase + claims-alignment CI guard — closes the hero `374→413` drift class structurally (every claim reads from `.claims.json`, hardcoded-claim scanner blocks regressions in CI).
- Focus-trap on dashboard modals — keyboard/screen-reader gap closed.
- `useApiData` stale-resolve race fix — slow earlier fetches no longer overwrite newer ones; failed older requests can't flip error state after a newer success.
- `CustomRuleStore` now tenant-aware (cloud-tier groundwork; OSS unchanged via `LOCAL_TENANT`).
- 3 security fixes: CORS allowlist label-boundary hardening, DNS pre-resolve guard against citation-verify SSRF rebinding, tenant gate on `/rules/custom`.

## Dependencies (this PR's merges)

- `safe-regex2` 5.1.0 → 5.1.1 (#101, patch, prod)
- `express-rate-limit` 8.3.2 → 8.5.0 (#126, minor, prod)
- `anchore/sbom-action` 0.9.0 → 0.24.0 (#127, CI)
- testing group (#110, devDeps)
- linting group (#107, devDeps)

## Deferred to v0.4.2

- `sigstore/cosign-installer` 3.9.2 → 4.1.1 (#125, MAJOR — wants pre-merge signing verification)
- github-actions group (#106)

Both blocked locally on `gh auth refresh -s workflow`.

## Test plan

- [x] `npm run claims:check` passes locally (truthbase aligned to v0.4.1)
- [ ] CI green: lint-and-typecheck, build, test (20/22), integration, e2e, lighthouse, claims-alignment
- [ ] After merge: npm publish + Docker push + GitHub Release + MCP Registry isLatest cascade
- [ ] Cosign verification on the v0.4.1 Docker artifact post-release

## Breaking changes

None for OSS. Cloud orchestrators (none yet) consuming `CustomRuleStore` directly will see the tenant-aware constructor signature shipped on main from session 43.