### PR TITLE
docs(readme): add OpenSSF Best Practices Passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/iris-eval/mcp-server?style=social)](https://github.com/iris-eval/mcp-server)
 [![CI](https://github.com/iris-eval/mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/iris-eval/mcp-server/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/iris-eval/mcp-server/badge)](https://securityscorecards.dev/viewer/?uri=github.com/iris-eval/mcp-server)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12849/badge)](https://www.bestpractices.dev/projects/12849)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docker](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/iris-eval/mcp-server/pkgs/container/mcp-server)
 [![PulseMCP](https://img.shields.io/badge/PulseMCP-Listed-blue?style=flat-square)](https://www.pulsemcp.com/servers/iris-eval)


### PR DESCRIPTION
## Why

Iris was awarded the **OpenSSF Best Practices Passing badge** on 2026-05-16:
- Project page: https://www.bestpractices.dev/projects/12849
- Badge level: `passing` (verified via `curl https://www.bestpractices.dev/projects/12849.json | jq .badge_level` → `"passing"`)
- Tiered percentage: **115%** — exceeds Passing-tier minimums, partway to Silver
- All 67 Passing-tier criteria Met with file-path-cited justifications

## What this PR does

Adds the badge to README alongside the Scorecard badge so the project page surfaces both posture signals.

## Score impact

Next Scorecard re-run picks up `CII-Best-Practices: 0 → 10` → aggregate **6.8 → ~7.4**. Combined with Phase D (Maintained auto-flip at Day 91, ~2026-06-13), reaches **~8.0** in the YC decision window.

## Verification

- Badge SVG returns 200 with content-type image/svg+xml
- Public JSON at https://www.bestpractices.dev/projects/12849.json confirms badge_level=passing
- README badge renders inline (visible after merge)