### PR TITLE
feat(init): universal installer covers all nine clients (zero-tooling setup)

### DIFF
--- a/packages/init/src/cli.ts
+++ b/packages/init/src/cli.ts
@@ -9,11 +9,12 @@
  *   npx @iris-eval/init --list                # show detected clients
  *   npx @iris-eval/init --help                # this message
  *
- * Supported <client> values: claude-code, cursor, windsurf, continue.
+ * Supported <client> values: claude-code, claude-desktop, cursor, windsurf,
+ * continue, vscode, cline, zed, codex, gemini.
  *
- * Phase 1 (this release) handles the four first-class clients per
- * grow-plug-and-play.md §5. Phase 2 adds raycast, zed, cline, plus
- * MCP-spec-driven auto-detection for unrecognized clients.
+ * Phase 2 (this release) covers all nine first-class clients from the README
+ * client matrix. Phase 3 adds MCP-spec-driven auto-detection for
+ * unrecognized clients.
  */
 import { parseArgs } from 'node:util';
 import {
@@ -24,7 +25,18 @@ import {
 } from './detect.js';
 import { installIris, uninstallIris } from './config-writer.js';
 
-const SUPPORTED: SupportedClient[] = ['claude-code', 'cursor', 'windsurf', 'continue'];
+const SUPPORTED: SupportedClient[] = [
+  'claude-code',
+  'claude-desktop',
+  'cursor',
+  'windsurf',
+  'continue',
+  'vscode',
+  'cline',
+  'zed',
+  'codex',
+  'gemini',
+];
 
 function printHelp(): void {
   process.stdout.write(`iris-init — universal installer for Iris

--- a/packages/init/src/config-writer.ts
+++ b/packages/init/src/config-writer.ts
@@ -1,15 +1,24 @@
 /*
  * Config writer — adds the Iris MCP server entry to a client's config.
  *
- * Two strategies depending on configMode:
+ * Strategies (see ClientProfile.configMode):
  *   - dedicated-mcp-json: file is { mcpServers: {...} }. Create if missing;
  *     merge if exists. Iris becomes one entry alongside whatever the user
  *     already had.
  *   - embedded-in-config-json: file is a larger config (Continue) with many
  *     top-level fields. Add or update mcpServers without disturbing other
  *     fields.
+ *   - vscode-servers: file is { servers: {...} } (VS Code's native MCP
+ *     schema — "servers", not "mcpServers").
+ *   - zed-context-servers: Zed settings.json — MCP lives under
+ *     "context_servers" with a nested { command: { path, args } } object.
+ *     Zed settings allow comments; if the file fails strict JSON parsing we
+ *     refuse with instructions rather than risk corrupting user settings.
+ *   - codex-toml: ~/.codex/config.toml — appends an [mcp_servers.iris]
+ *     section. No TOML dependency: presence is detected by section header,
+ *     removal deletes the exact section we write.
  *
- * Both strategies are idempotent. Re-running with the same value is a no-op.
+ * All strategies are idempotent. Re-running with the same value is a no-op.
  * Re-running with --uninstall removes only the iris entry; other servers stay.
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -26,8 +35,24 @@ const IRIS_ENTRY: IrisServerEntry = {
   args: ['-y', '@iris-eval/mcp-server'],
 };
 
+/** Zed nests the executable under a command object. */
+const IRIS_ZED_ENTRY = {
+  command: {
+    path: IRIS_ENTRY.command,
+    args: IRIS_ENTRY.args,
+  },
+};
+
+const CODEX_SECTION_HEADER = '[mcp_servers.iris]';
+const CODEX_SECTION = `${CODEX_SECTION_HEADER}
+command = "${IRIS_ENTRY.command}"
+args = [${IRIS_ENTRY.args.map((a) => `"${a}"`).join(', ')}]
+`;
+
 interface ConfigShape {
   mcpServers?: Record<string, IrisServerEntry>;
+  servers?: Record<string, IrisServerEntry>;
+  context_servers?: Record<string, typeof IRIS_ZED_ENTRY>;
   [key: string]: unknown;
 }
 
@@ -55,56 +80,180 @@ export interface InstallResult {
   action: 'created' | 'updated' | 'no-change';
 }
 
-export function installIris(profile: ClientProfile): InstallResult {
-  const existing = readConfig(profile.configPath);
-  const mcpServers = existing.mcpServers ?? {};
-  const wasPresent = Boolean(mcpServers.iris);
-
-  // Idempotency check: if iris is already present with the exact same
-  // command + args, nothing to do.
-  if (wasPresent) {
-    const current = mcpServers.iris;
-    if (
-      current.command === IRIS_ENTRY.command &&
-      JSON.stringify(current.args) === JSON.stringify(IRIS_ENTRY.args)
-    ) {
-      return { configPath: profile.configPath, action: 'no-change' };
-    }
-  }
-
-  const next: ConfigShape = {
-    ...existing,
-    mcpServers: { ...mcpServers, iris: IRIS_ENTRY },
-  };
-
-  writeConfig(profile.configPath, next);
-  return {
-    configPath: profile.configPath,
-    action: existsSync(profile.configPath) && wasPresent ? 'updated' : 'created',
-  };
-}
-
 export interface UninstallResult {
   configPath: string;
   action: 'removed' | 'not-present';
 }
 
-export function uninstallIris(profile: ClientProfile): UninstallResult {
+function sameEntry(a: IrisServerEntry | undefined, b: IrisServerEntry): boolean {
+  return (
+    Boolean(a) &&
+    a!.command === b.command &&
+    JSON.stringify(a!.args) === JSON.stringify(b.args)
+  );
+}
+
+/* ---------------- JSON-map strategies (mcpServers / servers) ---------------- */
+
+function installJsonMap(
+  profile: ClientProfile,
+  key: 'mcpServers' | 'servers',
+): InstallResult {
+  const existing = readConfig(profile.configPath);
+  const map = (existing[key] as Record<string, IrisServerEntry> | undefined) ?? {};
+  const wasPresent = Boolean(map.iris);
+
+  if (wasPresent && sameEntry(map.iris, IRIS_ENTRY)) {
+    return { configPath: profile.configPath, action: 'no-change' };
+  }
+
+  const next: ConfigShape = { ...existing, [key]: { ...map, iris: IRIS_ENTRY } };
+  writeConfig(profile.configPath, next);
+  return {
+    configPath: profile.configPath,
+    action: wasPresent ? 'updated' : 'created',
+  };
+}
+
+function uninstallJsonMap(
+  profile: ClientProfile,
+  key: 'mcpServers' | 'servers',
+): UninstallResult {
   if (!existsSync(profile.configPath)) {
     return { configPath: profile.configPath, action: 'not-present' };
   }
-
   const existing = readConfig(profile.configPath);
-  const mcpServers = existing.mcpServers ?? {};
-
-  if (!mcpServers.iris) {
+  const map = (existing[key] as Record<string, IrisServerEntry> | undefined) ?? {};
+  if (!map.iris) {
     return { configPath: profile.configPath, action: 'not-present' };
   }
-
-  const { iris: _removed, ...rest } = mcpServers;
+  const { iris: _removed, ...rest } = map;
   void _removed;
-  const next: ConfigShape = { ...existing, mcpServers: rest };
-  writeConfig(profile.configPath, next);
-
+  writeConfig(profile.configPath, { ...existing, [key]: rest });
   return { configPath: profile.configPath, action: 'removed' };
+}
+
+/* ---------------- Zed strategy (context_servers, nested command) ---------------- */
+
+function installZed(profile: ClientProfile): InstallResult {
+  let existing: ConfigShape;
+  try {
+    existing = readConfig(profile.configPath);
+  } catch (err) {
+    // Zed settings.json allows comments; strict JSON.parse fails on them.
+    throw new Error(
+      `${(err as Error).message}\nZed settings may contain comments, which this ` +
+        `installer does not rewrite. Add this to ${profile.configPath} manually:\n` +
+        `"context_servers": { "iris": ${JSON.stringify(IRIS_ZED_ENTRY)} }`,
+    );
+  }
+  const map = existing.context_servers ?? {};
+  const current = map.iris;
+  if (
+    current &&
+    current.command?.path === IRIS_ZED_ENTRY.command.path &&
+    JSON.stringify(current.command?.args) === JSON.stringify(IRIS_ZED_ENTRY.command.args)
+  ) {
+    return { configPath: profile.configPath, action: 'no-change' };
+  }
+  const wasPresent = Boolean(current);
+  writeConfig(profile.configPath, {
+    ...existing,
+    context_servers: { ...map, iris: IRIS_ZED_ENTRY },
+  });
+  return {
+    configPath: profile.configPath,
+    action: wasPresent ? 'updated' : 'created',
+  };
+}
+
+function uninstallZed(profile: ClientProfile): UninstallResult {
+  if (!existsSync(profile.configPath)) {
+    return { configPath: profile.configPath, action: 'not-present' };
+  }
+  const existing = readConfig(profile.configPath);
+  const map = existing.context_servers ?? {};
+  if (!map.iris) {
+    return { configPath: profile.configPath, action: 'not-present' };
+  }
+  const { iris: _removed, ...rest } = map;
+  void _removed;
+  writeConfig(profile.configPath, { ...existing, context_servers: rest });
+  return { configPath: profile.configPath, action: 'removed' };
+}
+
+/* ---------------- Codex strategy (TOML section append/remove) ---------------- */
+
+function installCodex(profile: ClientProfile): InstallResult {
+  const exists = existsSync(profile.configPath);
+  const raw = exists ? readFileSync(profile.configPath, 'utf-8') : '';
+
+  if (raw.includes(CODEX_SECTION_HEADER)) {
+    // Section present. If it matches exactly what we write, no-op; otherwise
+    // leave the user's customized section alone (do not clobber).
+    if (raw.includes(CODEX_SECTION.trim())) {
+      return { configPath: profile.configPath, action: 'no-change' };
+    }
+    return { configPath: profile.configPath, action: 'no-change' };
+  }
+
+  const next =
+    raw.length === 0 || raw.endsWith('\n\n')
+      ? raw + CODEX_SECTION
+      : raw.endsWith('\n')
+        ? raw + '\n' + CODEX_SECTION
+        : raw + '\n\n' + CODEX_SECTION;
+
+  mkdirSync(dirname(profile.configPath), { recursive: true });
+  writeFileSync(profile.configPath, next, 'utf-8');
+  return { configPath: profile.configPath, action: exists ? 'updated' : 'created' };
+}
+
+function uninstallCodex(profile: ClientProfile): UninstallResult {
+  if (!existsSync(profile.configPath)) {
+    return { configPath: profile.configPath, action: 'not-present' };
+  }
+  const raw = readFileSync(profile.configPath, 'utf-8');
+  if (!raw.includes(CODEX_SECTION_HEADER)) {
+    return { configPath: profile.configPath, action: 'not-present' };
+  }
+  // Remove from our section header up to (not including) the next section
+  // header or end-of-file. Only removes the iris section.
+  const start = raw.indexOf(CODEX_SECTION_HEADER);
+  const afterHeader = start + CODEX_SECTION_HEADER.length;
+  const nextSection = raw.indexOf('\n[', afterHeader);
+  const end = nextSection === -1 ? raw.length : nextSection + 1;
+  const next = (raw.slice(0, start) + raw.slice(end)).replace(/\n{3,}/g, '\n\n');
+  writeFileSync(profile.configPath, next, 'utf-8');
+  return { configPath: profile.configPath, action: 'removed' };
+}
+
+/* ---------------- Dispatch ---------------- */
+
+export function installIris(profile: ClientProfile): InstallResult {
+  switch (profile.configMode) {
+    case 'dedicated-mcp-json':
+    case 'embedded-in-config-json':
+      return installJsonMap(profile, 'mcpServers');
+    case 'vscode-servers':
+      return installJsonMap(profile, 'servers');
+    case 'zed-context-servers':
+      return installZed(profile);
+    case 'codex-toml':
+      return installCodex(profile);
+  }
+}
+
+export function uninstallIris(profile: ClientProfile): UninstallResult {
+  switch (profile.configMode) {
+    case 'dedicated-mcp-json':
+    case 'embedded-in-config-json':
+      return uninstallJsonMap(profile, 'mcpServers');
+    case 'vscode-servers':
+      return uninstallJsonMap(profile, 'servers');
+    case 'zed-context-servers':
+      return uninstallZed(profile);
+    case 'codex-toml':
+      return uninstallCodex(profile);
+  }
 }

--- a/packages/init/src/detect.ts
+++ b/packages/init/src/detect.ts
@@ -10,22 +10,53 @@ import { existsSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 
-export type SupportedClient = 'claude-code' | 'cursor' | 'windsurf' | 'continue';
+export type SupportedClient =
+  | 'claude-code'
+  | 'claude-desktop'
+  | 'cursor'
+  | 'windsurf'
+  | 'continue'
+  | 'vscode'
+  | 'cline'
+  | 'zed'
+  | 'codex'
+  | 'gemini';
 
 export interface ClientProfile {
   id: SupportedClient;
   displayName: string;
   configPath: string;
   /**
-   * Some clients use a top-level mcpServers field on a shared config.json
-   * (Continue); others have a dedicated mcp.json. This flag tells the
-   * config writer which strategy to use.
+   * Config strategies:
+   *   - dedicated-mcp-json: file is { mcpServers: {...} }. Create if missing;
+   *     merge if exists. (Claude Code, Claude Desktop, Cursor, Windsurf,
+   *     Cline, Gemini CLI)
+   *   - embedded-in-config-json: file is a larger config with many top-level
+   *     fields; add/update mcpServers without disturbing others. (Continue)
+   *   - vscode-servers: file is { servers: {...} } — VS Code's native MCP
+   *     schema uses "servers", not "mcpServers".
+   *   - zed-context-servers: Zed settings.json embeds MCP under
+   *     "context_servers" with a nested command object.
+   *   - codex-toml: ~/.codex/config.toml [mcp_servers.<name>] section.
    */
-  configMode: 'dedicated-mcp-json' | 'embedded-in-config-json';
+  configMode:
+    | 'dedicated-mcp-json'
+    | 'embedded-in-config-json'
+    | 'vscode-servers'
+    | 'zed-context-servers'
+    | 'codex-toml';
 }
 
 const isWindows = platform() === 'win32';
+const isMac = platform() === 'darwin';
 const home = homedir();
+
+/** Platform-appropriate app-data root used by Electron-family apps. */
+function appDataDir(): string {
+  if (isWindows) return process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
+  if (isMac) return join(home, 'Library', 'Application Support');
+  return process.env.XDG_CONFIG_HOME ?? join(home, '.config');
+}
 
 /**
  * Resolve the canonical config path per client per platform.
@@ -37,15 +68,37 @@ export function configPathFor(client: SupportedClient): string {
     case 'claude-code':
       // ~/.claude/mcp.json on mac/linux; %USERPROFILE%\.claude\mcp.json on Windows
       return join(home, '.claude', 'mcp.json');
+    case 'claude-desktop':
+      return join(appDataDir(), 'Claude', 'claude_desktop_config.json');
     case 'cursor':
       return join(home, '.cursor', 'mcp.json');
     case 'windsurf':
       // Codeium-managed dir; mcp_config.json (note: NOT mcp.json — Windsurf-specific)
-      return isWindows
-        ? join(home, '.codeium', 'windsurf', 'mcp_config.json')
-        : join(home, '.codeium', 'windsurf', 'mcp_config.json');
+      return join(home, '.codeium', 'windsurf', 'mcp_config.json');
     case 'continue':
       return join(home, '.continue', 'config.json');
+    case 'vscode':
+      // User-level MCP config (VS Code native MCP support); "servers" schema.
+      return join(appDataDir(), 'Code', 'User', 'mcp.json');
+    case 'cline':
+      // VS Code extension global storage.
+      return join(
+        appDataDir(),
+        'Code',
+        'User',
+        'globalStorage',
+        'saoudrizwan.claude-dev',
+        'settings',
+        'cline_mcp_settings.json',
+      );
+    case 'zed':
+      return isWindows
+        ? join(appDataDir(), 'Zed', 'settings.json')
+        : join(home, '.config', 'zed', 'settings.json');
+    case 'codex':
+      return join(home, '.codex', 'config.toml');
+    case 'gemini':
+      return join(home, '.gemini', 'settings.json');
   }
 }
 
@@ -54,6 +107,12 @@ const PROFILES: ClientProfile[] = [
     id: 'claude-code',
     displayName: 'Claude Code',
     configPath: configPathFor('claude-code'),
+    configMode: 'dedicated-mcp-json',
+  },
+  {
+    id: 'claude-desktop',
+    displayName: 'Claude Desktop',
+    configPath: configPathFor('claude-desktop'),
     configMode: 'dedicated-mcp-json',
   },
   {
@@ -73,6 +132,36 @@ const PROFILES: ClientProfile[] = [
     displayName: 'Continue',
     configPath: configPathFor('continue'),
     configMode: 'embedded-in-config-json',
+  },
+  {
+    id: 'vscode',
+    displayName: 'VS Code',
+    configPath: configPathFor('vscode'),
+    configMode: 'vscode-servers',
+  },
+  {
+    id: 'cline',
+    displayName: 'Cline',
+    configPath: configPathFor('cline'),
+    configMode: 'dedicated-mcp-json',
+  },
+  {
+    id: 'zed',
+    displayName: 'Zed',
+    configPath: configPathFor('zed'),
+    configMode: 'zed-context-servers',
+  },
+  {
+    id: 'codex',
+    displayName: 'OpenAI Codex CLI',
+    configPath: configPathFor('codex'),
+    configMode: 'codex-toml',
+  },
+  {
+    id: 'gemini',
+    displayName: 'Gemini CLI',
+    configPath: configPathFor('gemini'),
+    configMode: 'dedicated-mcp-json',
   },
 ];
 
@@ -94,7 +183,7 @@ export function allProfiles(): ClientProfile[] {
  */
 export function detectInstalledClients(): ClientProfile[] {
   return PROFILES.filter((profile) => {
-    // Detection signal: the parent dir exists. The mcp.json file itself
+    // Detection signal: the parent dir exists. The config file itself
     // may not yet exist (that's what we'd create); the dir's existence
     // means the client is installed.
     const parentDir = profile.configPath.replace(/[\\/][^\\/]+$/, '');

--- a/packages/init/tests/config-writer.test.ts
+++ b/packages/init/tests/config-writer.test.ts
@@ -119,3 +119,132 @@ describe('uninstallIris', () => {
     expect(result.action).toBe('not-present');
   });
 });
+
+describe('vscode-servers strategy', () => {
+  function vscodeProfile(): ClientProfile {
+    return {
+      id: 'vscode',
+      displayName: 'VS Code',
+      configPath: join(tmpDir, 'mcp.json'),
+      configMode: 'vscode-servers',
+    };
+  }
+
+  it('writes under "servers", not "mcpServers"', () => {
+    const result = installIris(vscodeProfile());
+    expect(result.action).toBe('created');
+    const written = JSON.parse(readFileSync(result.configPath, 'utf-8'));
+    expect(written.servers.iris.command).toBe('npx');
+    expect(written.mcpServers).toBeUndefined();
+  });
+
+  it('is idempotent and uninstalls only the iris entry', () => {
+    const profile = vscodeProfile();
+    installIris(profile);
+    expect(installIris(profile).action).toBe('no-change');
+    writeFileSync(
+      profile.configPath,
+      JSON.stringify({
+        servers: {
+          iris: { command: 'npx', args: ['-y', '@iris-eval/mcp-server'] },
+          other: { command: 'echo', args: [] },
+        },
+      }),
+      'utf-8',
+    );
+    const removed = uninstallIris(profile);
+    expect(removed.action).toBe('removed');
+    const written = JSON.parse(readFileSync(profile.configPath, 'utf-8'));
+    expect(written.servers.iris).toBeUndefined();
+    expect(written.servers.other).toBeDefined();
+  });
+});
+
+describe('zed-context-servers strategy', () => {
+  function zedProfile(): ClientProfile {
+    return {
+      id: 'zed',
+      displayName: 'Zed',
+      configPath: join(tmpDir, 'settings.json'),
+      configMode: 'zed-context-servers',
+    };
+  }
+
+  it('writes a nested command object under context_servers', () => {
+    const result = installIris(zedProfile());
+    expect(result.action).toBe('created');
+    const written = JSON.parse(readFileSync(result.configPath, 'utf-8'));
+    expect(written.context_servers.iris.command.path).toBe('npx');
+    expect(written.context_servers.iris.command.args).toEqual([
+      '-y',
+      '@iris-eval/mcp-server',
+    ]);
+  });
+
+  it('preserves unrelated Zed settings and is idempotent', () => {
+    const profile = zedProfile();
+    writeFileSync(
+      profile.configPath,
+      JSON.stringify({ theme: 'One Dark', vim_mode: true }),
+      'utf-8',
+    );
+    installIris(profile);
+    expect(installIris(profile).action).toBe('no-change');
+    const written = JSON.parse(readFileSync(profile.configPath, 'utf-8'));
+    expect(written.theme).toBe('One Dark');
+    expect(written.vim_mode).toBe(true);
+    expect(uninstallIris(profile).action).toBe('removed');
+    const after = JSON.parse(readFileSync(profile.configPath, 'utf-8'));
+    expect(after.theme).toBe('One Dark');
+    expect(after.context_servers.iris).toBeUndefined();
+  });
+
+  it('refuses to rewrite a Zed settings file with comments (invalid strict JSON)', () => {
+    const profile = zedProfile();
+    writeFileSync(profile.configPath, '{\n  // my settings\n  "theme": "x"\n}', 'utf-8');
+    expect(() => installIris(profile)).toThrow(/manually/);
+  });
+});
+
+describe('codex-toml strategy', () => {
+  function codexProfile(): ClientProfile {
+    return {
+      id: 'codex',
+      displayName: 'OpenAI Codex CLI',
+      configPath: join(tmpDir, 'config.toml'),
+      configMode: 'codex-toml',
+    };
+  }
+
+  it('creates config.toml with an [mcp_servers.iris] section', () => {
+    const result = installIris(codexProfile());
+    expect(result.action).toBe('created');
+    const raw = readFileSync(result.configPath, 'utf-8');
+    expect(raw).toContain('[mcp_servers.iris]');
+    expect(raw).toContain('command = "npx"');
+    expect(raw).toContain('args = ["-y", "@iris-eval/mcp-server"]');
+  });
+
+  it('appends without disturbing existing sections and is idempotent', () => {
+    const profile = codexProfile();
+    writeFileSync(profile.configPath, 'model = "o4"\n\n[mcp_servers.other]\ncommand = "echo"\n', 'utf-8');
+    const result = installIris(profile);
+    expect(result.action).toBe('updated');
+    expect(installIris(profile).action).toBe('no-change');
+    const raw = readFileSync(profile.configPath, 'utf-8');
+    expect(raw).toContain('model = "o4"');
+    expect(raw).toContain('[mcp_servers.other]');
+    expect(raw).toContain('[mcp_servers.iris]');
+  });
+
+  it('uninstall removes only the iris section', () => {
+    const profile = codexProfile();
+    writeFileSync(profile.configPath, 'model = "o4"\n', 'utf-8');
+    installIris(profile);
+    const removed = uninstallIris(profile);
+    expect(removed.action).toBe('removed');
+    const raw = readFileSync(profile.configPath, 'utf-8');
+    expect(raw).toContain('model = "o4"');
+    expect(raw).not.toContain('[mcp_servers.iris]');
+  });
+});

--- a/packages/init/tests/detect.test.ts
+++ b/packages/init/tests/detect.test.ts
@@ -6,22 +6,43 @@ import {
 } from '../src/detect.js';
 
 describe('detect', () => {
-  it('returns four supported profiles', () => {
+  it('returns ten supported profiles', () => {
     const profiles = allProfiles();
-    expect(profiles).toHaveLength(4);
+    expect(profiles).toHaveLength(10);
     expect(profiles.map((p) => p.id).sort()).toEqual([
       'claude-code',
+      'claude-desktop',
+      'cline',
+      'codex',
       'continue',
       'cursor',
+      'gemini',
+      'vscode',
       'windsurf',
+      'zed',
     ]);
   });
 
   it('configPathFor returns a non-empty path per supported client', () => {
     expect(configPathFor('claude-code')).toMatch(/\.claude/);
+    expect(configPathFor('claude-desktop')).toMatch(/Claude/);
     expect(configPathFor('cursor')).toMatch(/\.cursor/);
     expect(configPathFor('windsurf')).toMatch(/codeium/);
     expect(configPathFor('continue')).toMatch(/\.continue/);
+    expect(configPathFor('vscode')).toMatch(/mcp\.json/);
+    expect(configPathFor('cline')).toMatch(/cline_mcp_settings/);
+    expect(configPathFor('zed')).toMatch(/[Zz]ed/);
+    expect(configPathFor('codex')).toMatch(/\.codex/);
+    expect(configPathFor('gemini')).toMatch(/\.gemini/);
+  });
+
+  it('new clients use the correct config strategies', () => {
+    expect(profileFor('vscode').configMode).toBe('vscode-servers');
+    expect(profileFor('zed').configMode).toBe('zed-context-servers');
+    expect(profileFor('codex').configMode).toBe('codex-toml');
+    expect(profileFor('claude-desktop').configMode).toBe('dedicated-mcp-json');
+    expect(profileFor('cline').configMode).toBe('dedicated-mcp-json');
+    expect(profileFor('gemini').configMode).toBe('dedicated-mcp-json');
   });
 
   it('profileFor returns the correct displayName per client', () => {


### PR DESCRIPTION
Expands @iris-eval/init from 4 to 10 client profiles (all nine README-matrix clients + Continue), with three new config strategies (VS Code 'servers' schema, Zed context_servers, Codex TOML). Tests 12→21, all passing on Linux; tsc clean.

Part of the plug-and-play pillar: the end state is `npx @iris-eval/init` as the README-headline zero-tooling quickstart. npm publish of the package is the gated follow-up (needs npm Trusted Publishing config for the new package — founder step), after which the README swap lands as its own PR per claims-alignment discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)