### PR TITLE
feat(website): llms.txt surfaces advertise the Claude Code plugin

### DIFF
--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -27,7 +27,12 @@ Standard `mcpServers` JSON config (Claude Desktop, Cursor, Windsurf, Cline, Gemi
       }
     }
 
-Claude Code:
+Claude Code (plugin — includes an agent-eval skill that guides eval workflows):
+
+    /plugin marketplace add iris-eval/mcp-server
+    /plugin install iris-eval@iris-eval
+
+Claude Code (plain MCP server, no plugin):
 
     claude mcp add --transport stdio iris-eval -- npx @iris-eval/mcp-server
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -7,6 +7,7 @@ Iris registers 9 MCP tools (trace logging, heuristic eval, LLM-as-judge, semanti
 ## Getting Started
 
 - [GitHub repository](https://github.com/iris-eval/mcp-server): source, README with per-client setup for every major MCP client, full tool schemas
+- Claude Code plugin: `/plugin marketplace add iris-eval/mcp-server` then `/plugin install iris-eval@iris-eval` — MCP server + agent-eval skill in two commands
 - [npm package](https://www.npmjs.com/package/@iris-eval/mcp-server): `@iris-eval/mcp-server` — install via `npx @iris-eval/mcp-server`
 - [Playground](https://iris-eval.com/playground): try agent eval in the browser, no install
 - [Security](https://iris-eval.com/security): security posture, signed releases, disclosure policy


### PR DESCRIPTION
Follows #235: the plugin is live, so the machine-readable discovery files now carry the /plugin install path (with the agent-eval skill called out). README/init headline swap remains gated on the @iris-eval/init npm publish per claims discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)