### PR TITLE
fix(security): correct codeql-action SHA in Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,6 +38,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to GitHub code-scanning
-        uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7  # v4.35.4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Why

The Scorecard workflow added in #156 had the wrong commit SHA for `github/codeql-action/upload-sarif@v4.35.4` — it used `3ce22a6e...` (the tag-object SHA from `/git/refs/tags/v4.35.4`) instead of `68bde559...` (the actual commit SHA, which matches iris's existing `codeql.yml`).

Symptom: Scorecard's first run on main computed score **5.8/10** correctly but failed to publish to `api.securityscorecards.dev` with "imposter commit: 3ce22a6e... does not belong to github/codeql-action/upload-sarif". The badge URL therefore couldn't show a score.

## Fix

One-character — wait, one-SHA change. SHA `3ce22a6e336a7fcc318bc58ae1986395bdc83ba7` → `68bde559dea0fdcac2102bfdf6230c5f70eb485e` (the same SHA iris's `codeql.yml` uses for v4.35.4).

After this lands the next weekly run (or push to main) will publish successfully and the README Scorecard badge will start showing the score.