### PR TITLE
chore(security): SHA-pin actions in claims-alignment.yml

### DIFF
--- a/.github/workflows/claims-alignment.yml
+++ b/.github/workflows/claims-alignment.yml
@@ -14,8 +14,8 @@ jobs:
     name: Hardcoded-claim scanner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '24'
       - name: Run hardcoded-claim scanner
@@ -25,8 +25,8 @@ jobs:
     name: Truthbase regen vs committed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '24'
       - name: Install root deps


### PR DESCRIPTION
Pins `actions/checkout` and `actions/setup-node` in `claims-alignment.yml` to full commit SHAs (the same pins every other workflow already uses: checkout v6.0.2, setup-node v6.4.0).

This workflow was added after the repo-wide SHA-pinning pass and came in with tag refs. With this merged, the repository-level **require SHA pinning** Actions setting can be enabled so unpinned refs can never regress in.

- Closes 4 of the Scorecard `Pinned-Dependencies` findings
- Dependabot continues tracking these pins via the `github-actions` ecosystem (SHA + version comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)