### PR TITLE
fix(website): retire public version + manifest drift — truthbase drives what visitors see

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-07-07T07:28:45.152Z",
-  "generatedFromCommit": "c1ea31d",
+  "generatedAt": "2026-07-07T07:40:46.442Z",
+  "generatedFromCommit": "11a83bd",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -120,7 +120,7 @@
       "passed": null,
       "total": null
     },
-    "totalCombined": 542,
+    "totalCombined": 544,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -128,8 +128,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 431,
-      "total": 431
+      "passed": 433,
+      "total": 433
     }
   },
   "version": {

--- a/tests/claims-eval-rules-counts.test.ts
+++ b/tests/claims-eval-rules-counts.test.ts
@@ -81,3 +81,23 @@ describe('claims counts match runtime truth', () => {
     if (quoted) expect(Number(quoted[1])).toBe(HALLUCINATION_MARKERS.length);
   });
 });
+
+describe('public .well-known/mcp.json matches the truthbase', () => {
+  const claims = JSON.parse(readFileSync(resolve(__dirname, '..', '.claims.json'), 'utf-8')) as {
+    mcpTools: { names: string[] };
+    version: { mcpServer: string };
+  };
+  const manifest = JSON.parse(
+    readFileSync(resolve(__dirname, '..', 'website', 'public', '.well-known', 'mcp.json'), 'utf-8'),
+  ) as { version: string; tools: Array<{ name: string }>; install: { claude_desktop: { mcpServers: Record<string, unknown> } } };
+
+  it('lists every shipped tool, no more, no fewer (once listed only 3 of 9)', () => {
+    const manifestNames = manifest.tools.map(t => t.name).sort();
+    expect(manifestNames).toEqual([...claims.mcpTools.names].sort());
+  });
+
+  it('advertises the shipped version and the canonical server key', () => {
+    expect(manifest.version).toBe(claims.version.mcpServer);
+    expect(Object.keys(manifest.install.claude_desktop.mcpServers)).toEqual(['iris-eval']);
+  });
+});

--- a/website/public/.well-known/mcp.json
+++ b/website/public/.well-known/mcp.json
@@ -13,15 +13,39 @@
   "tools": [
     {
       "name": "log_trace",
-      "description": "Log an agent execution trace with spans, tool calls, and metrics"
-    },
-    {
-      "name": "evaluate_output",
-      "description": "Evaluate agent output quality using configurable rules"
+      "description": "Persist a single agent execution trace (input, output, spans, tool calls, cost, latency, token usage)"
     },
     {
       "name": "get_traces",
-      "description": "Query stored traces with filters, pagination, and summary stats"
+      "description": "Query stored agent-execution traces with filters, pagination, and optional dashboard summary"
+    },
+    {
+      "name": "delete_trace",
+      "description": "Remove a single trace by id; cascades to spans, eval results keep the score history"
+    },
+    {
+      "name": "evaluate_output",
+      "description": "Score agent output against configurable eval rules and return a 0..1 score + per-rule breakdown"
+    },
+    {
+      "name": "evaluate_with_llm_judge",
+      "description": "Score agent output using an LLM as the judge (Anthropic or OpenAI) with a calibrated 0..1 score and rationale"
+    },
+    {
+      "name": "verify_citations",
+      "description": "Extract citations from agent output, fetch the cited sources, and use an LLM judge to check whether each source supports the claim"
+    },
+    {
+      "name": "deploy_rule",
+      "description": "Deploy a new custom evaluation rule that fires on every future evaluate_output call of its eval category"
+    },
+    {
+      "name": "list_rules",
+      "description": "Enumerate deployed custom evaluation rules from the local rule store"
+    },
+    {
+      "name": "delete_rule",
+      "description": "Remove a deployed custom evaluation rule; past eval results are preserved"
     }
   ],
   "resources": [
@@ -33,7 +57,7 @@
   "install": {
     "claude_desktop": {
       "mcpServers": {
-        "iris": {
+        "iris-eval": {
           "command": "npx",
           "args": [
             "-y",

--- a/website/src/app/compare/deepeval/page.tsx
+++ b/website/src/app/compare/deepeval/page.tsx
@@ -4,6 +4,7 @@ import { OG_IMAGE_URL } from "@/lib/og";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
 import { CompareDisclaimer } from "@/components/compare-disclaimer";
+import { VERSION_MCP_SERVER } from "@/lib/claims";
 
 function sanitizeText(value: unknown): string {
   return String(value ?? "")
@@ -95,7 +96,7 @@ const FEATURES = [
   { feature: "OpenTelemetry export", iris: "OTLP/HTTP JSON to Jaeger/Tempo/Datadog (v0.4)", deepeval: "Not included", irisWin: true },
   { feature: "Supply-chain integrity", iris: "SBOM + cosign + SLSA build-provenance (v0.4)", deepeval: "Standard pip", irisWin: true },
   { feature: "License", iris: "MIT", deepeval: "Apache 2.0", irisWin: false },
-  { feature: "Maturity", iris: "Early stage (v0.4.0)", deepeval: "Established (14K+ GitHub stars)", deepevalWin: true, irisNeutral: true },
+  { feature: "Maturity", iris: `Early stage (v${VERSION_MCP_SERVER})`, deepeval: "Established (14K+ GitHub stars)", deepevalWin: true, irisNeutral: true },
 ];
 
 const IRIS_REASONS = [

--- a/website/src/components/nav.tsx
+++ b/website/src/components/nav.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useTheme } from "./theme-provider";
 import { IrisLogo } from "./iris-logo";
+import { VERSION_MCP_SERVER } from "@/lib/claims";
 
 const NAV_LINKS = [
   { label: "Product", href: "/#product" },
@@ -31,7 +32,7 @@ export function Nav(): React.ReactElement {
       {/* Event banner */}
       <div className="relative z-50 border-b border-border-subtle bg-iris-600/8 px-4 py-2.5 text-center">
         <a href="https://github.com/iris-eval/mcp-server" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm text-text-secondary transition-colors hover:text-text-primary">
-          <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v0.4.0</span>
+          <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v{VERSION_MCP_SERVER}</span>
           <span>Iris v0.4 — LLM-as-Judge + citation verify + OTel + 9 MCP tools</span>
           <span className="text-text-accent">&rarr;</span>
         </a>


### PR DESCRIPTION
Completes the S51 Mother-Audit **MUST-4** (public version drift), the second half of the D3 integrity work begun in #244.

## What was drifting

| Surface | Said | Truth |
|---|---|---|
| Nav event-banner badge (every page) | `v0.4.0` hardcoded | **0.4.4** |
| Compare → DeepEval maturity row | "Early stage (v0.4.0)" | **0.4.4** |
| `.well-known/mcp.json` tools | **3** listed | **9** shipped |
| `.well-known/mcp.json` install key | `iris` | **`iris-eval`** (matches every README install block) |

## The fix

- Nav badge + compare row now render from `lib/claims` (`VERSION_MCP_SERVER`) — the truthbase reader that already existed for exactly this; they can never lag a release again.
- Manifest rewritten: all 9 tools with their registered descriptions, canonical `iris-eval` key.
- **Drift locks** added to the claims test suite: manifest tool names must equal `.claims.json` `mcpTools.names` exactly; manifest version must equal `version.mcpServer`; install key must stay `iris-eval`.
- `.claims.json` test capture refreshed (433 root + 111 dashboard = 544).

## Verification

- `npm run test` — 433/433 (claims suite now 9 tests)
- `npm run typecheck` / `npm run lint` — clean (pre-existing tenant.ts warning untouched)
- `npm run claims:check` — OK
- `cd website && npm run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)