### PR TITLE
fix(ci): nightly real-LLM smoke skips gracefully without OPENAI_API_KEY

### DIFF
--- a/.github/workflows/nightly-real-llm-smoke.yml
+++ b/.github/workflows/nightly-real-llm-smoke.yml
@@ -12,10 +12,13 @@ name: Nightly Real-LLM Smoke
 #     within 24h, not necessarily within 24 minutes
 #   - Pinning expensive jobs to cron + manual dispatch keeps PR cycle fast
 #
-# Failure handling: the workflow fails if the script exits non-zero. The
-# job runs `continue-on-error: false` so the schedule shows red and a
-# notification fires. Post-failure: founder triages — usually a provider
-# wire-shape change requiring a tracked code update.
+# Failure handling: when OPENAI_API_KEY is configured, the workflow fails if
+# the smoke script exits non-zero — a red schedule + notification, which the
+# founder triages (usually a provider wire-shape change needing a code update).
+# When the secret is ABSENT, the job skips the smoke and succeeds with a notice
+# rather than hard-failing every night on a missing credential (a perpetual
+# red that trains reviewers to ignore the check). Set the OPENAI_API_KEY repo
+# secret to enable real coverage.
 
 on:
   schedule:
@@ -38,17 +41,37 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # Gate the run on the credential. Secrets can't be referenced directly in
+      # step `if:` expressions, so map presence to an output here. Absent key →
+      # skip the smoke (neutral) instead of FATAL-aborting the script.
+      - name: Check for OPENAI_API_KEY
+        id: keycheck
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OPENAI_API_KEY repo secret not configured — skipping the real-LLM smoke. Set it to enable nightly provider wire-shape coverage."
+          fi
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        if: steps.keycheck.outputs.present == 'true'
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci
-      - run: npm run build
-      # Run the real-LLM smoke. Script reads OPENAI_API_KEY from env;
-      # set in repo secrets. Cost cap enforced inside the script + the
-      # llm-judge evaluator's pessimistic pre-check (< $0.05 total).
+      - if: steps.keycheck.outputs.present == 'true'
+        run: npm ci
+      - if: steps.keycheck.outputs.present == 'true'
+        run: npm run build
+      # Run the real-LLM smoke. Script reads OPENAI_API_KEY from env.
+      # Cost cap enforced inside the script + the llm-judge evaluator's
+      # pessimistic pre-check (< $0.05 total).
       - name: Run track160 real-LLM smoke
+        if: steps.keycheck.outputs.present == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: node scripts/track160-real-llm-judge-smoke.mjs


### PR DESCRIPTION
The `OPENAI_API_KEY` repo secret was never set, so the scheduled **Nightly Real-LLM Smoke** has hard-failed every night since it was added (the script FATAL-aborts on the empty key) — a perpetual red that trains reviewers to ignore the check (same anti-pattern the lighthouse fix #200 addressed).

Now a keycheck step gates the run: **absent key → skip + `::notice::` + job goes green**; present key → full smoke as before. Founder can set the `OPENAI_API_KEY` repo secret to enable real provider wire-shape coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)