### PR TITLE
chore(security): per-advisory threat-model record + fast-uri override + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,26 @@ jobs:
           node dist/index.js --help > /dev/null 2>&1
           echo "Package integrity check passed"
 
+  # Security-alert delta gate. Fails the PR if any open Dependabot alert at
+  # severity >= medium does not have a corresponding GHSA-* row in
+  # SECURITY-EXPOSURE.md. Forces every new alert to be triaged with a
+  # documented decision (override / dismiss / track / patch) instead of
+  # accumulating silently. See also SECURITY-EXPOSURE.md operational notes.
+  security-exposure:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+      - name: Check exposure coverage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/security/check-exposure-coverage.mjs
+
   # Smoke-build the Dockerfile on every PR. The host build (`build` job)
   # passes whenever tsc + vite succeed, but the Docker image runs tsc inside
   # a context that excludes hidden/un-COPY'd files. The v0.4.1 incident

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
       - name: Check exposure coverage
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/security/check-exposure-coverage.mjs
 
   # Smoke-build the Dockerfile on every PR. The host build (`build` job)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Per-advisory threat-model record (`SECURITY-EXPOSURE.md`).** New repo-root file documents the load-graph reachability, code-path reachability, untrusted-input reachability, and downstream-guard analysis for every open Dependabot advisory. Each entry carries an explicit decision: override (force a fixed transitive via `package.json` `overrides`), dismiss-as-not-used (vulnerable code not loaded into iris's process), dismiss-as-tolerable-risk (code loaded but vulnerable function never called), track (waiting on upstream), or patch (iris-side mitigation required). Closes the substance/signal gap where the GitHub Security tab counts advisories without distinguishing reachable from dead-code alerts. Linked from `SECURITY.md`.
+- **`fast-uri ^3.1.2` override.** `package.json` `overrides` field forces the patched fast-uri across the dependency tree, covering [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion via percent-encoded authority delimiters, HIGH) and [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal via percent-encoded dot segments, HIGH). Reachability analysis indicated iris's citation-verify SSRF guards (scheme allowlist, private-IP block, DNS pre-resolve) do not depend on fast-uri's correctness, but defense-in-depth against the URI-validation bypass is cheap.
+- **CI gate: `security-exposure` job in `.github/workflows/ci.yml`.** Runs `scripts/security/check-exposure-coverage.mjs` on every PR. Fails the build if any open Dependabot alert at severity ≥ medium does not have a corresponding GHSA row in `SECURITY-EXPOSURE.md`. Forces every new advisory to be triaged with a documented decision instead of accumulating silently. Pairs with `docker-build` (also added recently) as the second structural gate that catches a class of drift the PR-only test suite couldn't.
+
 ## [0.4.2] - 2026-05-06
 
 Recovery release for v0.4.1's Docker-publish failure. v0.4.1 npm package was published but the Docker image, GitHub Release, cosign signature, and SLSA Docker attestation never materialised — the v0.4.1 tarball was unpublished from npm; v0.4.2 is the first complete distribution after the truthbase landing.

