### PR TITLE
feat(plugin): Claude Code plugin + installable marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "iris-eval",
+  "owner": {
+    "name": "Iris",
+    "email": "hello@iris-eval.com",
+    "url": "https://iris-eval.com"
+  },
+  "plugins": [
+    {
+      "name": "iris-eval",
+      "source": "./claude-plugin",
+      "description": "Agent eval for any MCP workflow — score output quality, catch PII and prompt injection, verify citations, and enforce cost budgets. 9 MCP tools + an agent-eval skill."
+    }
+  ]
+}

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "iris-eval",
+  "description": "Agent eval for any MCP workflow — score output quality, catch PII and prompt injection, verify citations, and enforce cost budgets. Adds the Iris MCP server (9 tools) plus an agent-eval skill that guides eval-driven development.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Iris",
+    "email": "hello@iris-eval.com",
+    "url": "https://iris-eval.com"
+  },
+  "keywords": [
+    "eval",
+    "agent-eval",
+    "evaluation",
+    "quality",
+    "safety",
+    "pii-detection",
+    "cost-tracking",
+    "mcp"
+  ]
+}

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "iris-eval": {
+      "command": "npx",
+      "args": ["-y", "@iris-eval/mcp-server"]
+    }
+  }
+}

--- a/claude-plugin/skills/agent-eval/SKILL.md
+++ b/claude-plugin/skills/agent-eval/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: agent-eval
+description: Evaluate AI agent output quality, safety, and cost using the Iris MCP server. Use when building, testing, or shipping agents and the user wants to score output quality, detect PII or prompt injection, verify citations, track cost per query, enforce cost budgets, add tracing/observability to an agent, or set up eval-driven development. Also use when the user asks "is my agent good enough to ship" or wants quality gates on agent responses.
+---
+
+# Agent Eval with Iris
+
+Iris is an MCP server for agent evaluation. If this plugin is installed, its
+nine tools are already available — no setup needed. If the tools are missing,
+the server starts with `npx -y @iris-eval/mcp-server` in any MCP client config.
+
+## Core workflow (eval loop)
+
+1. **Log** the agent execution: `log_trace` with spans, tool calls, token
+   usage, and cost. This builds the record everything else reads.
+2. **Score** the output: `evaluate_output` runs 13 built-in rules across
+   completeness, relevance, safety (12 PII patterns, 14 injection patterns,
+   18 hallucination markers), and cost. Heuristic, deterministic, free.
+3. **Judge** semantically when heuristics aren't enough:
+   `evaluate_with_llm_judge` (templates: accuracy, helpfulness, safety,
+   correctness, faithfulness). Requires the user's own API key in
+   `IRIS_ANTHROPIC_API_KEY` or `IRIS_OPENAI_API_KEY` — Iris never proxies.
+4. **Verify citations** in research/RAG outputs: `verify_citations` extracts
+   citations, fetches sources (SSRF-guarded, opt-in), and checks each claim.
+5. **Inspect** history: `get_traces` with filters; costs aggregate across
+   agents and time windows.
+
+## Custom rules
+
+`deploy_rule` registers a custom eval rule (Zod schema) that fires on every
+matching `evaluate_output`. `list_rules` enumerates; `delete_rule` removes.
+Use custom rules to encode product-specific quality bars — a required
+disclaimer, banned phrases, output length bands, expected coverage terms.
+
+## Patterns worth suggesting
+
+- **Quality gate before ship**: evaluate representative outputs; treat any
+  safety-rule failure as blocking. Cost rules catch budget regressions.
+- **Eval-driven development**: write rules first (the quality spec), then
+  iterate the agent until they pass — the eval loop is the test suite.
+- **Regression tracking**: log traces in CI runs; compare score drift across
+  versions to catch silent quality decay (eval drift).
+
+## Notes
+
+- Traces persist locally in SQLite (`~/.iris/iris.db`) in self-hosted mode.
+- Dashboard: `npx @iris-eval/mcp-server --dashboard` → http://localhost:6920.
+- OpenTelemetry export: set `IRIS_OTEL_ENDPOINT` and `log_trace` also emits
+  OTLP/HTTP to any collector.
+- Full docs: https://iris-eval.com and https://iris-eval.com/llms-full.txt


### PR DESCRIPTION
Adds a Claude Code plugin (MCP server + agent-eval skill) and a repo-root marketplace.json so the repo itself is installable today via /plugin marketplace add iris-eval/mcp-server — no directory approval needed. Anthropic official-directory submission remains the follow-up. Schema mirrored from official cached plugins (telegram, frontend-design); every factual claim checked against .claims.json + README (13 rules, 9 tools, port 6920).

🤖 Generated with [Claude Code](https://claude.com/claude-code)