### PR TITLE
fix(release): cosign v4 sign-blob — use --bundle (SBOM signing was broken)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,25 +274,29 @@ jobs:
           name: docker-sbom
           path: ./release-assets
 
-      # Cosign sign-blob both SBOMs and attach the .sig/.pem files to
+      # Cosign sign-blob both SBOMs and attach a .cosign.bundle per SBOM to
       # the GitHub Release. Closes Scorecard Signed-Releases — auditors
       # (and `cosign verify-blob`) can verify the SBOMs are the bytes we
       # shipped, not a mutated copy attacker-served from the release page.
       # Uses the same keyless OIDC flow as the Docker image signing in
       # publish-docker (no long-lived signing key).
+      #
+      # cosign v3+ deprecated --output-signature/--output-certificate and
+      # ignores them under the default new bundle format (writing to an empty
+      # --bundle path → "create bundle file: open : no such file or directory",
+      # which silently broke SBOM signing from the v4.1.2 installer bump until
+      # v0.4.4 surfaced it). The single .cosign.bundle carries signature +
+      # cert + Rekor entry; verify with `cosign verify-blob --bundle`.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Sign SBOMs with cosign (keyless)
-        env:
-          COSIGN_EXPERIMENTAL: 1
         run: |
           cd release-assets
           for sbom in *.spdx.json; do
             echo "Signing ${sbom}..."
             cosign sign-blob --yes "$sbom" \
-              --output-signature "${sbom}.sig" \
-              --output-certificate "${sbom}.pem"
+              --bundle "${sbom}.cosign.bundle"
           done
           ls -la
 
@@ -316,20 +320,17 @@ jobs:
           make_latest: ${{ steps.release-type.outputs.prerelease == 'false' && 'true' || 'false' }}
           files: |
             ./release-assets/iris-npm-sbom.spdx.json
-            ./release-assets/iris-npm-sbom.spdx.json.sig
-            ./release-assets/iris-npm-sbom.spdx.json.pem
+            ./release-assets/iris-npm-sbom.spdx.json.cosign.bundle
             ./release-assets/iris-docker-sbom.spdx.json
-            ./release-assets/iris-docker-sbom.spdx.json.sig
-            ./release-assets/iris-docker-sbom.spdx.json.pem
+            ./release-assets/iris-docker-sbom.spdx.json.cosign.bundle
           body: |
             ## Supply-chain transparency
 
             - **SBOMs**: `iris-npm-sbom.spdx.json` + `iris-docker-sbom.spdx.json` (attached below). Both are SPDX 2.3 JSON, cover direct + transitive dependencies.
-            - **SBOM signatures**: each SBOM has a companion `.sig` (cosign signature) and `.pem` (Sigstore-issued cert) attached to this release. Verify with:
+            - **SBOM signatures**: each SBOM has a companion `.cosign.bundle` (Sigstore bundle — signature + cert + Rekor entry) attached to this release. Verify with:
               ```
               cosign verify-blob \
-                --certificate iris-npm-sbom.spdx.json.pem \
-                --signature iris-npm-sbom.spdx.json.sig \
+                --bundle iris-npm-sbom.spdx.json.cosign.bundle \
                 --certificate-identity-regexp='https://github.com/${{ github.repository }}' \
                 --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
                 iris-npm-sbom.spdx.json


### PR DESCRIPTION
## Why

The `cosign-installer` v4.1.2 bump (#169, drained Session 46) deprecated `--output-signature` / `--output-certificate`. Under cosign v3+'s default new-bundle-format these flags are **ignored**, and `sign-blob` then tries to write to an empty `--bundle` path:

```
Error: signing iris-docker-sbom.spdx.json: create bundle file: open : no such file or directory
```

This silently broke the **SBOM-signing step** in the `github-release` job. It surfaced on **v0.4.4** — the first release since the installer bump — whose release job failed at signing and therefore produced **no GitHub Release** until one was created manually (with unsigned SBOMs).

## What

- `cosign sign-blob --yes "$sbom" --bundle "${sbom}.cosign.bundle"` — the single Sigstore bundle carries signature + cert + Rekor entry.
- Attached-files list: `.sig`/`.pem` → `.cosign.bundle`.
- Release-body verify recipe: `cosign verify-blob --bundle <file> --certificate-identity-regexp ... --certificate-oidc-issuer ...`.
- Dropped the no-op `COSIGN_EXPERIMENTAL` env from this step (keyless is default since cosign v2).

Docker image signing (`publish-docker`, `cosign sign`) is a different subcommand, was unaffected, and is unchanged.

## Validation caveat

`release.yml` runs only on tag push, so this isn't exercised by PR CI. Verified against cosign v4 `sign-blob` semantics; takes effect on the next release tag. Restores Scorecard Signed-Releases for SBOMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)