### PR TITLE
chore(release): v0.4.4 — recovery release completing v0.4.3 npm distribution

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-05-21T21:26:44.766Z",
-  "generatedFromCommit": "4281223",
+  "generatedAt": "2026-06-12T21:52:23.505Z",
+  "generatedFromCommit": "90c1371",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -102,8 +102,8 @@
     ]
   },
   "release": {
-    "currentReleaseDate": "2026-05-21",
-    "currentReleaseVersion": "0.4.3",
+    "currentReleaseDate": "2026-06-12",
+    "currentReleaseVersion": "0.4.4",
     "nextPlannedScope": "Cloud SKU foundation",
     "nextPlannedVersion": "0.5.0"
   },
@@ -136,7 +136,7 @@
     "dashboardPackage": "0.1.0",
     "initPackage": "0.1.0",
     "langchainPackage": "0.1.0",
-    "mcpServer": "0.4.3",
+    "mcpServer": "0.4.4",
     "websitePackage": "0.1.0"
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "author": {
     "name": "Iris",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Unreleased content rolls forward to the next non-RC release.)
 
+## [0.4.4] - 2026-06-12
+
+Recovery release completing v0.4.3's distribution. v0.4.3 published to Docker (GHCR) and the GitHub Release, but its **npm publish silently failed** — the `NPM_TOKEN` secret had expired, npm returned `E404` on the publish PUT, and the pre-#176 `npm publish ... || echo "skipping"` step swallowed the failure into a green run. npm `@latest` (and therefore the MCP Registry + downstream mirrors) stalled at 0.4.2, so the v0.4.3 LLM-judge prompt-injection hardening never reached npm installs. v0.4.4 carries all v0.4.3 runtime content forward and is the first complete distribution since 0.4.2. **No runtime code changes versus 0.4.3.**
+
+### Changed
+
+- **npm publishing migrated to Trusted Publishing (OIDC).** `release.yml` no longer uses a long-lived `NPM_TOKEN` secret — the publish job authenticates via the workflow's GitHub OIDC identity, configured as a trusted publisher on npmjs.com (`iris-eval/mcp-server` + `release.yml`). This eliminates the credential-expiry failure mode that broke the v0.4.3 npm publish. Requires npm ≥ 11.5.1, upgraded in-job (Node 22 ships npm 10.x). The fail-loud publish step from #176 is retained as defense-in-depth. PRs #194 + #195.
+
+### Security
+
+- **esbuild 0.28.0 → 0.28.1** ([GHSA-g7r4-m6w7-qqqr](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr), [GHSA-gv7w-rqvm-qjhr](https://github.com/advisories/GHSA-gv7w-rqvm-qjhr), HIGH). Transitive dev/build dependency (via `tsx` + `vite`/`vitest`) — not present in the shipped npm tarball or the Docker runtime, so no runtime exposure; both CVEs are dev-only (dev-server arbitrary file read on Windows; Deno-module integrity). Lockfile-only bump; both consumers already accept the patched range. PR #195.
+
 ## [0.4.3] - 2026-05-21
 
 Security + supply-chain release. Hardens LLM-as-Judge against the arxiv 2504.18333 prompt-injection class across all five eval templates, validates the Signed-Releases workflow (npm + Docker SBOMs now ship with `cosign sign-blob` `.sig` / `.pem` companions), per-advisory threat-model record, fast-uri override, and a `security-exposure` CI gate that fails any PR introducing an undocumented ≥medium advisory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iris-eval/mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "mcpName": "io.github.iris-eval/mcp-server",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/iris-eval/mcp-server",
     "source": "github"
   },
-  "version": "0.4.3",
+  "version": "0.4.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@iris-eval/mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "transport": {
         "type": "stdio"
       },

--- a/website/public/.well-known/mcp.json
+++ b/website/public/.well-known/mcp.json
@@ -4,7 +4,7 @@
   "homepage": "https://iris-eval.com",
   "repository": "https://github.com/iris-eval/mcp-server",
   "npm": "@iris-eval/mcp-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "MIT",
   "transport": [
     "stdio",


### PR DESCRIPTION
## What

Roll-forward **v0.4.4** release. v0.4.3 published to Docker (GHCR) + the GitHub Release, but its **npm publish silently failed** (expired `NPM_TOKEN` → `E404`, swallowed by the pre-#176 `|| echo skipping` step). npm `@latest` + the MCP Registry stalled at **0.4.2**, so the v0.4.3 LLM-judge prompt-injection hardening never reached npm installs.

v0.4.4 carries **all** v0.4.3 runtime content forward (**no runtime code changes vs 0.4.3**) and is the first complete distribution since 0.4.2, published over the new **OIDC Trusted Publishing** path — no `NPM_TOKEN`, nothing to expire.

The `v0.4.3` git tag is intentionally **not** re-pointed (Docker + GitHub already shipped 0.4.3 from the old commit; re-tagging would create mismatched artifacts). npm honestly goes 0.4.2 → 0.4.4.

## Changes

- Version bump 0.4.3 → 0.4.4 synced across `package.json`, `server.json`, `.well-known/mcp.json`, `.claude-plugin/plugin.json`, `package-lock.json`, `.claims.json` truthbase.
- `CHANGELOG.md` [0.4.4] entry.

(The OIDC `release.yml` migration + esbuild 0.28.1 bump already landed on main via #195.)

## After merge

Tag `v0.4.4` → release workflow publishes npm (Trusted Publishing) + Docker + GitHub Release + signs. Then MCP Registry publish + cascade. Verify npm `@latest` = 0.4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)