### PR TITLE
chore(release): v0.4.3-rc.0 — validate Signed-Releases workflow

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-05-07T01:30:53.512Z",
-  "generatedFromCommit": "1e5859a",
+  "generatedAt": "2026-05-16T02:01:14.983Z",
+  "generatedFromCommit": "6e9828f",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -136,7 +136,7 @@
     "dashboardPackage": "0.1.0",
     "initPackage": "0.1.0",
     "langchainPackage": "0.1.0",
-    "mcpServer": "0.4.2",
+    "mcpServer": "0.4.3-rc.0",
     "websitePackage": "0.1.0"
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris",
-  "version": "0.4.2",
+  "version": "0.4.3-rc.0",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "author": {
     "name": "Iris",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
+(Unreleased content rolls forward to the next non-RC release.)
+
+## [0.4.3-rc.0] - 2026-05-16
+
+Release-candidate to validate the **Signed-Releases** workflow shipped in PR #158 — verifies that `cosign sign-blob` produces `.sig` (signature) and `.pem` (Sigstore-issued cert) files for both SBOMs (npm + Docker) and that they attach to the GitHub Release page alongside the SBOMs themselves. After verifying, v0.4.3 (production) ships the same artifacts on `latest`.
+
+Published as npm dist-tag `next` (NOT `latest`); Docker tag `v0.4.3-rc.0` only (NOT `:latest`). `npm install @iris-eval/mcp-server` continues to resolve 0.4.2 until the production v0.4.3 ships.
+
+### Security posture (rolled forward from Unreleased)
 
 - **Per-advisory threat-model record (`SECURITY-EXPOSURE.md`).** New repo-root file documents the load-graph reachability, code-path reachability, untrusted-input reachability, and downstream-guard analysis for every open Dependabot advisory. Each entry carries an explicit decision: override (force a fixed transitive via `package.json` `overrides`), dismiss-as-not-used (vulnerable code not loaded into iris's process), dismiss-as-tolerable-risk (code loaded but vulnerable function never called), track (waiting on upstream), or patch (iris-side mitigation required). Closes the substance/signal gap where the GitHub Security tab counts advisories without distinguishing reachable from dead-code alerts. Linked from `SECURITY.md`.
 - **`fast-uri ^3.1.2` override.** `package.json` `overrides` field forces the patched fast-uri across the dependency tree, covering [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion via percent-encoded authority delimiters, HIGH) and [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal via percent-encoded dot segments, HIGH). Reachability analysis indicated iris's citation-verify SSRF guards (scheme allowlist, private-IP block, DNS pre-resolve) do not depend on fast-uri's correctness, but defense-in-depth against the URI-validation bypass is cheap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.2",
+  "version": "0.4.3-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iris-eval/mcp-server",
-      "version": "0.4.2",
+      "version": "0.4.3-rc.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.2",
+  "version": "0.4.3-rc.0",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "mcpName": "io.github.iris-eval/mcp-server",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/iris-eval/mcp-server",
     "source": "github"
   },
-  "version": "0.4.2",
+  "version": "0.4.3-rc.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@iris-eval/mcp-server",
-      "version": "0.4.2",
+      "version": "0.4.3-rc.0",
       "transport": {
         "type": "stdio"
       },

--- a/website/public/.well-known/mcp.json
+++ b/website/public/.well-known/mcp.json
@@ -4,7 +4,7 @@
   "homepage": "https://iris-eval.com",
   "repository": "https://github.com/iris-eval/mcp-server",
   "npm": "@iris-eval/mcp-server",
-  "version": "0.4.2",
+  "version": "0.4.3-rc.0",
   "license": "MIT",
   "transport": [
     "stdio",


### PR DESCRIPTION
## Why

Pre-release to validate the **Signed-Releases** workflow shipped in PR #158 — verifies that `cosign sign-blob` produces `.sig` + `.pem` files for both SBOMs and attaches them to the GitHub Release page. After verification, v0.4.3 (production) ships the same artifacts on `@latest`.

## What happens when this merges + tag is pushed

`release.yml` fires on tag `v0.4.3-rc.0`:
1. `validate` — typecheck + test + build
2. `publish-npm` — npm publish with dist-tag `next` (NOT `latest`); SBOM generated; attest-build-provenance
3. `publish-docker` — push to GHCR with tag `v0.4.3-rc.0` only (NOT `:latest`); cosign sign; SBOM
4. `github-release` — **cosign sign-blob both SBOMs** → `.sig` + `.pem` for each; attach all 6 files to a GitHub pre-release

`@latest` and `:latest` stay on 0.4.2 — no production impact. `npm install @iris-eval/mcp-server` continues to resolve 0.4.2.

## Verification (post-merge + tag push)

- GitHub Release at `https://github.com/iris-eval/mcp-server/releases/tag/v0.4.3-rc.0` shows **6 assets**: 2 SBOMs + 2 `.sig` + 2 `.pem`
- `cosign verify-blob` succeeds for each SBOM (commands in release body)
- Scorecard re-run shows **Signed-Releases 0 → 10**, aggregate **6.6 → ~7.2**

## Risk + rollback

- Pre-release dist-tag isolation: even if npm/Docker publish succeeds, `@latest` users are unaffected. If something breaks, deprecate the rc with `npm deprecate @iris-eval/mcp-server@0.4.3-rc.0 "failed verification"` and rebuild.
- Standard iris release flow per `docs/launch/release-checklist.md`.

## Founder action after merge

Tag the merge commit:

```bash
git fetch origin main
git tag v0.4.3-rc.0 origin/main
git push origin v0.4.3-rc.0
```

Or I can handle the tagging step from this session.