### PR TITLE
fix(llms): llms-full.txt quoted the inflated pattern counts — 12/14/18 → 10/13/17

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-07-07T07:40:46.442Z",
-  "generatedFromCommit": "11a83bd",
+  "generatedAt": "2026-07-07T07:55:51.084Z",
+  "generatedFromCommit": "f95c033",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -120,7 +120,7 @@
       "passed": null,
       "total": null
     },
-    "totalCombined": 544,
+    "totalCombined": 545,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -128,8 +128,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 433,
-      "total": 433
+      "passed": 434,
+      "total": 434
     }
   },
   "version": {

--- a/scripts/claims/allow-list.json
+++ b/scripts/claims/allow-list.json
@@ -62,12 +62,6 @@
       "reason": "Migration candidate — currently accurate (9 tools); reader migration deferred to follow-on PR alongside other website component sweeps."
     },
     {
-      "file": "website/src/components/nav.tsx",
-      "pattern": "mcp-tool-count",
-      "line": 35,
-      "reason": "Migration candidate — currently accurate (9 tools); reader migration deferred to follow-on PR."
-    },
-    {
       "file": "website/src/components/roadmap.tsx",
       "pattern": "mcp-tool-count",
       "line": 11,

--- a/tests/claims-eval-rules-counts.test.ts
+++ b/tests/claims-eval-rules-counts.test.ts
@@ -82,6 +82,15 @@ describe('claims counts match runtime truth', () => {
   });
 });
 
+describe('public llms-full.txt quotes the real pattern counts', () => {
+  it('safety-depth line matches the runtime arrays (once shipped 12/14/18)', () => {
+    const txt = readFileSync(resolve(__dirname, '..', 'website', 'public', 'llms-full.txt'), 'utf-8');
+    expect(txt).toContain(`${PII_PATTERNS.length} PII patterns`);
+    expect(txt).toContain(`${INJECTION_PATTERNS.length} prompt-injection patterns`);
+    expect(txt).toContain(`${HALLUCINATION_MARKERS.length} hallucination markers`);
+  });
+});
+
 describe('public .well-known/mcp.json matches the truthbase', () => {
   const claims = JSON.parse(readFileSync(resolve(__dirname, '..', '.claims.json'), 'utf-8')) as {
     mcpTools: { names: string[] };

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -74,7 +74,7 @@ Categories: completeness, relevance, safety, cost.
 
 Rules: nonEmptyOutput, minOutputLength, noStubOutput, sentenceCount, expectedCoverage, keywordOverlap, topicConsistency, noPii, noInjectionPatterns, noHallucinationMarkers, noBlocklistWords, costUnderThreshold, tokenEfficiency.
 
-Safety depth: 12 PII patterns (SSN, credit card, phone, email, IBAN, DOB, MRN, IP, API key, passport, and more), 14 prompt-injection patterns, 18 hallucination markers, stub-output detection. Custom rules are added via Zod schemas and the `deploy_rule` tool.
+Safety depth: 10 PII patterns (SSN, credit card, phone, email, IBAN, passport, DOB, medical record number, IP address, API key), 13 prompt-injection patterns, 17 hallucination markers, stub-output detection. Custom rules are added via Zod schemas and the `deploy_rule` tool.
 
 ## Trust signals
 

--- a/website/src/components/nav.tsx
+++ b/website/src/components/nav.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useTheme } from "./theme-provider";
 import { IrisLogo } from "./iris-logo";
-import { VERSION_MCP_SERVER } from "@/lib/claims";
+import { MCP_TOOL_COUNT, VERSION_MCP_SERVER } from "@/lib/claims";
 
 const NAV_LINKS = [
   { label: "Product", href: "/#product" },
@@ -33,7 +33,7 @@ export function Nav(): React.ReactElement {
       <div className="relative z-50 border-b border-border-subtle bg-iris-600/8 px-4 py-2.5 text-center">
         <a href="https://github.com/iris-eval/mcp-server" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm text-text-secondary transition-colors hover:text-text-primary">
           <span className="rounded-full bg-iris-600 px-2 py-0.5 text-[11px] font-semibold text-white">v{VERSION_MCP_SERVER}</span>
-          <span>Iris v0.4 — LLM-as-Judge + citation verify + OTel + 9 MCP tools</span>
+          <span>Iris v0.4 — LLM-as-Judge + citation verify + OTel + {MCP_TOOL_COUNT} MCP tools</span>
           <span className="text-text-accent">&rarr;</span>
         </a>
       </div>


### PR DESCRIPTION
The one public surface #244 missed: `website/public/llms-full.txt` line 77 still told every LLM reading it that iris ships **12 PII / 14 injection / 18 hallucination** patterns. Source truth (locked by the #244 drift suite): **10 / 13 / 17**.

- Safety-depth line corrected, naming the exact 10 PII patterns (no "and more" padding).
- Drift lock added: the claims test suite now asserts llms-full.txt quotes `PII_PATTERNS.length` / `INJECTION_PATTERNS.length` / `HALLUCINATION_MARKERS.length` verbatim — this file can never quote stale counts again.
- Test capture refreshed (combined 545).

Completes MUST-1's "fix public llms-full.txt" clause — with #244 and #245 this closes the S51 Mother-Audit D3 integrity work in full.

## Verification
- `npm run test` — claims suite 10/10
- `npm run typecheck` / `npm run lint` — clean
- `npm run claims:check` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)