### PR TITLE
fix(ci): lighthouse median-of-3 to kill the flake (#193)

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -12,7 +12,8 @@
         "http://localhost:6922/rules",
         "http://localhost:6922/audit"
       ],
-      "numberOfRuns": 1,
+      "$comment-runs": "median-of-3 — single-run Lighthouse on shared CI runners has high variance and false-failed ~50% near the perf floor (issue #193). LHCI asserts against the median of N runs, which moves us off the variance boundary without lowering the floor.",
+      "numberOfRuns": 3,
       "settings": {
         "$comment-preset": "desktop matches the audience: this is a devtool dashboard, not a public-consumer page",
         "preset": "desktop",


### PR DESCRIPTION
`numberOfRuns: 1` → `3`. Single-run Lighthouse on shared CI runners has high variance and false-failed ~50% near the perf floor (#193) on diffs that can't affect dashboard perf. LHCI asserts against the **median** of N runs, moving us off the variance boundary without lowering the floor. Job ~1m40s → ~4min; lighthouse isn't a required check so the extra time blocks nothing.

Closes #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)