### PR TITLE
fix(release): stop swallowing npm publish failures + add workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dispatch lets us re-run a release for an existing tag after
+  # recovering from a failed earlier run (e.g., rotated credentials).
+  # Trigger with: `gh workflow run release.yml --ref vX.Y.Z`. The dispatched
+  # workflow's github.ref/ref_name resolve to the tag, so the rest of the
+  # workflow logic (npm-tag, Docker tags, SBOM names, prerelease detection)
+  # works identically to the push-trigger path.
+  workflow_dispatch: {}
 
 # OIDC migration (audit item #9): `id-token: write` grants the workflow a
 # GitHub-signed identity token. npm uses it to attest provenance on publish
@@ -94,9 +101,30 @@ jobs:
             echo "Publishing as 'next' (pre-release: ${GITHUB_REF_NAME})"
           fi
 
-      - run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }} || echo "Version already published, skipping"
+      # Idempotent re-runs (e.g., workflow_dispatch on a tag whose earlier run
+      # failed) must succeed on EPUBLISHCONFLICT (version already exists) but
+      # must FAIL LOUDLY on auth errors, network errors, or anything else.
+      # The previous `npm publish ... || echo "skipping"` swallowed an
+      # NPM_TOKEN auth 404 silently, producing a "successful" workflow run
+      # that did not publish v0.4.3 — see PR #176 incident notes.
+      - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -o pipefail
+          publish_log=$(mktemp)
+          if npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }} 2>&1 | tee "$publish_log"; then
+            echo "✓ npm publish succeeded"
+          else
+            exit_code=$?
+            if grep -qE "EPUBLISHCONFLICT|cannot publish over the previously published" "$publish_log"; then
+              echo "✓ Version already published on npm — idempotent re-run, continuing"
+            else
+              echo "✗ npm publish failed with non-conflict error (exit ${exit_code})"
+              echo "  Common causes: NPM_TOKEN expired/revoked, token lacks @iris-eval scope publish, registry-side outage."
+              exit "${exit_code}"
+            fi
+          fi
 
       # Attestation (SLSA provenance): separate from `npm publish
       # --provenance` attestation — this one covers the checked-out source


### PR DESCRIPTION
## Summary

Incident response to the v0.4.3 release: workflow's `npm publish ... || echo "Version already published, skipping"` swallowed an NPM_TOKEN auth-404, producing a green workflow run that did not publish v0.4.3 to npm. GitHub Release + Docker shipped; npm \`@latest\` stayed on 0.4.2.

## Two fixes

**1. Strict publish error handling.** EPUBLISHCONFLICT / "cannot publish over the previously published" remain idempotent (so re-runs of a tag whose previous publish succeeded don't fail). Everything else — auth 404, network errors, scope-mismatch — now exits non-zero and fails the workflow loudly.

**2. \`workflow_dispatch\` trigger.** Re-run a release for an existing tag with \`gh workflow run release.yml --ref vX.Y.Z\` — no delete+retag dance. The dispatched workflow's \`github.ref\` / \`ref_name\` resolve to the tag, so all downstream logic (npm-tag picker, Docker tag list, SBOM artifact naming, prerelease detection) behaves identically to the push-trigger path.

## Recovery plan after this merges

1. Founder rotates NPM_TOKEN at npmjs.com (granular, 90d, scope @iris-eval/mcp-server, read+write)
2. \`gh secret set NPM_TOKEN -R iris-eval/mcp-server\`
3. \`gh workflow run release.yml -R iris-eval/mcp-server --ref v0.4.3\`
4. Verify: \`npm view @iris-eval/mcp-server@0.4.3 version\` returns 0.4.3 and \`dist-tags.latest\` is 0.4.3

Then unblocks: GHSA filing, blog #030 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)