### PR TITLE
chore(security): Scorecard hardening — Token-Permissions + Signed-Releases + Branch-Protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Top-level least-privilege default. Individual jobs override when they
+# need more (e.g., security-exposure declares contents:read; no job in
+# this workflow needs write). Closes Scorecard Token-Permissions.
+permissions:
+  contents: read
+
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
 
+# Top-level least-privilege; analyze job upgrades to security-events:write
+# for SARIF upload. Closes Scorecard Token-Permissions.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/devto-crosspost.yml
+++ b/.github/workflows/devto-crosspost.yml
@@ -20,6 +20,12 @@ on:
         default: 'false'
         type: boolean
 
+# Top-level least-privilege. Cross-posting only reads the repo;
+# DEVTO_API_KEY is the outbound credential, not a GitHub permission.
+# Closes Scorecard Token-Permissions for this workflow.
+permissions:
+  contents: read
+
 jobs:
   crosspost:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,6 +16,11 @@ on:
   pull_request:
     branches: [main]
 
+# Top-level least-privilege. Lighthouse only needs to read the repo.
+# Closes Scorecard Token-Permissions for this workflow.
+permissions:
+  contents: read
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
@@ -51,7 +56,9 @@ jobs:
 
       - name: Lighthouse CI
         run: |
-          npm install -g @lhci/cli@^0.15
+          # scorecard: pinned to exact version for Pinned-Dependencies check.
+          # Bump in lockstep with a deliberate version bump PR, not via caret.
+          npm install -g @lhci/cli@0.15.0
           lhci autorun
         env:
           LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,28 @@ jobs:
           name: docker-sbom
           path: ./release-assets
 
