### PR TITLE
fix(claims): Phase E completion — every content surface truthbase-aligned, scanner extended to see them all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN npm run build
 # NOTE: uses `npm install` not `npm ci` — the Windows-generated lockfile prunes
 # Linux-only @emnapi transitive deps that rolldown needs at build time
 # (per memory/reference_rolldown_lockfile_trap.md).
+# .claims.json feeds the dashboard's build-time defines (vite.config.ts reads
+# ../.claims.json for __IRIS_RULE_COUNT__) — must be in the build context.
+COPY .claims.json ./
 COPY dashboard/ dashboard/
 RUN cd dashboard && npm install && npm run build
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Iris evaluates all of it.
 
 ## Quickstart
 
-Add Iris to your MCP config. Works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Cline, Zed, Codex CLI, Gemini CLI — and any other MCP-compatible agent.
+Add Iris to your MCP config. Works with Claude Desktop, Claude Code, Cursor, Windsurf, Continue, VS Code, Cline, Zed, Codex CLI, Gemini CLI — and any other MCP-compatible agent.
 
 ```json
 {

--- a/claude-plugin/skills/agent-eval/SKILL.md
+++ b/claude-plugin/skills/agent-eval/SKILL.md
@@ -14,8 +14,8 @@ the server starts with `npx -y @iris-eval/mcp-server` in any MCP client config.
 1. **Log** the agent execution: `log_trace` with spans, tool calls, token
    usage, and cost. This builds the record everything else reads.
 2. **Score** the output: `evaluate_output` runs 13 built-in rules across
-   completeness, relevance, safety (12 PII patterns, 14 injection patterns,
-   18 hallucination markers), and cost. Heuristic, deterministic, free.
+   completeness, relevance, safety (10 PII patterns, 13 injection patterns,
+   17 hallucination markers), and cost. Heuristic, deterministic, free.
 3. **Judge** semantically when heuristics aren't enough:
    `evaluate_with_llm_judge` (templates: accuracy, helpfulness, safety,
    correctness, faithfulness). Requires the user's own API key in

--- a/dashboard/src/components/dashboard/DriftView.tsx
+++ b/dashboard/src/components/dashboard/DriftView.tsx
@@ -155,7 +155,7 @@ export function DriftView() {
       {/* §4 PER-RULE PERFORMANCE */}
       <SectionHeader
         title="Per-rule performance"
-        question="How is each of the 13 built-in rules performing, and which moved?"
+        question={`How is each of the ${__IRIS_RULE_COUNT__} built-in rules performing, and which moved?`}
       />
       <PerRuleMeterGrid
         currentMoments={currentMoments?.moments}

--- a/dashboard/src/components/layout/AccountMenu.tsx
+++ b/dashboard/src/components/layout/AccountMenu.tsx
@@ -21,7 +21,7 @@ import { Icon } from '../shared/Icon';
 import { useTheme } from './ThemeProvider';
 import { usePreferences } from '../../hooks/usePreferences';
 
-const VERSION = '0.4.0';
+const VERSION = __IRIS_VERSION__;
 
 const styles = {
   triggerWrap: {

--- a/dashboard/src/components/layout/SidebarFooter.tsx
+++ b/dashboard/src/components/layout/SidebarFooter.tsx
@@ -15,7 +15,7 @@ import { Settings, HelpCircle, ChevronsLeft, ChevronsRight } from 'lucide-react'
 import { Icon } from '../shared/Icon';
 import { Tooltip } from '../shared/Tooltip';
 
-const VERSION = '0.4.0';
+const VERSION = __IRIS_VERSION__;
 
 const styles = {
   footer: {

--- a/dashboard/src/components/onboarding/WelcomeTour.tsx
+++ b/dashboard/src/components/onboarding/WelcomeTour.tsx
@@ -188,7 +188,7 @@ export function WelcomeTour({
           <>
             <p style={styles.text}>
               Iris is the agent eval standard for MCP. Every trace your agents log gets scored
-              against 13 built-in rules covering completeness, relevance, safety, and cost.
+              against {__IRIS_RULE_COUNT__} built-in rules covering completeness, relevance, safety, and cost.
             </p>
             <p style={styles.text}>
               The next 4 steps introduce the system-design ideas that make Iris different from

--- a/dashboard/src/vite-env.d.ts
+++ b/dashboard/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+// Injected by vite.config.ts / vitest.config.ts `define` from the root
+// package.json / .claims.json — the server version + claim counts the
+// dashboard chrome displays.
+declare const __IRIS_VERSION__: string;
+declare const __IRIS_RULE_COUNT__: number;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,8 +1,24 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// The dashboard displays the SERVER's version — sourced from the root
+// package.json at build time so chrome can never drift from the release
+// (two components previously hardcoded '0.4.0' and shipped stale).
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+  version: string;
+};
+// Same discipline for claim counts: build-time from the truthbase.
+const claims = JSON.parse(readFileSync(new URL('../.claims.json', import.meta.url), 'utf-8')) as {
+  evalRules: { builtInCount: number };
+};
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __IRIS_VERSION__: JSON.stringify(pkg.version),
+    __IRIS_RULE_COUNT__: JSON.stringify(claims.evalRules.builtInCount),
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:6920',

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,8 +1,22 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+// Mirror vite.config.ts — components read the server version + claim counts
+// from these build-time defines; tests need the same globals.
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+  version: string;
+};
+const claims = JSON.parse(readFileSync(new URL('../.claims.json', import.meta.url), 'utf-8')) as {
+  evalRules: { builtInCount: number };
+};
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __IRIS_VERSION__: JSON.stringify(pkg.version),
+    __IRIS_RULE_COUNT__: JSON.stringify(claims.evalRules.builtInCount),
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -827,7 +827,7 @@ Health check endpoint. Reports server status and storage connectivity.
 ```json
 {
   "status": "ok",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "uptime_seconds": 3600,
   "trace_count": 142,
   "storage": "connected"
@@ -841,7 +841,7 @@ The `version` field is sourced dynamically from `package.json` at runtime (see `
 ```json
 {
   "status": "degraded",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "uptime_seconds": 3600,
   "storage": "disconnected"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,7 +212,7 @@ dashboard/              React SPA (separate Vite build)
 |-----------------|--------------------------------------------------------------|-----------------|
 | `completeness`  | `min_output_length`, `non_empty_output`, `sentence_count`, `expected_coverage` | 1, 2, 0.5, 1.5 |
 | `relevance`     | `keyword_overlap`, `no_hallucination_markers`, `topic_consistency` | 1, 1, 1 |
-| `safety`        | `no_pii`, `no_blocklist_words`, `no_injection_patterns`      | 2, 2, 2 |
+| `safety`        | `no_pii`, `no_blocklist_words`, `no_injection_patterns`, `no_stub_output` | 2, 2, 2, 2 |
 | `cost`          | `cost_under_threshold`, `token_efficiency`                   | 1, 0.5 |
 | `custom`        | Dynamically built from `CustomRuleDefinition` array          | User-defined |
 

--- a/docs/blog/002-state-of-mcp-agent-observability-2026.md
+++ b/docs/blog/002-state-of-mcp-agent-observability-2026.md
@@ -7,7 +7,7 @@ tags: [observability, mcp, agents, report, evaluation, cost-tracking]
 relatedPosts: [mcp-observability-specification, mcp-observability-is-the-new-apm, closing-the-eval-gap]
 ---
 
-> **Editor's note (2026-04):** This post was written when Iris framed itself as observability-first. Iris has since repositioned as "the agent eval standard for MCP" — scoring outputs, not just watching them. The market analysis below remains accurate; the framing of where Iris fits has sharpened. See [Closing the Eval Gap](/blog/closing-the-eval-gap) for the current thesis.
+> **Editor's note (2026-04):** This post was written when Iris framed itself as observability-first. Iris has since repositioned as "the agent eval standard for MCP" — scoring outputs, not just watching them. The market analysis below remains accurate; the framing of where Iris fits has sharpened. See [Closing the Eval Gap](/blog/closing-the-eval-gap) for the current thesis. *(2026-07: ecosystem adoption figures are now marked as reported rather than independently verified, and the original "first MCP-native" line was retired in favor of the standard positioning.)*
 
 # The State of MCP Agent Observability (March 2026)
 
@@ -34,7 +34,7 @@ The market is responding. The observability market is projected to reach $3.35B 
 The Model Context Protocol has moved from specification to industry standard faster than most developer protocols in recent memory. The milestone that cemented this: **in December 2025, Anthropic donated MCP to the Agentic AI Foundation (AAIF) under the Linux Foundation**, co-founded by Anthropic, Block, and OpenAI, with backing from Google, Microsoft, AWS, Cloudflare, and Bloomberg. MCP is no longer one company's protocol. It's governed by an open foundation with the major players at the table.
 
 The adoption numbers reflect this:
-- **97M+ monthly SDK downloads** across the MCP ecosystem
+- **97M+ monthly SDK downloads** reported across the MCP ecosystem (ecosystem-reported figure)
 - **20,470+ GitHub stars** on Langfuse alone (one observability platform in the space)
 - **Remote MCP servers up 4x** since May 2025
 - Gartner predicts **40% of enterprise applications will include AI agents** by end of 2026
@@ -54,7 +54,7 @@ Adoption is not universal, and intellectual honesty requires acknowledging the p
 
 Perplexity CTO Denis Yarats publicly moved away from MCP toward direct APIs and CLIs (March 11, 2026), citing context window consumption and auth friction as practical blockers. His argument: MCP's abstraction layer adds overhead that doesn't justify itself for every use case, particularly when context windows are a finite resource and authentication across tool providers remains inconsistent.
 
-This is a legitimate critique. MCP adds a layer. That layer has a cost — in tokens, in latency, in complexity. For single-tool integrations where the agent always calls the same API, a direct integration may be simpler. But for agents that discover and compose tools dynamically — the multi-tool, multi-provider pattern that's becoming standard in production — the protocol abstraction pays for itself. The AAIF governance and the 97M+ monthly downloads suggest the industry agrees, but the tradeoff is real and teams should evaluate it for their specific architecture.
+This is a legitimate critique. MCP adds a layer. That layer has a cost — in tokens, in latency, in complexity. For single-tool integrations where the agent always calls the same API, a direct integration may be simpler. But for agents that discover and compose tools dynamically — the multi-tool, multi-provider pattern that's becoming standard in production — the protocol abstraction pays for itself. The AAIF governance and the reported 97M+ monthly downloads suggest the industry agrees, but the tradeoff is real and teams should evaluate it for their specific architecture.
 
 ## 3. Security: The Adoption Bottleneck
 
@@ -176,7 +176,7 @@ This doesn't mean every agent needs enterprise compliance tooling today. But it 
 
 ## What Iris Does About This
 
-Iris is the first MCP-native eval and observability tool for AI agents. Open-source core, MIT licensed. Any MCP-compatible agent discovers Iris automatically — no SDK, no code changes. Log traces, evaluate output quality, detect PII and prompt injection, track costs per execution.
+Iris is the agent eval standard for MCP — an eval and observability tool built MCP-native from day one. Open-source core, MIT licensed. Any MCP-compatible agent discovers Iris automatically — no SDK, no code changes. Log traces, evaluate output quality, detect PII and prompt injection, track costs per execution.
 
 If you're building agents and want to see what they're actually doing:
 

--- a/docs/blog/003-why-every-mcp-agent-needs-an-independent-observer.md
+++ b/docs/blog/003-why-every-mcp-agent-needs-an-independent-observer.md
@@ -74,7 +74,7 @@ This is the distributed systems pattern applied to agents. The observer is indep
 
 I built Iris as an MCP server specifically because of this architectural principle. Add it to your MCP config, and every MCP-compatible agent — Claude Desktop, Cursor, Claude Code, custom agents built with the MCP SDK — discovers it on startup.
 
-The agent gains three tools without any code changes:
+The agent gains nine tools without any code changes. The three core ones:
 
 **`log_trace`** records the full execution path:
 

--- a/docs/blog/005-heuristic-vs-semantic-eval.md
+++ b/docs/blog/005-heuristic-vs-semantic-eval.md
@@ -7,6 +7,8 @@ tags: [evaluation, heuristic, llm-as-judge, performance, cost, safety, mcp]
 relatedPosts: [how-to-evaluate-agent-output-without-llm, the-ai-eval-tax, eval-driven-development]
 ---
 
+> **Editor's note (2026-07):** Updated to reflect the current rule library — Iris ships **13** built-in rules (v0.3.1 added `no_stub_output`, making Safety a four-rule category, and expanded `no_pii` to 10 patterns), and LLM-as-Judge shipped in v0.4 as `evaluate_with_llm_judge`. The original text described the 12-rule library and a roadmapped judge.
+
 # Heuristic vs Semantic Eval: When <1ms Matters More Than LLM-as-Judge
 
 There is a default assumption in the agent eval space right now: if you want to evaluate agent output, you need an LLM to judge it. Feed the output to GPT-4o with a rubric, get a score back, done. LLM-as-Judge is the pattern everyone reaches for first.
@@ -95,11 +97,11 @@ The 80% (heuristic): PII detection, prompt injection detection, output completen
 
 The 20% (semantic): factual accuracy against source documents, nuanced quality scoring, tone assessment, complex reasoning verification. These run selectively -- on a sample of traces, or triggered when heuristic scores fall below a threshold -- and the cost is justified because the evaluation requires actual language understanding.
 
-Iris implements the heuristic side today. LLM-as-Judge is on the roadmap for v0.4.0, and when it ships, it will slot in alongside the heuristic rules as a complementary layer -- not a replacement.
+Iris implements both sides today: the heuristic rules below run on every evaluation, and LLM-as-Judge (shipped in v0.4 as `evaluate_with_llm_judge`) slots in alongside them as a complementary layer -- not a replacement.
 
-## The 12 Built-in Rules
+## The 13 Built-in Rules
 
-Iris ships with 12 heuristic eval rules across 4 categories. Here is what each category covers and why it does not need an LLM.
+Iris ships with 13 heuristic eval rules across 4 categories. Here is what each category covers and why it does not need an LLM.
 
 ### Completeness (4 rules)
 
@@ -116,11 +118,12 @@ These are structural checks. An empty response is not a nuance problem. It is a 
 - **no_hallucination_markers** -- Flags common AI hedging phrases: "as an AI," "I cannot," "I don't have access." These are exact string matches. Weight: 1.
 - **topic_consistency** -- Measures whether output words relate to input words. A coarse but fast check for topic drift. Weight: 1.
 
-### Safety (3 rules)
+### Safety (4 rules)
 
-- **no_pii** -- Regex patterns for SSN (`\d{3}-\d{2}-\d{4}`), credit card numbers, phone numbers, and email addresses. Weight: 2.
+- **no_pii** -- 10 regex patterns: SSN (`\d{3}-\d{2}-\d{4}`), credit card, phone, email, IBAN, passport, date-of-birth, medical record number, IP address, and API-key heuristics. Weight: 2.
 - **no_blocklist_words** -- Configurable phrase blocklist. Default includes harmful content patterns. Weight: 2.
-- **no_injection_patterns** -- Regex patterns matching common prompt injection attempts. Weight: 2.
+- **no_injection_patterns** -- 13 regex patterns matching common prompt injection attempts. Weight: 2.
+- **no_stub_output** -- Detects placeholder/stub markers (TODO, FIXME, PLACEHOLDER, [INSERT) that mean the agent shipped scaffolding instead of an answer. Weight: 2.
 
 Safety rules have the highest weights because a safety failure matters more than a completeness failure.
 

--- a/docs/blog/007-how-to-evaluate-agent-output-without-llm.md
+++ b/docs/blog/007-how-to-evaluate-agent-output-without-llm.md
@@ -7,6 +7,8 @@ tags: [eval, agents, mcp, tutorial, heuristics, observability]
 relatedPosts: [heuristic-vs-semantic-eval, eval-driven-development, output-quality-score]
 ---
 
+> **Editor's note (2026-07):** Updated for the current release — Iris now registers **nine** MCP tools (this walkthrough uses the three core ones) and ships **13** built-in rules (v0.3.1 added `no_stub_output`). The original text described the v0.1-era three-tool, 12-rule surface.
+
 # How to Evaluate AI Agent Output Without Calling Another LLM
 
 Here is the default approach to evaluating agent output in 2026: take the output, send it to another LLM, ask that LLM to judge quality, and trust the result.
@@ -50,7 +52,7 @@ That is the entire integration. When your agent starts, it queries its configure
 
 ## What Your Agent Discovers
 
-Once Iris is in the MCP config, your agent has access to three tools:
+Once Iris is in the MCP config, your agent has access to nine tools. The three core ones this walkthrough uses:
 
 - **`log_trace`** — Record an agent execution with input, output, tool calls, latency, token usage, and cost.
 - **`evaluate_output`** — Run deterministic eval rules against an output and get pass/fail scores.
@@ -125,7 +127,7 @@ No LLM call. No latency spike. The eval caught a real problem: the agent include
 
 ## The Eval Categories
 
-Iris ships with 12 built-in eval rules across four categories. Each one is a deterministic check — regex, heuristics, or arithmetic. No LLM involved.
+Iris ships with 13 built-in eval rules across four categories. Each one is a deterministic check — regex, heuristics, or arithmetic. No LLM involved.
 
 ### Completeness
 

--- a/docs/blog/008-mcp-observability-specification.md
+++ b/docs/blog/008-mcp-observability-specification.md
@@ -216,6 +216,6 @@ What I am asking for:
 
 If you are building MCP tools, agent frameworks, or observability infrastructure, I want to hear what you have run into. What schema decisions have you made? What interoperability problems have you hit? What would a standard need to include for you to adopt it?
 
-Without standardization, the fragmented ecosystem will make it harder to achieve the [eval coverage](/blog/eval-coverage-the-metric-your-agents-are-missing) that production agents need. The conversation is happening on [GitHub Discussions](https://github.com/iris-eval/iris/discussions) and in the [MCP Discord](https://discord.gg/mcp). Open an issue, start a thread, or reach out directly. The spec will be better if it reflects the experience of everyone building in this space, not just one team's perspective.
+Without standardization, the fragmented ecosystem will make it harder to achieve the [eval coverage](/blog/eval-coverage-the-metric-your-agents-are-missing) that production agents need. The conversation is happening on [GitHub Discussions](https://github.com/iris-eval/mcp-server/discussions) and in the [MCP Discord](https://discord.gg/mcp). Open an issue, start a thread, or reach out directly. The spec will be better if it reflects the experience of everyone building in this space, not just one team's perspective.
 
 Observability that is protocol-native starts with a protocol that takes observability seriously. This is a proposal that it should.

--- a/docs/blog/009-mcp-meets-opentelemetry.md
+++ b/docs/blog/009-mcp-meets-opentelemetry.md
@@ -7,6 +7,8 @@ tags: [opentelemetry, observability, mcp, infrastructure, datadog, grafana, agen
 relatedPosts: [mcp-observability-specification, mcp-observability-is-the-new-apm, state-of-mcp-agent-observability-2026]
 ---
 
+> **Editor's note (2026-07):** Written before v0.4 shipped. The OpenTelemetry export described below as roadmap **shipped in v0.4** (2026-04-24) — set `IRIS_OTEL_ENDPOINT` and traces flow to any OTLP collector today. Wording updated from future to present tense where it described the export.
+
 # MCP Meets OpenTelemetry: Bridging Agent Observability and Infrastructure Monitoring
 
 There are two worlds in production observability right now, and they do not talk to each other.
@@ -116,7 +118,7 @@ This structural compatibility is why we proposed standard trace schemas in [Towa
 
 ## The Export Path
 
-The Iris v0.4 roadmap includes OpenTelemetry trace export. Here is what this means in practice.
+Iris v0.4 shipped OpenTelemetry trace export. Here is what it means in practice.
 
 Iris continues to store traces locally in SQLite. That does not change. But it also exports spans to an OTel collector endpoint using the OTLP protocol. From the collector, traces flow into whatever backend you already run -- Datadog, Grafana Tempo, Jaeger, Honeycomb.
 
@@ -150,11 +152,11 @@ The future I am building toward is simple to describe: agent traces flow alongsi
 
 This means you open Grafana and see a trace that starts at the API gateway, passes through your orchestration service, enters the agent, fans out to LLM calls and tool invocations, and returns through the same path. Every span has timing, status, and attributes. The agent spans also carry eval scores, cost data, and quality signals. All in one view.
 
-We are not there yet. Iris today stores traces locally and serves them through its own dashboard. The OTel export in v0.4 is the bridge. Once Iris traces are in your OTel pipeline, the integration with existing dashboards, alerts, and runbooks follows naturally.
+Iris still stores traces locally and serves them through its own dashboard — the v0.4 OTel export is the bridge. Once Iris traces are in your OTel pipeline, the integration with existing dashboards, alerts, and runbooks follows naturally.
 
 If you are running agents in production and you already have a Datadog or Grafana deployment, this is the path to unified observability. Not replacing your monitoring stack. Extending it to cover the agent layer.
 
-Iris is open-source, MIT licensed. The code is at [github.com/iris-eval/mcp-server](https://github.com/iris-eval/mcp-server). Add it to your MCP config today, and when v0.4 ships, your agent traces will flow directly into the monitoring stack you already trust.
+Iris is open-source, MIT licensed. The code is at [github.com/iris-eval/mcp-server](https://github.com/iris-eval/mcp-server). Add it to your MCP config today, set `IRIS_OTEL_ENDPOINT`, and your agent traces flow directly into the monitoring stack you already trust.
 
 ```bash
 npx @iris-eval/mcp-server --dashboard

--- a/docs/blog/011-the-ai-eval-tax.md
+++ b/docs/blog/011-the-ai-eval-tax.md
@@ -22,7 +22,7 @@ The industry has a strange relationship with agent evaluation. Teams will spend 
 The numbers show what this costs:
 
 - An estimated **$67.4 billion** in global financial losses tied to AI hallucinations in 2024 alone ([AllAboutAI](https://allaboutai.com/resources/ai-statistics/ai-hallucinations/))
-- Industry estimates put hallucination-related verification costs at **$14,200 per employee per year** — knowledge workers spending hours every week fact-checking AI outputs instead of doing their jobs
+- Knowledge workers now spend **hours every week fact-checking AI outputs** instead of doing their jobs — hallucination verification has become a standing line item of its own
 - A hallucinated answer in Google's Bard demo erased **$100 billion in Alphabet's market cap** in a single day ([Time, Feb 2023](https://time.com/6254226/alphabet-google-bard-100-billion-ai-error/))
 - AI safety incidents surged **56.4% year-over-year** — from 149 to 233 documented incidents ([Stanford AI Index 2025](https://hai.stanford.edu/ai-index/2025-ai-index-report))
 
@@ -75,7 +75,7 @@ The adoption curve for testing culture took about 15 years:
 
 A joint IBM and Microsoft study confirmed: TDD reduces post-release defects by [40-90% depending on team](https://www.microsoft.com/en-us/research/wp-content/uploads/2009/10/Realizing-Quality-Improvement-Through-Test-Driven-Development-Results-and-Experiences-of-Four-Industrial-Teams-nagappan_tdd.pdf).
 
-Where are we with agent eval? The [LangChain State of Agent Engineering survey](https://www.langchain.com/state-of-agent-engineering) (1,340 respondents, late 2025) tells us exactly: **89% of teams have observability** (is the agent running?), but **only 37% have inline eval** (is the answer right?). That 52-point gap is the eval tax manifesting as a metric. Most teams can tell you whether their agent returned a response. They cannot tell you whether the response was any good.
+Where are we with agent eval? The [LangChain State of Agent Engineering survey](https://www.langchain.com/state-of-agent-engineering) (1,340 respondents, late 2025) tells us exactly: **89% of teams have observability** (is the agent running?), but **only 37% run evals on production traffic** (is the answer right?). That 52-point gap is the eval tax manifesting as a metric. Most teams can tell you whether their agent returned a response. They cannot tell you whether the response was any good.
 
 This 52-point gap is what we call [the eval gap](/blog/the-eval-gap) — the distance between "agent works in demo" and "agent works in production." We're in 2003. The tools exist. The culture hasn't caught up.
 

--- a/docs/blog/026-on-chain-agent-eval.md
+++ b/docs/blog/026-on-chain-agent-eval.md
@@ -8,6 +8,8 @@ relatedPosts: [the-eval-gap, self-calibrating-eval, the-ai-eval-tax]
 devto_tags: [ai, blockchain, security, programming]
 ---
 
+> **Editor's note (2026-07):** Updated for source discipline — the SCONE-bench description now reflects that Anthropic's red-team tested multiple frontier models (not Claude alone) and links the research; the Clawdbot section now clearly separates two distinct events (one agent's autonomous contract deployment, and the later discovery of exposed instances); and adoption figures are marked as industry estimates.
+
 # Why On-Chain Agent Actions Need Pre-Flight Eval
 
 There's no undo button on a blockchain.
@@ -18,17 +20,19 @@ And yet, that's exactly what's happening.
 
 ## The Numbers That Should Scare You
 
-There are now **250,000+ AI agents executing on-chain daily**, a 400% increase over 2025. 68% of new DeFi protocols in Q1 2026 include at least one autonomous AI agent. 41% of crypto hedge funds are testing on-chain AI agents for trading, rebalancing, and yield optimization.
+Industry estimates put it at **250,000+ AI agents executing on-chain daily** — a roughly 400% increase over 2025 — with 68% of new DeFi protocols in Q1 2026 including at least one autonomous AI agent and 41% of crypto hedge funds testing on-chain agents for trading, rebalancing, and yield optimization. (Early-2026 ecosystem estimates; the direction is unambiguous even where the precision isn't.)
 
-The losses keep pace. **$3.4 billion was stolen from crypto platforms in 2025.** Not from AI agents specifically — not yet. But Anthropic's SCONE-bench research, which red-teamed Claude against 405 smart contracts, found **$550 million in simulated exploits** that an AI agent could execute or be tricked into executing. These aren't theoretical attack surfaces. They're the exact patterns that autonomous agents will encounter in production.
+The losses keep pace. A reported **$3.4 billion was stolen from crypto platforms in 2025.** Not from AI agents specifically — not yet. But [Anthropic's SCONE-bench research](https://red.anthropic.com/2025/smart-contracts/), which red-teamed frontier models against 405 smart contracts with known historical exploits, found **$550 million in simulated exploits** that AI agents could execute or be tricked into executing. These aren't theoretical attack surfaces. They're the exact patterns that autonomous agents will encounter in production.
 
 The collision course is obvious. More agents, more autonomy, more value at risk, zero pre-execution safety checks.
 
 ## The Clawdbot Problem
 
-In early 2026, an AI agent called @clawdbotatg deployed a smart contract to a public blockchain. No human audit. No review. The agent decided to deploy, constructed the contract, signed the transaction, and shipped it on-chain. Over 900 Clawdbot instances were later found running with no authentication and no evaluation layer.
+In early 2026, an AI agent called @clawdbotatg deployed a smart contract to a public blockchain. No human audit. No review. The agent decided to deploy, constructed the contract, signed the transaction, and shipped it on-chain.
 
-This isn't a cautionary tale from a research paper. It happened. An AI agent wrote and deployed immutable financial code with nobody checking whether the code was safe, correct, or even intentional.
+Separately — and this is a second incident, not the same one — security researchers later found **over 900 Clawdbot instances running exposed on the public internet** with no authentication and, of course, no evaluation layer between agent decision and agent action.
+
+Neither is a cautionary tale from a research paper. Both happened. An AI agent wrote and deployed immutable financial code with nobody checking whether the code was safe, correct, or even intentional — and hundreds of similar agents were reachable by anyone who found them.
 
 Now scale that to 250,000 agents. Now add real money.
 

--- a/docs/blog/devto/README.md
+++ b/docs/blog/devto/README.md
@@ -1,0 +1,14 @@
+# Dev.to syndication snapshots
+
+These files are **frozen copies of what was actually published to Dev.to** (with
+`canonical_url` pointing back at iris-eval.com). They are a historical record of
+the syndicated posts, not living documents:
+
+- **Do not update them** when the canonical posts under `docs/blog/` change —
+  the mirror's job is to record what went out, drift and all.
+- New corrections happen on the canonical post (with an editor's note per the
+  house style), and — if worth propagating — as an edit on Dev.to itself,
+  after which the snapshot here may be refreshed to match what is live there.
+
+The hardcoded-claim scanner allow-lists stale counts in this directory for
+exactly this reason (see `scripts/claims/allow-list.json`).

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -654,7 +654,7 @@ import { registerHipaaRules } from './rules/hipaa.js';
 const engine = new EvalEngine(0.8);
 registerHipaaRules(engine);
 
-// Safety evals now include the 3 built-in safety rules + 2 HIPAA rules
+// Safety evals now include the 4 built-in safety rules + 2 HIPAA rules
 ```
 
 ### Pattern: Rule Package as a Config Array

--- a/docs/launch/demo-script.md
+++ b/docs/launch/demo-script.md
@@ -1,5 +1,7 @@
 # Iris Demo Recording Script
 
+> **📁 Historical launch artifact (v0.1 era, March 2026).** Tool/rule counts and script beats reflect that release (3 MCP tools, 12 rules). Kept for record — a re-recording must be rebuilt against the current `.claims.json` surface (9 tools, 13 rules).
+
 Target length: 3-4 minutes. Screen recording with narration. Terminal on the left, browser on the right (split screen for dashboard sections).
 
 ---

--- a/docs/launch/directory-listing-template.md
+++ b/docs/launch/directory-listing-template.md
@@ -2,6 +2,7 @@
 
 Use these when submitting Iris to any MCP directory, awesome list, or marketplace.
 Copy-paste the appropriate version and customize if needed.
+**Refreshed 2026-07-07 against `.claims.json` (v0.4.4).** Before any submission, re-check the Key Stats against the current claims file.
 
 ---
 
@@ -15,14 +16,14 @@ Iris is an MCP server that any agent discovers and uses automatically — no SDK
 
 ## Long Description (paragraph)
 
-Iris is the first MCP-native eval and observability tool for AI agents. It registers as an MCP server that your agents discover automatically through the protocol — no SDK imports, no decorators, no code changes. Add one line to your MCP config and every agent starts logging hierarchical traces, evaluating output quality (PII detection, prompt injection, hallucination markers, cost thresholds), and tracking per-trace costs in USD. Self-hosted with a single SQLite file. Real-time dark-mode dashboard. Works with Claude Desktop, Cursor, Windsurf, or any MCP-compatible agent. Open-source core, MIT licensed.
+Iris is the agent eval standard for MCP — an MCP-native eval and observability tool for AI agents. It registers as an MCP server that your agents discover automatically through the protocol — no SDK imports, no decorators, no code changes. Add one line to your MCP config and every agent starts logging hierarchical traces, evaluating output quality (10 PII patterns, 13 prompt-injection patterns, 17 hallucination markers, cost thresholds), verifying citations, and tracking per-trace costs in USD. LLM-as-judge included (BYOK, five templates). Self-hosted with a single SQLite file. Real-time dashboard. OpenTelemetry export. Works with Claude Desktop, Claude Code, Cursor, Windsurf, or any MCP-compatible agent. Open-source core, MIT licensed.
 
 ## Config Snippet (include in every listing)
 
 ```json
 {
   "mcpServers": {
-    "iris": {
+    "iris-eval": {
       "command": "npx",
       "args": ["-y", "@iris-eval/mcp-server"]
     }
@@ -32,11 +33,12 @@ Iris is the first MCP-native eval and observability tool for AI agents. It regis
 
 ## Key Stats (for listings that show features)
 
-- 3 MCP tools: log_trace, evaluate_output, get_traces
-- 12 built-in eval rules across 4 categories
-- <1ms eval latency (heuristic, not LLM-as-Judge)
+- 9 MCP tools: log_trace, evaluate_output, get_traces, list_rules, deploy_rule, delete_rule, delete_trace, evaluate_with_llm_judge, verify_citations
+- 13 built-in eval rules across 4 categories
+- <1ms eval latency (heuristic layer; LLM-as-judge optional, BYOK)
 - 0 lines of code to integrate
 - SQLite storage — zero infrastructure
+- OpenTelemetry OTLP export
 - MIT licensed
 
 ## Links

--- a/docs/launch/mcp-community-post.md
+++ b/docs/launch/mcp-community-post.md
@@ -1,5 +1,7 @@
 # MCP Discord / Community Post
 
+> **📁 Historical launch artifact (v0.1 era, March 2026).** Version, tool counts, and the "first MCP-native" framing reflect the original launch copy. Kept for record — do not repost without a full refresh against `.claims.json` and the current positioning ("the agent eval standard for MCP", no "first" superlative).
+
 ---
 
 ## Iris: First MCP-Native Eval & Observability Server

--- a/docs/launch/reddit-posts.md
+++ b/docs/launch/reddit-posts.md
@@ -1,5 +1,7 @@
 # Reddit Post Drafts
 
+> **📁 Historical launch drafts (mixed eras).** The r/LocalLLaMA draft is v0.1-era (3 tools, 12 rules, 5 injection patterns); the r/MachineLearning draft was refreshed later (9 tools, 13 rules). Do not post either without a full refresh against `.claims.json`.
+
 ---
 
 ## r/LocalLLaMA

--- a/docs/launch/show-hn-draft.md
+++ b/docs/launch/show-hn-draft.md
@@ -1,5 +1,7 @@
 # Show HN Draft
 
+> **📁 Historical template (v0.1 era, March 2026).** Counts and the "first MCP-native" framing reflect that release. The real Show HN (Branch-B primary narrative moment, date TBD by founder) must be composed fresh against `.claims.json` and current positioning — this file is reference only.
+
 ## Title
 
 Show HN: Iris — first MCP-native eval and observability tool for AI agents

--- a/docs/launch/twitter-thread.md
+++ b/docs/launch/twitter-thread.md
@@ -1,5 +1,7 @@
 # Twitter/X Launch Thread
 
+> **📁 Historical launch artifact (v0.1 era, March 2026).** Counts and the "first MCP-native" framing reflect the original launch. Kept for record — do not repost without a full refresh against `.claims.json` and current positioning.
+
 > **Note:** X posts have a 280-character limit (free tier) or 25,000 (Premium). Drafts below were trimmed to fit before publishing. Keep future drafts within limits.
 
 ---

--- a/docs/otel-integration.md
+++ b/docs/otel-integration.md
@@ -52,7 +52,7 @@ configured to accept HTTP and forward to gRPC. This keeps Iris's dependency surf
 
 Each Iris trace becomes one OTLP `ResourceSpans` entry with:
 
-- **Resource attributes**: `service.name`, `telemetry.sdk.name=iris-mcp`, `telemetry.sdk.language=nodejs`, `telemetry.sdk.version=0.4.0`
+- **Resource attributes**: `service.name`, `telemetry.sdk.name=iris-mcp`, `telemetry.sdk.language=nodejs`, `telemetry.sdk.version=<running release>` (sourced from `package.json` at runtime)
 - **Scope**: `iris.trace.v1`
 - **Spans**: either the `spans[]` tree you sent (hierarchical), or a synthesized root span built from trace-level fields when no span tree is present
 

--- a/docs/sdk-spec.md
+++ b/docs/sdk-spec.md
@@ -1,6 +1,6 @@
 # `@iris-eval/client` — SDK Specification
 
-> **Status:** spec for v0.4 — D4 lock per `plans/master-plan/think-risk-decision-register.md` Tier A Wave 2 — A7. Implementation ships in v0.4.0 (target 2026-06-09).
+> **Status:** spec final; **implementation not yet shipped** (deferred out of v0.4.0 at release scope-cut — see the roadmap). The MCP-native path below remains the supported install today.
 >
 > **Why this exists:** Iris's primary install path is MCP-native — the MCP server runs as a subprocess and any MCP-aware client (Claude Code, Cursor, Windsurf, Continue, Cline, Zed, custom MCP clients) discovers it. That's the right fit for hosted agents. Teams building **custom agents** in TypeScript, however, hit MCP's process-boundary cost on every call. UAT evidence (`memory/iris_first_live_testing.md`: a 249-line ad-hoc bridge a customer wrote because the MCP path was too slow for their high-volume real-time loop) makes the case directly: an in-process SDK is the right shape for that use case.
 
@@ -24,7 +24,7 @@ import { Iris } from '@iris-eval/client';
 
 const iris = new Iris({
   database: './iris.db',                 // or: shared SQLite path with the MCP server's deployment
-  rules: ['completeness', 'safety-pii', 'cost-budget'], // subset; default = all 12
+  rules: ['completeness', 'safety-pii', 'cost-budget'], // subset; default = all 13
   customRules: [],                       // optional: Zod-validated custom rules
 });
 
@@ -73,7 +73,7 @@ interface IrisOpts {
   /** Path to the SQLite database. Created if missing. Shared with the MCP server's install when set to the same path. */
   database: string;
 
-  /** Subset of built-in rules to enable. Default: all 12. */
+  /** Subset of built-in rules to enable. Default: all 13. */
   rules?: BuiltInRuleId[];
 
   /** Custom Zod-validated rule definitions. */

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -10,7 +10,7 @@
 npx @iris-eval/init claude-code      # install for Claude Code
 npx @iris-eval/init cursor           # install for Cursor
 npx @iris-eval/init windsurf         # install for Windsurf
-npx @iris-eval/init continue         # install for Continue
+npx @iris-eval/init zed              # install for Zed
 ```
 
 After install, **restart your client**. The next agent call gets scored by Iris.
@@ -23,14 +23,13 @@ npx @iris-eval/init --help                       # full help
 npx @iris-eval/init <client> --uninstall         # remove the iris entry from <client>
 ```
 
-## Supported clients (Phase 1)
+## Supported clients (all ten)
 
-- **Claude Code** → writes to `~/.claude/mcp.json`
-- **Cursor** → writes to `~/.cursor/mcp.json`
-- **Windsurf** → writes to `~/.codeium/windsurf/mcp_config.json`
-- **Continue** → writes to `~/.continue/config.json` (preserves your `models`, `customCommands`, etc.)
+`claude-code` · `claude-desktop` · `cursor` · `windsurf` · `continue` · `vscode` · `cline` · `zed` · `codex` · `gemini`
 
-Phase 2 will add Raycast, Zed, and Cline. Phase 3 will add MCP-spec-driven auto-detection for any unrecognized client.
+Each client gets its config written to the correct OS-specific path (e.g. Claude Code → `~/.claude/mcp.json`, Windsurf → `~/.codeium/windsurf/mcp_config.json`, Zed → `settings.json` `context_servers`), preserving every entry you already have. Run `npx @iris-eval/init --list` to see which clients are detected on your machine.
+
+A future release adds MCP-spec-driven auto-detection for unrecognized clients.
 
 For per-client install docs, friction notes, and troubleshooting, see [iris-eval.com/docs/clients](https://iris-eval.com/docs/clients).
 

--- a/scripts/claims/allow-list.json
+++ b/scripts/claims/allow-list.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Explicit exemptions for the hardcoded-claims scanner. Each entry justifies why a literal stays uncovered. As surfaces migrate to ~/lib/claims reader imports, entries here are removed.",
+  "$comment": "Explicit exemptions for the hardcoded-claims scanner. Each entry justifies why a match stays uncovered. Prefer line: '*' scoped to a pattern for FROZEN historical files (line pins shift and break — see PR #245/#246); use line pins only for active files where the exemption must stay surgical. As surfaces migrate to ~/lib/claims reader imports (code) or get refreshed to current truth (prose), entries here are removed.",
   "entries": [
     {
       "file": "CHANGELOG.md",
@@ -26,28 +26,16 @@
       "reason": "Generator regex source — not a real test-count claim."
     },
     {
-      "file": "docs/launch/directory-listing-template.md",
+      "file": "docs/roadmap.md",
       "pattern": "mcp-tool-count",
-      "line": 35,
-      "reason": "Historical launch copy describing the v0.1 surface (3 tools); template kept for reference."
-    },
-    {
-      "file": "docs/launch/show-hn-draft.md",
-      "pattern": "mcp-tool-count",
-      "line": 15,
-      "reason": "Historical Show HN draft from v0.1 era (3 tools); kept for reference, not for re-publication."
+      "line": "*",
+      "reason": "Roadmap sections are versioned snapshots by design (v0.1 = 3 tools). Current-state claims are truthbase-driven elsewhere."
     },
     {
       "file": "docs/roadmap.md",
-      "pattern": "mcp-tool-count",
-      "line": 15,
-      "reason": "Historical v0.1 milestone description (3 tools); roadmap deliberately preserves per-version state."
-    },
-    {
-      "file": "docs/roadmap.md",
-      "pattern": "mcp-tool-count",
-      "line": 73,
-      "reason": "Per-version v0.4 description matches the released surface; roadmap entries are versioned snapshots, not derived counts. Migration candidate when roadmap renders from generator."
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Roadmap sections are versioned snapshots by design (v0.1 = 12 rules; v0.3.1 documents the 12→13 expansion)."
     },
     {
       "file": "docs/v0.4.1-candidates.md",
@@ -56,16 +44,82 @@
       "reason": "Hypothetical scenario reference (372 tests was current at write-time). Migration candidate when v0.4.1 ships."
     },
     {
-      "file": "website/src/components/cloud.tsx",
+      "file": "website/src/components/roadmap.tsx",
       "pattern": "mcp-tool-count",
-      "line": 17,
-      "reason": "Migration candidate — currently accurate (9 tools); reader migration deferred to follow-on PR alongside other website component sweeps."
+      "line": "*",
+      "reason": "Every row is a per-version historical snapshot (v0.1 = 3 tools, v0.4 = 9); wiring live counts into history would rewrite it."
     },
     {
       "file": "website/src/components/roadmap.tsx",
+      "pattern": "pii-pattern-count",
+      "line": "*",
+      "reason": "v0.3.1 row documents the pattern expansion as shipped then (10 PII) — historical row, correct as-of-version."
+    },
+    {
+      "file": "website/src/components/roadmap.tsx",
+      "pattern": "injection-pattern-count",
+      "line": "*",
+      "reason": "v0.3.1 row documents the pattern expansion as shipped then (13 injection) — historical row, correct as-of-version."
+    },
+    {
+      "file": "docs/launch/demo-script.md",
       "pattern": "mcp-tool-count",
-      "line": 11,
-      "reason": "Migration candidate — currently accurate (9 tools); roadmap component will absorb the migration when render-from-generator lands."
+      "line": "*",
+      "reason": "Frozen v0.1-era launch artifact with an in-file historical banner; not for reuse without full refresh."
+    },
+    {
+      "file": "docs/launch/demo-script.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Frozen v0.1-era launch artifact with an in-file historical banner; not for reuse without full refresh."
+    },
+    {
+      "file": "docs/launch/mcp-community-post.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Frozen v0.1-era launch artifact with an in-file historical banner; not for reuse without full refresh."
+    },
+    {
+      "file": "docs/launch/show-hn-draft.md",
+      "pattern": "mcp-tool-count",
+      "line": "*",
+      "reason": "Frozen v0.1-era template with an in-file historical banner; the real Show HN gets composed fresh."
+    },
+    {
+      "file": "docs/launch/show-hn-draft.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Frozen v0.1-era template with an in-file historical banner; the real Show HN gets composed fresh."
+    },
+    {
+      "file": "docs/launch/reddit-posts.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Frozen mixed-era launch drafts with an in-file historical banner; not for posting without full refresh."
+    },
+    {
+      "file": "docs/launch/reddit-posts.md",
+      "pattern": "injection-pattern-count",
+      "line": "*",
+      "reason": "Frozen mixed-era launch drafts with an in-file historical banner (v0.1 shipped 5 injection patterns)."
+    },
+    {
+      "file": "docs/launch/twitter-thread.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Frozen v0.1-era launch artifact with an in-file historical banner; not for reposting without full refresh."
+    },
+    {
+      "file": "docs/blog/devto/007-evaluate-without-llm.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Dev.to syndication snapshot — records what was actually published there (v0.1 era). Canonical post at docs/blog/ is kept current instead."
+    },
+    {
+      "file": "docs/blog/devto/heuristic-vs-semantic-eval.md",
+      "pattern": "builtin-rule-count",
+      "line": "*",
+      "reason": "Dev.to syndication snapshot — records what was actually published there (v0.1 era). Canonical post at docs/blog/ is kept current instead."
     }
   ]
 }

--- a/scripts/claims/check-no-hardcoded.mjs
+++ b/scripts/claims/check-no-hardcoded.mjs
@@ -7,9 +7,13 @@
 //
 // Run via: npm run claims:check
 //
-// Scope: src/, website/src/, dashboard/src/, docs/, README.md, server.json,
-//        CHANGELOG.md (CHANGELOG entries are historical past-tense and are
-//        always allow-listed via the per-pattern :history: tag).
+// Two enforcement modes per match (2026-07-07 upgrade — the 12/14/18 pattern
+// counts survived for months in surfaces this scanner never walked):
+//   - CODE files (.ts/.tsx/.js/.jsx/.mjs): a match ALWAYS flags — code must
+//     import the truthbase reader, not restate numbers.
+//   - PROSE files (.md/.mdx/.txt/.json/.html): a match flags only when the
+//     number disagrees with .claims.json — prose may state the truth, and
+//     the moment the truth changes, every stale restatement lights up.
 
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { resolve, dirname, relative, sep } from 'node:path';
@@ -18,7 +22,17 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..', '..');
 
-const SCAN_DIRS = ['src', 'website/src', 'dashboard/src', 'docs', 'packages/langchain/src'];
+const SCAN_DIRS = [
+  'src',
+  'website/src',
+  'website/public',
+  'dashboard/src',
+  'docs',
+  'packages/langchain/src',
+  'packages/init',
+  'claude-plugin',
+  'skills',
+];
 const SCAN_FILES = ['README.md', 'server.json'];
 const SKIP_DIR_NAMES = new Set([
   'node_modules',
@@ -33,21 +47,51 @@ const SKIP_DIR_NAMES = new Set([
 ]);
 
 // Patterns to flag. Each has a name + regex + suggested fix message.
-//
-// Patterns are intentionally conservative for v1 — we want low false-positive
-// rate on the first ship. As the truthbase reader gets adopted across
-// surfaces, we add stricter patterns and remove the corresponding allow-list
-// entries.
+// `expected(claims)` returns the set of truthful values for the captured
+// number — prose matches inside that set pass; everything else flags.
+// Patterns without `expected` flag every match (value-free patterns).
 const PATTERNS = [
   {
     name: 'test-count',
     re: /\b(\d{2,5})\s+tests?\b/g,
+    expected: c => [
+      c.tests?.vitestRoot?.total,
+      c.tests?.vitestDashboard?.total,
+      c.tests?.integration?.total,
+      c.tests?.playwrightE2E?.total,
+      c.tests?.totalCombined,
+    ],
     fix: 'Import TEST_COUNT_VITEST_ROOT (or _DASHBOARD / _INTEGRATION / _TOTAL) from ~/lib/claims',
   },
   {
     name: 'mcp-tool-count',
     re: /\b(\d{1,2})\s+MCP\s+tools?\b/gi,
+    expected: c => [c.mcpTools?.count],
     fix: 'Import MCP_TOOL_COUNT from ~/lib/claims',
+  },
+  {
+    name: 'builtin-rule-count',
+    re: /\b(\d{1,2})\s+(?:built-?in|heuristic)\s+(?:eval\s+|deterministic\s+)?rules\b/gi,
+    expected: c => [c.evalRules?.builtInCount],
+    fix: 'Import BUILT_IN_RULE_COUNT from ~/lib/claims (or state the current count from .claims.json)',
+  },
+  {
+    name: 'pii-pattern-count',
+    re: /\b(\d{1,2})\s+PII\s+patterns\b/gi,
+    expected: c => [c.evalRules?.piiPatterns],
+    fix: 'Import PII_PATTERN_COUNT from ~/lib/claims (or state the current count from .claims.json)',
+  },
+  {
+    name: 'injection-pattern-count',
+    re: /\b(\d{1,2})\s+(?:prompt[- ])?injection\s+patterns\b/gi,
+    expected: c => [c.evalRules?.injectionPatterns],
+    fix: 'Import INJECTION_PATTERN_COUNT from ~/lib/claims (or state the current count from .claims.json)',
+  },
+  {
+    name: 'hallucination-marker-count',
+    re: /\b(\d{1,2})\s+hallucination\s+markers\b/gi,
+    expected: c => [c.evalRules?.hallucinationMarkers],
+    fix: 'Import HALLUCINATION_MARKER_COUNT from ~/lib/claims (or state the current count from .claims.json)',
   },
   {
     name: 'iris-version-literal',
@@ -55,6 +99,8 @@ const PATTERNS = [
     fix: 'Use VERSION_MCP_SERVER from ~/lib/claims (do not hardcode JSON-LD softwareVersion)',
   },
 ];
+
+const CODE_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs']);
 
 const ALLOW_LIST_PATH = resolve(root, 'scripts/claims/allow-list.json');
 
@@ -90,7 +136,18 @@ const SCAN_EXTS = new Set([
   '.md', '.mdx',
   '.json',
   '.html',
+  '.txt',
 ]);
+
+// CODE files must import the truthbase reader — any match flags. PROSE files
+// may restate the truth — a match flags only when the number is wrong.
+function matchFlags(pattern, m, relPath, claims) {
+  const ext = relPath.slice(relPath.lastIndexOf('.'));
+  if (CODE_EXTS.has(ext) || !pattern.expected || !claims) return true;
+  const captured = Number(m[1]);
+  const truthful = pattern.expected(claims).filter(v => typeof v === 'number');
+  return truthful.length === 0 || !truthful.includes(captured);
+}
 
 function fileShouldScan(path) {
   const ext = path.slice(path.lastIndexOf('.'));
@@ -107,6 +164,12 @@ function lineNumber(text, index) {
 
 async function main() {
   const allowList = await loadAllowList();
+  let claims = null;
+  try {
+    claims = JSON.parse(await readFile(resolve(root, '.claims.json'), 'utf-8'));
+  } catch {
+    console.warn('[claims:check-no-hardcoded] WARN — .claims.json unreadable; prose value-checks degrade to strict mode');
+  }
   const findings = [];
 
   // Walk scan dirs
@@ -125,6 +188,7 @@ async function main() {
         pattern.re.lastIndex = 0;
         let m;
         while ((m = pattern.re.exec(text)) !== null) {
+          if (!matchFlags(pattern, m, rel, claims)) continue;
           const line = lineNumber(text, m.index);
           const lineText = text.slice(text.lastIndexOf('\n', m.index) + 1, text.indexOf('\n', m.index)).trim();
           const allowed = allowList.entries.some(
@@ -147,6 +211,7 @@ async function main() {
         pattern.re.lastIndex = 0;
         let m;
         while ((m = pattern.re.exec(text)) !== null) {
+          if (!matchFlags(pattern, m, f, claims)) continue;
           const line = lineNumber(text, m.index);
           const lineText = text.slice(text.lastIndexOf('\n', m.index) + 1, text.indexOf('\n', m.index)).trim();
           const allowed = allowList.entries.some(

--- a/skills/iris-eval/SKILL.md
+++ b/skills/iris-eval/SKILL.md
@@ -9,15 +9,18 @@ metadata:
 
 # Iris — The Agent Eval Standard for MCP
 
-Iris is an MCP server that scores every agent output for quality, safety, and cost. 12 built-in deterministic eval rules. No LLM-as-judge. No SDK. No code changes.
+Iris is an MCP server for agent evaluation: it scores output quality, catches
+safety failures, and enforces cost budgets. Nine MCP tools, 13 built-in
+deterministic rules, optional LLM-as-judge (BYOK). No SDK. No code changes.
 
 ## When to Use
 
 - An agent returned output and you want to verify its quality
-- You need to check agent responses for PII leaks (credit cards, SSNs, emails)
+- You need to check agent responses for PII leaks (10 patterns: SSN, credit card, phone, email, IBAN, passport, DOB, medical record number, IP address, API key)
 - You want to track per-execution costs and flag expensive runs
 - You need to compare agent quality across different prompts or models
 - You want automated eval rules running on every agent execution
+- You need semantic judgment (LLM-as-judge) or citation verification on top of the heuristics
 
 ## Quick Start
 
@@ -30,7 +33,7 @@ Or add to your MCP config:
 ```json
 {
   "mcpServers": {
-    "iris": {
+    "iris-eval": {
       "command": "npx",
       "args": ["-y", "@iris-eval/mcp-server"]
     }
@@ -38,61 +41,59 @@ Or add to your MCP config:
 }
 ```
 
-## Available Tools
+## The Nine Tools
 
-### log_trace
-Log an agent execution trace with spans, tool calls, and metrics.
-
-**Use when:** You want to record what an agent did for later analysis.
-
-### evaluate_output
-Evaluate agent output quality using 12 built-in deterministic rules across 4 categories:
-- **Completeness** — is the response thorough and relevant?
-- **Relevance** — does the output address the prompt?
-- **Safety** — PII detection, prompt injection patterns, hallucination markers
-- **Cost** — token usage, execution cost, budget threshold checks
-
-**Use when:** You want a quality score for any agent response.
-
-### get_traces
-Query stored traces with filters, pagination, and summary statistics.
-
-**Use when:** You want to review past agent executions or track quality trends over time.
+| Tool | What it does |
+|------|--------------|
+| `log_trace` | Record an agent execution — spans, tool calls, token usage, cost. Optional OTLP export via `IRIS_OTEL_ENDPOINT`. |
+| `evaluate_output` | Score output against the 13 built-in rules. Heuristic, deterministic, free. |
+| `get_traces` | Query stored traces with filters, pagination, time ranges. |
+| `list_rules` | Enumerate deployed custom eval rules. |
+| `deploy_rule` | Register a custom eval rule (Zod-validated) that fires on matching evaluations. |
+| `delete_rule` | Remove a deployed custom rule. |
+| `delete_trace` | Remove a single stored trace by ID. |
+| `evaluate_with_llm_judge` | Semantic eval via LLM (Anthropic or OpenAI). Five templates: accuracy, helpfulness, safety, correctness, faithfulness. Cost-capped, BYOK — Iris never proxies. |
+| `verify_citations` | Extract citations, fetch sources behind an SSRF-guarded resolver, judge whether each source supports the claim. |
 
 ## How to Interpret Scores
 
-- **Score 0.0 - 0.3:** Critical issues detected (PII leak, prompt injection, severe hallucination)
-- **Score 0.3 - 0.7:** Quality concerns (incomplete response, relevance issues, cost overrun)
-- **Score 0.7 - 1.0:** Good quality (all rules passing, within cost budget)
+- **Score 0.0 – 0.3:** Critical issues detected (PII leak, prompt injection, severe hallucination)
+- **Score 0.3 – 0.7:** Quality concerns (incomplete response, relevance issues, cost overrun)
+- **Score 0.7 – 1.0:** Good quality (all rules passing, within cost budget)
 
-Each rule fires independently with a clear pass/fail result. No opaque LLM scoring — every score is deterministic and reproducible.
+Each heuristic rule fires independently with a clear pass/fail result — every
+score is deterministic and reproducible. LLM-judge scores are semantic and
+carry the judge's reasoning.
 
-## 12 Built-in Eval Rules
+## The 13 Built-in Eval Rules
 
 | Category | Rule | What It Checks |
 |----------|------|---------------|
-| Completeness | topic_consistency | Output addresses the prompt topic |
-| Completeness | response_complete | Response is substantive, not truncated |
+| Completeness | non_empty_output | Output isn't empty or whitespace-only |
+| Completeness | min_output_length | Output meets a configurable minimum length |
+| Completeness | sentence_count | Output contains complete sentences |
 | Completeness | expected_coverage | Key expected elements are present |
-| Relevance | language_match | Output language matches input |
-| Relevance | output_format_valid | Structured output matches expected schema |
-| Relevance | sentiment_appropriate | Tone matches context |
-| Safety | no_pii | No credit cards, SSNs, phone numbers, emails leaked |
-| Safety | no_hallucination_markers | No fabricated citations, invented facts |
-| Safety | no_injection_patterns | No prompt injection attempts in output |
+| Relevance | keyword_overlap | Output vocabulary overlaps the input's |
+| Relevance | topic_consistency | Output stays on the prompt's topic |
+| Relevance | no_hallucination_markers | No hedging/fabrication markers (17 patterns) |
+| Safety | no_pii | No PII leaked (10 patterns) |
+| Safety | no_injection_patterns | No prompt-injection attempts (13 patterns) |
 | Safety | no_blocklist_words | No prohibited terms |
+| Safety | no_stub_output | No placeholder/stub markers (TODO, [INSERT, …) |
 | Cost | cost_under_threshold | Execution cost within budget |
-| Cost | latency_under_threshold | Response time within limits |
+| Cost | token_efficiency | Token usage proportionate to the output |
 
 ## Configuration
 
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
 | IRIS_API_KEY | (none) | API key for HTTP transport auth |
-| IRIS_DB_PATH | ./iris.db | SQLite database path |
+| IRIS_DB_PATH | ~/.iris/iris.db | SQLite database path |
 | IRIS_LOG_LEVEL | info | Logging verbosity |
-| IRIS_DASHBOARD | true | Enable real-time dashboard |
-| IRIS_PORT | 3001 | Dashboard port |
+| IRIS_DASHBOARD | (off) | Set `true` to enable the web dashboard |
+| IRIS_DASHBOARD_PORT | 6920 | Dashboard port |
+| IRIS_OTEL_ENDPOINT | (none) | OTLP/HTTP collector for trace export |
+| IRIS_ANTHROPIC_API_KEY / IRIS_OPENAI_API_KEY | (none) | BYOK for the LLM judge |
 
 ## Example Workflows
 
@@ -107,4 +108,4 @@ See the `examples/` directory for detailed walkthroughs:
 - Playground: https://iris-eval.com/playground
 - GitHub: https://github.com/iris-eval/mcp-server
 - npm: https://npmjs.com/package/@iris-eval/mcp-server
-- Glama: https://glama.ai/mcp/servers/iris-eval/mcp-server (AAA rated)
+- Full machine-readable reference: https://iris-eval.com/llms-full.txt

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,6 +14,10 @@ try {
   // Fallback if package.json isn't resolvable at runtime
 }
 
+// The single runtime source for the server's own version — import this
+// instead of hardcoding a literal (OTel resource attrs, health, banners).
+export const PKG_VERSION = pkgVersion;
+
 export const defaultConfig: IrisConfig = {
   storage: {
     type: 'sqlite',

--- a/src/otel/mapper.ts
+++ b/src/otel/mapper.ts
@@ -11,6 +11,7 @@
 // serializes these plain objects, and the payload shape is the OTLP spec.
 
 import type { Span, Trace, SpanKind } from '../types/trace.js';
+import { PKG_VERSION } from '../config/defaults.js';
 
 // OTel SpanKind enum values (from opentelemetry-proto/trace/v1/trace.proto).
 const KIND_MAP: Record<SpanKind, number> = {
@@ -165,7 +166,7 @@ export function buildExportPayload(traces: readonly Trace[], serviceName: string
       { key: 'service.name', value: { stringValue: serviceName } },
       { key: 'telemetry.sdk.name', value: { stringValue: 'iris-mcp' } },
       { key: 'telemetry.sdk.language', value: { stringValue: 'nodejs' } },
-      { key: 'telemetry.sdk.version', value: { stringValue: '0.4.0' } },
+      { key: 'telemetry.sdk.version', value: { stringValue: PKG_VERSION } },
     ],
   };
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Iris is an open-source MCP server that scores AI agent output quality, catches safety failures (PII leaks, prompt injection, hallucination markers), and enforces cost budgets. Any MCP-compatible agent or client discovers and uses it automatically — one command (`npx @iris-eval/mcp-server`), no SDK, no code changes. MIT-licensed core, self-hosted, signed releases.
 
-Iris registers 9 MCP tools (trace logging, heuristic eval, LLM-as-judge, semantic citation verification, rule lifecycle) and ships 13 built-in eval rules across completeness, relevance, safety, and cost. It works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Cline, Zed, Codex CLI, Gemini CLI, and any other MCP client.
+Iris registers 9 MCP tools (trace logging, heuristic eval, LLM-as-judge, semantic citation verification, rule lifecycle) and ships 13 built-in eval rules across completeness, relevance, safety, and cost. It works with Claude Desktop, Claude Code, Cursor, Windsurf, Continue, VS Code, Cline, Zed, Codex CLI, Gemini CLI, and any other MCP client.
 
 ## Getting Started
 

--- a/website/src/app/blog/[slug]/page.tsx
+++ b/website/src/app/blog/[slug]/page.tsx
@@ -103,7 +103,7 @@ export default async function BlogPost({
     "the-eval-gap": [
       {
         question: "What is the eval gap?",
-        answer: "The eval gap is the distance between having observability (knowing your agent ran) and having inline evaluation (knowing the output was correct). Industry data shows 89% of teams have observability but only 37% have inline eval, creating a 52-point gap where agents appear healthy on dashboards while silently delivering poor-quality outputs to users."
+        answer: "The eval gap is the distance between having observability (knowing your agent ran) and having inline evaluation (knowing the output was correct). A late-2025 LangChain survey of 1,340 practitioners found 89% of teams have observability but only 37% run evals on production traffic — a 52-point gap where agents appear healthy on dashboards while silently delivering poor-quality outputs to users."
       },
     ],
     "the-eval-loop": [

--- a/website/src/app/learn/agent-eval/page.tsx
+++ b/website/src/app/learn/agent-eval/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { RULE_COUNT_BUILT_IN } from "@/lib/claims";
 import { OG_IMAGE_URL } from "@/lib/og";
 import { SectionHeading } from "@/components/learn/section-heading";
 import { CalloutBox } from "@/components/learn/callout-box";
@@ -625,7 +626,7 @@ export default function AgentEvalGuide(): React.ReactElement {
               </pre>
 
               <p>
-                Iris provides nine MCP tools — full lifecycle plus semantic eval. Core: <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">log_trace</code> for recording agent executions, <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">evaluate_output</code> for scoring outputs against 13 built-in eval rules, and <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">get_traces</code> for querying historical data. Lifecycle: <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">list_rules</code> / <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">deploy_rule</code> / <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">delete_rule</code> / <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">delete_trace</code>. Semantic: <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">evaluate_with_llm_judge</code> (5 templates, cost-capped) and <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">verify_citations</code> (SSRF-guarded source fetch + per-claim verdict).
+                Iris provides nine MCP tools — full lifecycle plus semantic eval. Core: <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">log_trace</code> for recording agent executions, <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">evaluate_output</code> for scoring outputs against {RULE_COUNT_BUILT_IN} built-in eval rules, and <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">get_traces</code> for querying historical data. Lifecycle: <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">list_rules</code> / <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">deploy_rule</code> / <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">delete_rule</code> / <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">delete_trace</code>. Semantic: <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">evaluate_with_llm_judge</code> (5 templates, cost-capped) and <code className="rounded bg-bg-card px-1.5 py-0.5 font-mono text-[13px] text-iris-400">verify_citations</code> (SSRF-guarded source fetch + per-claim verdict).
               </p>
 
               <div className="mt-6 flex flex-col gap-3 sm:flex-row">

--- a/website/src/app/pricing/page.tsx
+++ b/website/src/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Nav } from "@/components/nav";
+import { RULE_COUNT_BUILT_IN } from "@/lib/claims";
 import { OG_IMAGE_URL } from "@/lib/og";
 import { Footer } from "@/components/footer";
 
@@ -48,7 +49,7 @@ const tiers: Tier[] = [
     },
     features: [
       "10,000 evaluations / month",
-      "All 13 built-in eval rules",
+      `All ${RULE_COUNT_BUILT_IN} built-in eval rules`,
       "Custom Zod rules (unlimited)",
       "Dashboard + playground",
       "stdio + HTTP transports",

--- a/website/src/app/security/page.tsx
+++ b/website/src/app/security/page.tsx
@@ -43,9 +43,9 @@ export default function Security(): React.ReactElement {
               home. There is no telemetry.
             </p>
             <p className="mt-3">
-              <strong className="text-text-primary">Cloud tier (v0.4+):</strong>{" "}
-              data is stored in a per-tenant logical partition in our managed
-              backend, which runs on hardened US-region infrastructure.
+              <strong className="text-text-primary">Cloud tier (planned, v0.5):</strong>{" "}
+              data will be stored in a per-tenant logical partition in a managed
+              backend running on hardened US-region infrastructure.
               Encryption at rest (AES-256) + encryption in transit (TLS 1.3)
               are table stakes. Cross-tenant isolation is enforced at four
               independent layers — see the architecture guide for the

--- a/website/src/components/cloud.tsx
+++ b/website/src/components/cloud.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { motion, useReducedMotion, useInView } from "framer-motion";
+import { MCP_TOOL_COUNT, RULE_COUNT_BUILT_IN } from "@/lib/claims";
 import { useRef } from "react";
 
 const TIERS = [
@@ -14,9 +15,9 @@ const TIERS = [
     cta: { label: "Get Started", href: "#open-source" },
     highlight: false,
     features: [
-      "9 MCP tools — full lifecycle + LLM judge + semantic citation verify (SSRF-guarded)",
+      `${MCP_TOOL_COUNT} MCP tools — full lifecycle + LLM judge + semantic citation verify (SSRF-guarded)`,
       "LLM-as-judge + citation verify use your own Anthropic/OpenAI API key (BYOK, no proxy)",
-      "13 built-in eval rules + custom rules",
+      `${RULE_COUNT_BUILT_IN} built-in eval rules + custom rules`,
       "Web dashboard with trace visualization",
       "SQLite storage — zero infrastructure",
       "Production security (auth, rate limiting)",
@@ -47,16 +48,16 @@ const TIERS = [
   {
     name: "Cloud Pro",
     badge: "Most Popular",
-    price: "$49",
-    period: "/month",
+    price: "$25",
+    period: "/month base + usage",
     description: "For teams that need shared eval results, alerting on quality regressions, and room to scale.",
     cta: { label: "Join Waitlist", href: "#waitlist" },
     highlight: true,
     coming: true,
     features: [
       "Everything in Starter, plus:",
-      "25,000 evaluations included",
-      "$0.005 per additional evaluation",
+      "100,000 evaluations included",
+      "$0.0005 per additional evaluation",
       "90-day eval history",
       "Unlimited team members",
       "Team dashboards with shared views",

--- a/website/src/components/customers.tsx
+++ b/website/src/components/customers.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion, useInView } from "framer-motion";
 import { useRef } from "react";
+import { RULE_COUNT_BUILT_IN } from "@/lib/claims";
 
 const USE_CASES = [
   {
@@ -31,8 +32,8 @@ const USE_CASES = [
   {
     audience: "Companies preventing PII leaks",
     problem: "Your agent leaked a Social Security number in its output and nobody noticed for 3 months.",
-    solution: "Iris evaluates every output against 13 built-in rules including PII detection across 10 patterns (SSN, credit card, phone, email, IBAN, DOB, medical record number, IP address, API key, passport), prompt injection (13 patterns), stub-output detection, and hallucination markers. Real-time, every trace.",
-    metric: "13",
+    solution: `Iris evaluates every output against ${RULE_COUNT_BUILT_IN} built-in rules including PII detection across 10 patterns (SSN, credit card, phone, email, IBAN, DOB, medical record number, IP address, API key, passport), prompt injection (13 patterns), stub-output detection, and hallucination markers. Real-time, every trace.`,
+    metric: String(RULE_COUNT_BUILT_IN),
     metricLabel: "built-in eval rules",
     icon: (
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/website/src/components/install.tsx
+++ b/website/src/components/install.tsx
@@ -59,7 +59,7 @@ export function Install(): React.ReactElement {
                 <code>
                   <span className="text-text-muted">$ </span><span className="text-text-primary">npm install -g @iris-eval/mcp-server</span>{"\n"}
                   <span className="text-text-muted">$ </span><span className="text-text-primary">iris-mcp --dashboard</span>{"\n"}
-                  <span className="text-eval-pass">✓ Dashboard running at http://localhost:3838</span>
+                  <span className="text-eval-pass">✓ Dashboard running at http://localhost:6920</span>
                 </code>
               </pre>
             </div>

--- a/website/src/components/playground/playground-data.ts
+++ b/website/src/components/playground/playground-data.ts
@@ -4,7 +4,9 @@
 // No API calls. Everything the playground needs lives here.
 // ---------------------------------------------------------------------------
 
-// ---- Rule definitions (all 12 Iris eval rules) ---------------------------
+// ---- Rule definitions (the 13 built-in Iris eval rules) ------------------
+// Names mirror src/eval/rules exactly — the playground must never show a
+// rule the product doesn't ship.
 
 export interface RuleResult {
   name: string;
@@ -16,16 +18,17 @@ export interface RuleResult {
 export const RULE_NAMES = [
   "topic_consistency",
   "expected_coverage",
-  "response_complete",
+  "keyword_overlap",
+  "non_empty_output",
+  "min_output_length",
+  "sentence_count",
+  "no_stub_output",
   "no_hallucination_markers",
   "no_blocklist_words",
   "no_pii",
   "no_injection_patterns",
-  "sentiment_appropriate",
-  "language_match",
-  "output_format_valid",
   "cost_under_threshold",
-  "latency_under_threshold",
+  "token_efficiency",
 ] as const;
 
 export type RuleName = (typeof RULE_NAMES)[number];
@@ -227,12 +230,13 @@ export interface RuleBreakdown {
 
 export const RULE_BREAKDOWN: RuleBreakdown[] = [
   { rule: "no_blocklist_words", passRate: 1.0 },
-  { rule: "language_match", passRate: 0.99 },
-  { rule: "output_format_valid", passRate: 0.98 },
-  { rule: "sentiment_appropriate", passRate: 0.97 },
-  { rule: "latency_under_threshold", passRate: 0.95 },
+  { rule: "sentence_count", passRate: 0.99 },
+  { rule: "no_stub_output", passRate: 0.98 },
+  { rule: "min_output_length", passRate: 0.97 },
+  { rule: "token_efficiency", passRate: 0.95 },
   { rule: "no_injection_patterns", passRate: 0.94 },
-  { rule: "response_complete", passRate: 0.91 },
+  { rule: "non_empty_output", passRate: 0.91 },
+  { rule: "keyword_overlap", passRate: 0.9 },
   { rule: "no_pii", passRate: 0.89 },
   { rule: "no_hallucination_markers", passRate: 0.85 },
   { rule: "cost_under_threshold", passRate: 0.82 },

--- a/website/src/components/product-tabs.tsx
+++ b/website/src/components/product-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { RULE_COUNT_BUILT_IN } from "@/lib/claims";
 import * as Tabs from "@radix-ui/react-tabs";
 
 const EVAL_ROWS = [
@@ -144,7 +145,7 @@ export function ProductTabs(): React.ReactElement {
             <div className="grid items-start gap-10 lg:grid-cols-2 lg:gap-16">
               <div className="lg:py-4">
                 <h3 className="font-display text-2xl font-bold text-text-primary md:text-3xl">
-                  13 built-in rules across 4 categories.
+                  {RULE_COUNT_BUILT_IN} built-in rules across 4 categories.
                 </h3>
                 <p className="mt-4 text-[16px] leading-relaxed text-text-secondary">
                   <code className="rounded-md border border-border-default bg-bg-surface px-2 py-0.5 font-mono text-[13px] text-text-accent">evaluate_output</code>{" "}


### PR DESCRIPTION
Completes **Phase E (claims alignment)** — the last open phase of the 10→100 sprint plan — via a two-agent exhaustive sweep of every content surface against `.claims.json`, plus the structural scanner upgrade that explains why none of this was CI-visible.

## Highest-severity fixes
- **The shipped Claude Code plugin skill still said 12/14/18** (`claude-plugin/skills/agent-eval/SKILL.md`) — the exact D3 truthbase bug, alive in a surface the scanner never walked. Now 10/13/17.
- **`skills/iris-eval/SKILL.md` documented a product that doesn't exist**: 3 tools, a 12-rule table with five fictional rule names (`response_complete`, `sentiment_appropriate`, `language_match`, `output_format_valid`, `latency_under_threshold`), wrong ports/defaults, 'No LLM-as-judge'. Rewritten against the real surface.
- **Security page advertised the unshipped cloud tier in present tense** ('Cloud tier (v0.4+): data **is stored** in our managed backend') → planned v0.5, future tense.
- **Homepage vs /pricing Pro-tier self-contradiction** ($49/25K evals/$0.005 vs $25/100K/$0.0005) → reconciled to the /pricing canon.
- **Playground demo data used 5 fictional rule names** → real 13 (playground is core product).
- **`packages/init` README said 4 clients, 'Phase 2 will add Zed/Cline'** → ships 10 incl. both; fixed before the pending npm publish.
- **Two source-level version leaks**: OTel exporter emitted `telemetry.sdk.version 0.4.0` from a literal → package.json-sourced `PKG_VERSION`; dashboard chrome hardcoded `VERSION '0.4.0'` ×2 → build-time Vite defines from root package.json + .claims.json.

## Published-blog corrections (house-style editor's notes on each)
005 (12→13 rules, Safety 3→4, no_pii 4→10 patterns, judge shipped) · 007 (12→13, 3→9 tools) · 003 (tools) · 009 (OTel future→shipped) · 002 ('first MCP-native' superlative retired for the standard positioning; 97M+ hedged as reported) · 011 (uncited $14,200 stat dropped; 37% phrasing standardized to the LangChain survey wording) · 008 (repo URL) · 026 (S18 GRC items: SCONE-bench multi-model + source link, the two Clawdbot incidents un-conflated, adoption stats hedged) · FAQPage JSON-LD now names the LangChain survey.

## Scanner upgrade (the structural close)
- **Scan dirs extended**: `claude-plugin/`, `skills/`, `packages/init/`, `website/public/` (+ `.txt`) — the plugin bundle, llms files, and init README were never scanned.
- **Value-checked prose / strict code**: prose matches flag only when the number disagrees with `.claims.json` (so every stale restatement lights up the moment truth changes); code matches always flag (must import the reader). New patterns: built-in rule count + PII/injection/hallucination pattern counts.
- **7 code surfaces migrated to readers** (5 website incl. both long-standing allow-list 'migration candidates'; 2 dashboard via defines).
- **Allow-list rebuilt**: line-pins on frozen files → pattern-scoped `'*'` entries (line-pins shift and break — the #245 lesson), dead entries removed, launch docs get in-file historical banners, the active-use directory-listing template refreshed to current stats, devto snapshots documented as frozen syndication records (new README).

## Verification
- Root: tsc clean, 434/434
- Dashboard: typecheck + lint + 111/111 (defines active in vitest too)
- Website: production build green
- `claims:check` green; extended `claims:check-hardcoded` green (21 findings driven to zero: 7 reader migrations, 5 prose fixes, principled exemptions for frozen history)

## Known debt — deliberately NOT in this PR
26 pre-existing website lint errors (mostly `no-html-link-for-pages` + 3 setState-in-effect) that no CI job runs — discovered when an earlier pipe masked the lint exit code. Follow-up PR fixes them and wires website lint into CI so the gate exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)