### PR TITLE
chore(security): YC-grade posture hardening — encrypted-report path + close postinstall slot

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in Iris, please report it responsibly.
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email: **security@iris-eval.com**
+Instead, please email **security@iris-eval.com** or submit through GitHub's **Private Vulnerability Reporting** at https://github.com/iris-eval/mcp-server/security/advisories/new — this delivers the report privately to maintainers, supports attachments, and avoids email entirely. A PGP public key for the email channel is available on request to the same address.
 
 We aim to acknowledge receipt within 48 hours and provide a detailed response within 5 business days. These are best-effort targets — Iris is currently maintained by a solo founder, so a brief delay during travel or focused-work periods is possible. Critical vulnerabilities (active exploitation, RCE, data exposure) get top priority regardless.
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "claims:check-hardcoded": "node scripts/claims/check-no-hardcoded.mjs",
     "clean": "rm -rf dist coverage",
     "seed:demo": "tsx scripts/seed-demo-data.ts",
-    "demo": "tsx scripts/demo.ts",
-    "postinstall": "echo \"\\n  ✅ Iris installed — the agent eval standard for MCP\\n  📖 Docs: https://iris-eval.com\\n  🎯 Try the playground: https://iris-eval.com/playground\\n  ⭐ Star us: https://github.com/iris-eval/mcp-server\\n\""
+    "demo": "tsx scripts/demo.ts"
   },
   "keywords": [
     "mcp",

--- a/website/public/.well-known/security.txt
+++ b/website/public/.well-known/security.txt
@@ -1,5 +1,6 @@
 Contact: mailto:security@iris-eval.com
-Expires: 2027-04-16T00:00:00.000Z
+Contact: https://github.com/iris-eval/mcp-server/security/advisories/new
+Expires: 2027-05-15T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://iris-eval.com/.well-known/security.txt
 Policy: https://github.com/iris-eval/mcp-server/blob/main/SECURITY.md


### PR DESCRIPTION
## Why

Three closely-related security-posture upgrades that improve iris's public stance without touching any code paths.

## Changes

### 1. `SECURITY.md` — add GitHub Private Vulnerability Reporting as encrypted channel
Adds a secondary submission path alongside `security@iris-eval.com`. GitHub's PVR delivers the report privately to maintainers, supports attachments, and avoids email entirely. Also notes that a PGP key for the email channel is available on request.

### 2. `.well-known/security.txt` — second Contact line + Expires bump
RFC 9116 supports multiple `Contact` lines; this lets reporters choose email or in-tool submission. Expires bumped 2027-04-16 → 2027-05-15.

### 3. `package.json` — remove `postinstall` echo
Closes a live execution slot every consumer runs on \`npm install\`. The current content was a benign welcome echo, but a future supply-chain compromise could repurpose it (cf. `lottiefiles`, `ua-parser-js`, `eslint-scope` — all exploited this exact pattern). The welcome message lives on the README and iris-eval.com; no functional regression.

## Verification posture (already in place — not modified here)
- Repo settings: secret-scanning push protection ✅, private vulnerability reporting ✅, secret scanning ✅, dependabot security updates ✅ (confirmed via \`gh api repos/iris-eval/mcp-server\`)
- `SECURITY-EXPOSURE.md` per-advisory threat model + CI gate already on main (PR #145, May 8)
- 0 open Dependabot alerts post-#151 Next bump (May 15)

## Scope
Posture-only. No source files, no workflow files, no release pipeline changes. Tests + lint + build unaffected.