+      # Cosign sign-blob both SBOMs and attach the .sig/.pem files to
+      # the GitHub Release. Closes Scorecard Signed-Releases — auditors
+      # (and `cosign verify-blob`) can verify the SBOMs are the bytes we
+      # shipped, not a mutated copy attacker-served from the release page.
+      # Uses the same keyless OIDC flow as the Docker image signing in
+      # publish-docker (no long-lived signing key).
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
+
+      - name: Sign SBOMs with cosign (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cd release-assets
+          for sbom in *.spdx.json; do
+            echo "Signing ${sbom}..."
+            cosign sign-blob --yes "$sbom" \
+              --output-signature "${sbom}.sig" \
+              --output-certificate "${sbom}.pem"
+          done
+          ls -la
+
       # Pre-release detection: any tag NOT matching strict vX.Y.Z (e.g.
       # vX.Y.Z-rc.N) is published as a GitHub pre-release so it doesn't
       # appear on the "latest release" sort + so users browsing the
@@ -239,11 +261,24 @@ jobs:
           make_latest: ${{ steps.release-type.outputs.prerelease == 'false' && 'true' || 'false' }}
           files: |
             ./release-assets/iris-npm-sbom.spdx.json
+            ./release-assets/iris-npm-sbom.spdx.json.sig
+            ./release-assets/iris-npm-sbom.spdx.json.pem
             ./release-assets/iris-docker-sbom.spdx.json
+            ./release-assets/iris-docker-sbom.spdx.json.sig
+            ./release-assets/iris-docker-sbom.spdx.json.pem
           body: |
             ## Supply-chain transparency
 
             - **SBOMs**: `iris-npm-sbom.spdx.json` + `iris-docker-sbom.spdx.json` (attached below). Both are SPDX 2.3 JSON, cover direct + transitive dependencies.
+            - **SBOM signatures**: each SBOM has a companion `.sig` (cosign signature) and `.pem` (Sigstore-issued cert) attached to this release. Verify with:
+              ```
+              cosign verify-blob \
+                --certificate iris-npm-sbom.spdx.json.pem \
+                --signature iris-npm-sbom.spdx.json.sig \
+                --certificate-identity-regexp='https://github.com/${{ github.repository }}' \
+                --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+                iris-npm-sbom.spdx.json
+              ```
             - **npm provenance**: published with `--provenance` (verifiable via `npm audit signatures` or on the package page).
             - **Docker signature**: image signed with cosign keyless (Sigstore). Verify with:
               ```

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,11 @@ on:
   push:
     branches: [main]
 
-permissions: read-all
+# Top-level least-privilege; analysis job upgrades to the writes it
+# needs. Explicit replaces the previous `read-all` (Scorecard's own
+# Token-Permissions check prefers explicit minimal over read-all).
+permissions:
+  contents: read
 
 jobs:
   analysis:
@@ -30,6 +34,14 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # Required for Scorecard's Branch-Protection check. The default
+          # GITHUB_TOKEN cannot read classic branch protection rules; without
+          # a PAT the check returns -1 (internal error). SCORECARD_PAT is a
+          # fine-grained PAT with Public Repositories > Administration: Read,
+          # scoped only to this repo. If the secret is unset the action falls
+          # back to GITHUB_TOKEN and the check stays at -1 (other checks
+          # unaffected — fail-open).
+          repo_token: ${{ secrets.SCORECARD_PAT }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:


### PR DESCRIPTION
## Goal
Lift iris's OpenSSF Scorecard score from **5.8 → ~7.4** via four score-affecting fixes bundled in one PR.

## Why bundle
All four touch overlapping workflow files (`ci.yml`, `codeql.yml`, `lighthouse.yml`, `devto-crosspost.yml`, `scorecard.yml`, `release.yml`). Splitting would cascade rebase conflicts and require ≥4 browser bypass-merges. One PR = one merge.

## Changes

### Token-Permissions (0 → 10) — closes 6 SARIF alerts
Top-level `permissions: { contents: read }` added to:
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/lighthouse.yml`
- `.github/workflows/devto-crosspost.yml`

`scorecard.yml` had `permissions: read-all` — replaced with the explicit minimal. Jobs that need more permissions (security-exposure, codeql analyze, scorecard analysis) already declare them at the job level; `release.yml`'s top-level write set is unchanged because every job in that workflow needs it.

### Signed-Releases (0 → 10)
Added a `cosign sign-blob` step to the `github-release` job that signs both SBOMs (npm + Docker) using the same keyless OIDC flow as the Docker image signing. Outputs `.sig` (signature) + `.pem` (Sigstore cert) per SBOM, attached to the GitHub Release. Auditors can verify with:
\`\`\`
cosign verify-blob \
  --certificate iris-npm-sbom.spdx.json.pem \
  --signature iris-npm-sbom.spdx.json.sig \
  --certificate-identity-regexp='https://github.com/iris-eval/mcp-server' \
  --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
  iris-npm-sbom.spdx.json
\`\`\`

First fires on the next tagged release; recommend cutting \`v0.4.3-rc.0\` to verify before \`v0.4.3\`.

### Branch-Protection (-1 → ~7-10)
Added \`repo_token: \${{ secrets.SCORECARD_PAT }}\` to the scorecard-action step. Default \`GITHUB_TOKEN\` can't read classic branch protection rules; Scorecard returns -1 internal error.

**Founder out-of-band action (one-time):**
1. Generate fine-grained PAT at https://github.com/settings/tokens with only \`Public Repositories > Administration: Read\` scope on this repo. Expiry ≤6 months.
2. Add as secret \`SCORECARD_PAT\` at https://github.com/iris-eval/mcp-server/settings/secrets/actions

If the secret is unset, Scorecard falls back to \`GITHUB_TOKEN\` and the check stays at -1 — fail-open, no other checks affected.

### Pinned-Dependencies (6 → 8)
\`lighthouse.yml:54\`: \`@lhci/cli@^0.15\` → \`@lhci/cli@0.15.0\` (exact version). Remaining unpinned items are intentional rolldown-lockfile-trap workarounds, already documented.

## Verification

- All CI checks green on this PR before merge
- After merge: Scorecard workflow re-runs on \`push to main\`; new score visible at https://api.securityscorecards.dev/projects/github.com/iris-eval/mcp-server/badge within ~3 min
- 6 \`TokenPermissionsID\` SARIF alerts should auto-close on the next Scorecard run
- For Signed-Releases: cut \`v0.4.3-rc.0\` pre-release; verify 4 new files (\`.sig\` + \`.pem\` × 2 SBOMs) appear as release assets

## Risk + rollback

Top-level \`contents: read\` is conservatively safe — every job that needs more permissions already declares them. If something breaks, \`gh pr revert\` opens a revert PR. Signed-Releases doesn't fire until tag push, so this merge can't break the release pipeline retroactively.

## Score trajectory
- Today: 5.8
- After this PR: ~7.4
- After Phase C (OpenSSF Best Practices): ~8.0
- After Phase D (~Day 91, Maintained auto-flip): ~8.6 (the structural ceiling for solo-founder MCP)