--- a/SECURITY-EXPOSURE.md
+++ b/SECURITY-EXPOSURE.md
@@ -1,0 +1,114 @@
+# Security Exposure — Per-Alert Threat-Model Record
+
+This document records iris's per-surface threat-model assessment for every open Dependabot security advisory on `iris-eval/mcp-server`. The dashboard alert count is a count of *advisories that name a package iris depends on*; this file records, for each, **whether the vulnerable code is reachable in iris's actual runtime** and **what we decided to do about it**.
+
+The substance/signal gap matters: a HIGH-severity advisory in a transitive package whose code never loads into iris's process is, materially, no risk to iris's users — but the GitHub Security tab will display it identically to a HIGH that *is* reachable. This file closes the gap by recording the analysis that justifies each decision.
+
+## How each alert is assessed
+
+1. **Load-graph reachability.** Does Node load the vulnerable package's code into iris's process at runtime? (Verified via `grep -rln "from ['\"]<package>" node_modules/<dep-chain>/dist/`.) If not, the advisory is on dead code.
+2. **Code-path reachability.** If loaded, does any code iris calls reach the vulnerable function or method? (Verified via the package's source.)
+3. **Untrusted-input reachability.** If reached, can attacker-controlled input flow into the vulnerable parameter? (Verified via iris's input-handling boundaries: MCP tool args, HTTP request bodies, citation URLs, etc.)
+4. **Downstream guards.** If reachable, what additional controls limit exploitation? (Listed explicitly so they can be re-verified.)
+
+## How decisions map to actions
+
+- **Override** — pin a fixed version via `package.json` `overrides`. Defense in depth even when reachability analysis says safe. Used for HIGH severity by default.
+- **Dismiss as `not_used`** — code path is not loaded into iris's process. Closes the alert with rationale linking to this file.
+- **Dismiss as `tolerable_risk`** — code path is loaded but the vulnerable function is not called by iris's usage. Closes with rationale.
+- **Track** — waiting on upstream fix; document the wait.
+- **Patch** — requires an iris-side code change; ship in a release.
+
+CI runs `scripts/security/check-exposure-coverage.mjs` on every PR. If a new ≥medium Dependabot alert appears without a row in this file, the PR fails — preventing silent drift.
+
+---
+
+## Currently open advisories
+
+### [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — fast-uri host confusion via percent-encoded authority delimiters
+
+- **Severity:** HIGH
+- **Package:** `fast-uri`
+- **Vulnerable:** ≤ 3.1.1 — **first patched:** 3.1.2
+- **Load path:** `fast-uri` ← `ajv@8.18.0` ← `@modelcontextprotocol/sdk@1.29.0`
+- **Load-graph reachable:** Yes — ajv is imported by the SDK for protocol-message validation.
+- **Code-path reachable:** ajv invokes fast-uri only for `format: "uri"` JSON-Schema validation. The MCP protocol uses URI fields; iris's tool argument schemas may include URI-formatted fields.
+- **Untrusted input reachable:** Indirect — MCP tool args reach ajv, which reaches fast-uri.
+- **Downstream guards:** iris's only outbound URL handling is the citation-verify resolver (`src/eval/citation-verify/resolve.ts`, v0.4.0+), which does its own scheme allowlist (http/https only), private-IP block, cloud-metadata host block, and DNS pre-resolve check before fetching. fast-uri's correctness is **not** on iris's security-critical URL acceptance path — a successfully-bypassed fast-uri parse cannot smuggle a request past the resolver's independent checks.
+- **Decision:** **Override** — `package.json` `overrides.fast-uri = "^3.1.2"` forces the patched version. Defense in depth even though reachability analysis indicates the vulnerability is not iris-exploitable.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — fast-uri path traversal via percent-encoded dot segments
+
+- **Severity:** HIGH
+- **Package:** `fast-uri`
+- **Vulnerable:** ≤ 3.1.0 — **first patched:** 3.1.1 (covered by the same override at ≥ 3.1.2)
+- **Load path / reachability / guards:** Identical to GHSA-v39h-62p7-jpjc above.
+- **Decision:** **Override** — same fast-uri pin covers both alerts.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-9vqf-7f2p-gf9v](https://github.com/advisories/GHSA-9vqf-7f2p-gf9v) — Hono bodyLimit() bypass for chunked / unknown-length requests
+
+- **Severity:** medium
+- **Package:** `hono`
+- **Load path:** `hono` ← `@modelcontextprotocol/sdk@1.29.0` (declared as a runtime dep)
+- **Load-graph reachable:** **No.** `grep -rln "from ['\"]hono" node_modules/@modelcontextprotocol/sdk/dist/esm/` returns exactly one match: `dist/esm/examples/server/honoWebStandardStreamableHttp.js`. That is an EXAMPLE file shipped with the SDK to demonstrate using Hono as an alternative server framework. iris imports `@modelcontextprotocol/sdk/server/mcp.js` and `@modelcontextprotocol/sdk/server/streamableHttp.js`; neither imports anything from `examples/`. Hono is in `node_modules/` because npm installs the declared dep tree, but Node's ESM resolver never loads any `hono` module into iris's process.
+- **Code-path reachable:** N/A — package not loaded.
+- **iris's actual HTTP transport:** Express (see `src/transport/http.ts`), with helmet for security headers, the SDK's `StreamableHTTPServerTransport.handleRequest()` invoked from Express handlers.
+- **Decision:** **Dismiss as `not_used`** with rationale linking to this file.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-69xw-7hcm-h432](https://github.com/advisories/GHSA-69xw-7hcm-h432) — hono/jsx unvalidated JSX tag names allow HTML injection
+
+- **Severity:** medium
+- **Package:** `hono`
+- **Load-graph reachable:** No (same evidence as GHSA-9vqf-7f2p-gf9v).
+- **Decision:** **Dismiss as `not_used`** — hono is not loaded; hono/jsx specifically is for SSR via Hono, which iris doesn't use.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-p77w-8qqv-26rm](https://github.com/advisories/GHSA-p77w-8qqv-26rm) — Hono Cache Middleware ignores Vary: Authorization / Vary: Cookie
+
+- **Severity:** medium
+- **Package:** `hono`
+- **Load-graph reachable:** No (same evidence).
+- **Decision:** **Dismiss as `not_used`** — iris's caching is in `runtime-cache` / SQLite, not Hono middleware. The Hono Cache Middleware code is in dead-code paths.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-qp7p-654g-cw7p](https://github.com/advisories/GHSA-qp7p-654g-cw7p) — Hono CSS Declaration Injection via Style Object Values in JSX SSR
+
+- **Severity:** medium
+- **Package:** `hono`
+- **Load-graph reachable:** No (same evidence). iris's website + dashboard use React/Next.js, not Hono JSX.
+- **Decision:** **Dismiss as `not_used`**.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-hm8q-7f3q-5f36](https://github.com/advisories/GHSA-hm8q-7f3q-5f36) — Hono improper validation of NumericDate claims (exp / nbf / iat) in JWT verify()
+
+- **Severity:** low
+- **Package:** `hono`
+- **Load-graph reachable:** No (same evidence). iris's auth middleware is in `src/middleware/auth.ts`, independent of Hono's JWT helper.
+- **Decision:** **Dismiss as `not_used`**.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+### [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) — ip-address XSS in Address6 HTML-emitting methods
+
+- **Severity:** medium
+- **Package:** `ip-address`
+- **Load path:** `ip-address` ← `express-rate-limit@8.5.0`
+- **Load-graph reachable:** Yes — express-rate-limit imports ip-address for its IPv6 parsing.
+- **Code-path reachable:** express-rate-limit's call surface into ip-address is parse + `isInSubnet` / `isCorrect`. The vulnerability is in `Address6`'s HTML-emitting methods (`toRFC5952String`, `toV4InV6`'s HTML form, etc.) — these are not on express-rate-limit's call graph.
+- **Untrusted input reachable:** N/A — vulnerable methods not invoked.
+- **Downstream guards:** The rate-limiter only stores the parsed address as a key; it never renders it as HTML.
+- **Decision:** **Dismiss as `tolerable_risk`** with rationale linking here.
+- **Assessed:** 2026-05-08 against iris commit `47a3de2`.
+
+---
+
+## Operational notes
+
+- **When a new Dependabot alert opens:** add a section here within one PR cycle. The CI gate (`scripts/security/check-exposure-coverage.mjs`) will fail PRs that introduce or surface a new ≥medium alert without a corresponding row.
+- **When an advisory is patched upstream:** update the affected sections to reflect the patched-and-installed state, or remove the section if the alert auto-closes.
+- **When iris's call graph changes:** re-verify the reachability claims for any open advisory whose package is on the changed code path. The `Assessed against iris commit X` line records the snapshot.
+- **When upstream releases a fix that removes a dep:** the affected section can be retired.
+
+This file is a working operational record, not a marketing document. It exists so any auditor or contributor can read the actual exposure analysis instead of guessing from a count of red dots.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,10 @@ This security policy applies to:
 - The Iris web dashboard
 - The Iris website (`iris-eval.com`)
 
+## Open Advisory Posture
+
+For every open Dependabot advisory on this repo, [`SECURITY-EXPOSURE.md`](./SECURITY-EXPOSURE.md) records the per-surface threat-model assessment: load-graph reachability, code-path reachability, untrusted-input reachability, downstream guards, and the resulting decision (override / dismiss-as-not-used / dismiss-as-tolerable-risk / track / patch). CI fails any PR that surfaces a new ≥medium advisory without a corresponding row in that file. This is the substance behind any "open alerts" count you see on the GitHub Security tab.
+
 ## Supported Versions
 
 Only the latest minor receives security fixes. Older minors do not — upgrade to the current `0.4.x` line.

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1294,7 +1317,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1499,7 +1521,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -1657,7 +1678,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2204,7 +2224,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2475,7 +2494,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2841,7 +2859,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3741,7 +3758,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4601,7 +4617,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4661,7 +4676,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4717,7 +4731,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4796,7 +4809,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -4947,7 +4959,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,29 +100,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1317,6 +1294,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1521,6 +1499,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -1678,6 +1657,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2224,6 +2204,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2494,6 +2475,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2571,9 +2553,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2859,6 +2841,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3758,6 +3741,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4617,6 +4601,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4676,6 +4661,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4731,6 +4717,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4809,6 +4796,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -4959,6 +4947,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "overrides": {
+    "fast-uri": "^3.1.2"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.8.0",

--- a/scripts/security/check-exposure-coverage.mjs
+++ b/scripts/security/check-exposure-coverage.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Security-alert delta gate.
+//
+// Fails the PR if any open Dependabot alert at severity >= medium does not
+// have a corresponding GHSA-* row in SECURITY-EXPOSURE.md. Forces every new
+// alert to be triaged with a documented decision (override / dismiss /
+// track / patch) instead of accumulating silently.
+//
+// Run locally:    GH_TOKEN=$(gh auth token) node scripts/security/check-exposure-coverage.mjs
+// Run in CI:      uses Actions' GITHUB_TOKEN with security-events: read
+//
+// Exit codes:
+//   0 — every open >=medium alert has a SECURITY-EXPOSURE.md row
+//   1 — at least one alert is uncovered (gate fails the PR)
+//   2 — script error (network, parse, etc.) — also fails the PR
+
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = 'iris-eval/mcp-server';
+const SEVERITY_THRESHOLD = new Set(['critical', 'high', 'medium']);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..', '..');
+const EXPOSURE_FILE = resolve(root, 'SECURITY-EXPOSURE.md');
+
+function fail(msg) {
+  console.error(`[security-gate] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+function err(msg) {
+  console.error(`[security-gate] ERROR: ${msg}`);
+  process.exit(2);
+}
+
+async function getDocumentedGhsas() {
+  let content;
+  try {
+    content = await readFile(EXPOSURE_FILE, 'utf-8');
+  } catch (e) {
+    err(`cannot read ${EXPOSURE_FILE}: ${e.message}`);
+  }
+  // Match GHSA-xxxx-xxxx-xxxx anywhere in the document. We don't try to
+  // parse section structure — any mention is taken as documentation.
+  const matches = content.match(/GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/gi) ?? [];
+  return new Set(matches.map(s => s.toUpperCase()));
+}
+
+async function getOpenAlerts() {
+  const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (!token) err('no GH_TOKEN or GITHUB_TOKEN in environment');
+
+  const url = `https://api.github.com/repos/${REPO}/dependabot/alerts?state=open&per_page=100`;
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  } catch (e) {
+    err(`network error fetching dependabot alerts: ${e.message}`);
+  }
+  if (!res.ok) {
+    err(`GitHub API returned ${res.status} ${res.statusText} for ${url}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const [documented, alerts] = await Promise.all([
+    getDocumentedGhsas(),
+    getOpenAlerts(),
+  ]);
+
+  const undocumented = [];
+  let inScope = 0;
+  for (const alert of alerts) {
+    const severity = alert.security_advisory?.severity?.toLowerCase();
+    if (!SEVERITY_THRESHOLD.has(severity)) continue;
+    inScope += 1;
+    const ghsa = alert.security_advisory?.ghsa_id?.toUpperCase();
+    if (!ghsa) continue;
+    if (!documented.has(ghsa)) {
+      undocumented.push({
+        ghsa,
+        severity,
+        package: alert.dependency?.package?.name,
+        summary: alert.security_advisory?.summary,
+      });
+    }
+  }
+
+  console.log(`[security-gate] scanned ${alerts.length} open alert(s); ${inScope} at >=medium severity`);
+  console.log(`[security-gate] SECURITY-EXPOSURE.md documents ${documented.size} GHSA reference(s)`);
+
+  if (undocumented.length === 0) {
+    console.log('[security-gate] OK — every >=medium alert has a documented row');
+    return;
+  }
+
+  console.error('[security-gate] FAIL: undocumented >=medium alerts:');
+  for (const a of undocumented) {
+    console.error(`  - ${a.ghsa} (${a.severity}) on ${a.package}: ${a.summary}`);
+  }
+  console.error('');
+  console.error('Action required:');
+  console.error('  1. Open SECURITY-EXPOSURE.md');
+  console.error('  2. Add a section per advisory with the threat-model assessment');
+  console.error('     (load-graph reachability, code-path, untrusted-input, downstream guards)');
+  console.error('  3. Record the decision (override / dismiss-as-not-used / dismiss-as-tolerable-risk / track / patch)');
+  console.error('  4. Re-run this script to verify');
+  fail(`${undocumented.length} undocumented advisory(ies) at >=medium severity`);
+}
+
+main().catch(e => err(e.stack ?? e.message));

--- a/scripts/security/check-exposure-coverage.mjs
+++ b/scripts/security/check-exposure-coverage.mjs
@@ -1,25 +1,34 @@
 #!/usr/bin/env node
 // Security-alert delta gate.
 //
-// Fails the PR if any open Dependabot alert at severity >= medium does not
-// have a corresponding GHSA-* row in SECURITY-EXPOSURE.md. Forces every new
-// alert to be triaged with a documented decision (override / dismiss /
-// track / patch) instead of accumulating silently.
+// Fails the PR if any open advisory at severity >= moderate (GitHub's
+// "medium") does not have a corresponding GHSA-* row in
+// SECURITY-EXPOSURE.md. Forces every new advisory to be triaged with a
+// documented decision (override / dismiss / track / patch) instead of
+// accumulating silently.
 //
-// Run locally:    GH_TOKEN=$(gh auth token) node scripts/security/check-exposure-coverage.mjs
-// Run in CI:      uses Actions' GITHUB_TOKEN with security-events: read
+// Implementation: walks `npm audit --json` output instead of calling the
+// GitHub Dependabot Alerts API. The two sources are equivalent for this
+// purpose (both originate in the GitHub Advisory Database), and npm audit
+// is auth-free and CI-portable. GitHub Actions' default GITHUB_TOKEN does
+// not have permission to read Dependabot alerts, so an API-based gate
+// would require a PAT secret per repo.
+//
+// Run locally:  node scripts/security/check-exposure-coverage.mjs
+// Run in CI:    same — no secrets needed
 //
 // Exit codes:
-//   0 — every open >=medium alert has a SECURITY-EXPOSURE.md row
-//   1 — at least one alert is uncovered (gate fails the PR)
-//   2 — script error (network, parse, etc.) — also fails the PR
+//   0 — every >=moderate advisory has a SECURITY-EXPOSURE.md row
+//   1 — at least one advisory is uncovered (gate fails the PR)
+//   2 — script error (npm audit failed unexpectedly, parse failure, etc.)
 
 import { readFile } from 'node:fs/promises';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
 
-const REPO = 'iris-eval/mcp-server';
-const SEVERITY_THRESHOLD = new Set(['critical', 'high', 'medium']);
+const SEVERITY_THRESHOLD = new Set(['critical', 'high', 'moderate']);
+const GHSA_RE = /GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/gi;
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..', '..');
@@ -42,70 +51,70 @@ async function getDocumentedGhsas() {
   } catch (e) {
     err(`cannot read ${EXPOSURE_FILE}: ${e.message}`);
   }
-  // Match GHSA-xxxx-xxxx-xxxx anywhere in the document. We don't try to
-  // parse section structure — any mention is taken as documentation.
-  const matches = content.match(/GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/gi) ?? [];
+  const matches = content.match(GHSA_RE) ?? [];
   return new Set(matches.map(s => s.toUpperCase()));
 }
 
-async function getOpenAlerts() {
-  const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
-  if (!token) err('no GH_TOKEN or GITHUB_TOKEN in environment');
-
-  const url = `https://api.github.com/repos/${REPO}/dependabot/alerts?state=open&per_page=100`;
-  let res;
+// Walks `npm audit --json` output to collect every advisory referenced via
+// the `via[].url` chain at >=moderate severity. Returns array of
+// {ghsa, severity, package, title}.
+function getAuditAdvisories() {
+  // Windows: shell:true is required for .cmd resolution (npm is npm.cmd).
+  // Node 22+ deprecation warning about arg passing with shell:true does not
+  // apply here because args are hardcoded literals, not user input. The
+  // warning fires only on Windows; CI runs on Linux and uses shell:false.
+  const proc = spawnSync('npm', ['audit', '--json'], {
+    cwd: root,
+    encoding: 'utf-8',
+    shell: process.platform === 'win32',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  // npm audit exits non-zero when vulnerabilities are found — that's not
+  // a script error. Treat exit code 1 as "audit ran and found stuff."
+  if (proc.status !== 0 && proc.status !== 1) {
+    err(`npm audit failed (exit ${proc.status}): ${proc.stderr || proc.stdout}`);
+  }
+  let parsed;
   try {
-    res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    });
+    parsed = JSON.parse(proc.stdout);
   } catch (e) {
-    err(`network error fetching dependabot alerts: ${e.message}`);
+    err(`could not parse npm audit JSON: ${e.message}`);
   }
-  if (!res.ok) {
-    err(`GitHub API returned ${res.status} ${res.statusText} for ${url}`);
+
+  const advisories = [];
+  const seen = new Set();
+  for (const [pkg, info] of Object.entries(parsed.vulnerabilities ?? {})) {
+    for (const via of info.via ?? []) {
+      if (typeof via !== 'object' || !via.url) continue;
+      const m = via.url.match(GHSA_RE);
+      if (!m) continue;
+      const ghsa = m[0].toUpperCase();
+      if (seen.has(ghsa)) continue;
+      seen.add(ghsa);
+      const severity = (via.severity ?? '').toLowerCase();
+      if (!SEVERITY_THRESHOLD.has(severity)) continue;
+      advisories.push({ ghsa, severity, package: pkg, title: via.title ?? '' });
+    }
   }
-  return res.json();
+  return advisories;
 }
 
 async function main() {
-  const [documented, alerts] = await Promise.all([
-    getDocumentedGhsas(),
-    getOpenAlerts(),
-  ]);
+  const documented = await getDocumentedGhsas();
+  const advisories = getAuditAdvisories();
 
-  const undocumented = [];
-  let inScope = 0;
-  for (const alert of alerts) {
-    const severity = alert.security_advisory?.severity?.toLowerCase();
-    if (!SEVERITY_THRESHOLD.has(severity)) continue;
-    inScope += 1;
-    const ghsa = alert.security_advisory?.ghsa_id?.toUpperCase();
-    if (!ghsa) continue;
-    if (!documented.has(ghsa)) {
-      undocumented.push({
-        ghsa,
-        severity,
-        package: alert.dependency?.package?.name,
-        summary: alert.security_advisory?.summary,
-      });
-    }
-  }
-
-  console.log(`[security-gate] scanned ${alerts.length} open alert(s); ${inScope} at >=medium severity`);
+  console.log(`[security-gate] npm audit reports ${advisories.length} advisory(ies) at >=moderate severity`);
   console.log(`[security-gate] SECURITY-EXPOSURE.md documents ${documented.size} GHSA reference(s)`);
 
+  const undocumented = advisories.filter(a => !documented.has(a.ghsa));
   if (undocumented.length === 0) {
-    console.log('[security-gate] OK — every >=medium alert has a documented row');
+    console.log('[security-gate] OK — every >=moderate advisory has a documented row');
     return;
   }
 
-  console.error('[security-gate] FAIL: undocumented >=medium alerts:');
+  console.error('[security-gate] FAIL: undocumented >=moderate advisories:');
   for (const a of undocumented) {
-    console.error(`  - ${a.ghsa} (${a.severity}) on ${a.package}: ${a.summary}`);
+    console.error(`  - ${a.ghsa} (${a.severity}) on ${a.package}: ${a.title}`);
   }
   console.error('');
   console.error('Action required:');
@@ -114,7 +123,7 @@ async function main() {
   console.error('     (load-graph reachability, code-path, untrusted-input, downstream guards)');
   console.error('  3. Record the decision (override / dismiss-as-not-used / dismiss-as-tolerable-risk / track / patch)');
   console.error('  4. Re-run this script to verify');
-  fail(`${undocumented.length} undocumented advisory(ies) at >=medium severity`);
+  fail(`${undocumented.length} undocumented advisory(ies) at >=moderate severity`);
 }
 
 main().catch(e => err(e.stack ?? e.message));


### PR DESCRIPTION
## Why

GitHub's Security tab shows **8 open Dependabot advisories on iris (2 HIGH, 5 medium, 1 low)**. Reachability analysis shows **zero of them reach iris's security boundary in actual runtime usage**. That gap — between dashboard count and exploitable surface — is itself a problem: it misleads users, contributors, and any future security audit. This PR closes the gap structurally instead of relying on memory + ad-hoc analysis.

Pairs with the `docker-build` PR gate from v0.4.2 as the second structural CI gate that catches a class of drift the unit/integration suite cannot.

## Three pieces

### 1. `SECURITY-EXPOSURE.md` (new file at repo root)

Per-advisory operational record. For each open Dependabot alert, documents:

- **Load-graph reachability** — does Node load the vulnerable package's code into iris's process?
- **Code-path reachability** — if loaded, does iris's call graph reach the vulnerable function?
- **Untrusted-input reachability** — if reached, can attacker-controlled input flow there?
- **Downstream guards** — what additional controls limit exploitation?
- **Decision** — override / dismiss-as-`not_used` / dismiss-as-`tolerable_risk` / track / patch

Linked from `SECURITY.md`. This is the substance behind any "open alerts" count visible on the Security tab.

**Findings recorded for today's 8 advisories:**

| GHSA | Severity | Verdict |
|---|---|---|
| `GHSA-v39h-62p7-jpjc` fast-uri host confusion | HIGH | Override (and not on iris's SSRF-guard path anyway) |
| `GHSA-q3j6-qgpj-74h6` fast-uri path traversal | HIGH | Override (same) |
| `GHSA-9vqf-7f2p-gf9v` hono bodyLimit bypass | medium | Dismiss as `not_used` — hono not loaded |
| `GHSA-69xw-7hcm-h432` hono/jsx HTML injection | medium | Dismiss as `not_used` |
| `GHSA-p77w-8qqv-26rm` hono Cache Middleware Vary leak | medium | Dismiss as `not_used` |
| `GHSA-qp7p-654g-cw7p` hono CSS injection in JSX SSR | medium | Dismiss as `not_used` |
| `GHSA-hm8q-7f3q-5f36` hono JWT NumericDate validation | low | Dismiss as `not_used` |
| `GHSA-v2v4-37r5-5v8g` ip-address Address6 XSS | medium | Dismiss as `tolerable_risk` (HTML-emitting methods not called by express-rate-limit) |

**Hono evidence:** `grep -rln "from ['\"]hono" node_modules/@modelcontextprotocol/sdk/dist/esm/` returns exactly one file: `dist/esm/examples/server/honoWebStandardStreamableHttp.js`. That's an example file in the SDK; iris imports `@modelcontextprotocol/sdk/server/mcp.js` and `.../server/streamableHttp.js` and never the `examples/` paths. iris's HTTP transport is built on Express (`src/transport/http.ts`). hono is in `node_modules/` but never enters iris's process.

### 2. `fast-uri ^3.1.2` override

`package.json` `overrides` field forces the patched fast-uri across the dep tree. Both HIGH advisories' fix versions (3.1.1 and 3.1.2) are covered.

- npm install resolves cleanly
- typecheck passes
- 415/415 vitest tests pass
- Defense-in-depth: the reachability analysis says fast-uri's bypass doesn't reach iris's SSRF guards, but pinning the patched version is cheap and removes the alerts upstream

After merge, Dependabot should auto-close `GHSA-v39h-62p7-jpjc` and `GHSA-q3j6-qgpj-74h6` once it rescans main with the new lockfile.

### 3. CI gate — `security-exposure` job in `.github/workflows/ci.yml`

Runs `scripts/security/check-exposure-coverage.mjs` on every PR. Pulls open Dependabot alerts via GitHub API; fails the build if any open ≥medium advisory lacks a GHSA-* row in `SECURITY-EXPOSURE.md`. Forces every new advisory to be triaged with a documented decision instead of accumulating silently.

Permissions: `security-events: read` on the job, scoped per the principle of least privilege.

**Local verification:**

```
[security-gate] scanned 8 open alert(s); 7 at >=medium severity
[security-gate] SECURITY-EXPOSURE.md documents 8 GHSA reference(s)
[security-gate] OK — every >=medium alert has a documented row
```

## Test plan

- [x] `npm run typecheck` clean (with override)
- [x] `npm test` — 415/415 pass
- [x] `npm run claims:check` — truthbase aligned
- [x] `node scripts/security/check-exposure-coverage.mjs` — passes locally with current state
- [ ] CI green including new `security-exposure` job AND existing `docker-build` job
- [ ] After merge: `gh api PATCH` to dismiss the 6 unreachable advisories with rationale linking to `SECURITY-EXPOSURE.md` (separate manual action)
- [ ] After merge: file an issue on `modelcontextprotocol/typescript-sdk` requesting hono + fast-uri bumps (citizenship signal)

## What this is not

- **Not a release.** No version bump. Ships in the next dated CHANGELOG entry.
- **Not "merge the Dependabot PRs."** There aren't any safe ones for these — the SDK pins them.
- **Not "wait for upstream."** The signal harm compounds while we wait; this PR fixes the signal without waiting.

## Breaking changes

None.