### PR TITLE
fix(init): local vitest config for isolated CI checkouts

### DIFF
--- a/packages/init/vitest.config.ts
+++ b/packages/init/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Local config so vitest does NOT walk up to the repo root's
+// vitest.config.ts — in isolated CI checkouts (release-init.yml,
+// bootstrap workflow) only this package's node_modules exist, and the
+// root config's imports fail with ERR_MODULE_NOT_FOUND.
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Bootstrap run 28629357182 failed: vitest in packages/init walked up to the repo-root vitest.config.ts whose deps aren't installed in package-scoped workflows. Local config pins resolution. 21/21 tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)