### PR TITLE
chore(website): erase the 26-error lint debt + add the missing website CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,22 @@ jobs:
       - run: npm ci
       - run: npm run test:integration
 
+  # The website previously had NO CI gate at all — Vercel builds it without
+  # linting, and 26 lint errors accumulated invisibly (found 2026-07-07).
+  # This job makes website lint + typecheck a first-class check.
+  website-lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - run: cd website && npm ci
+      - run: cd website && npm run lint
+      - run: cd website && npx tsc --noEmit
+
   build:
     runs-on: ubuntu-latest
     needs: [lint-and-typecheck, test]

--- a/website/src/app/blog/[slug]/page.tsx
+++ b/website/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { OG_IMAGE_URL } from "@/lib/og";
 import ReactMarkdown from "react-markdown";
@@ -161,13 +162,13 @@ export default async function BlogPost({
       <article className="mx-auto max-w-3xl px-6 pb-16 pt-32 lg:pt-40">
         {/* Header */}
         <div className="mb-10">
-          <a
+          <Link
             href="/blog"
             className="inline-flex items-center gap-1.5 text-[13px] text-text-muted transition-colors hover:text-text-accent"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
             All posts
-          </a>
+          </Link>
           <h1 className="mt-6 font-display text-3xl font-extrabold tracking-tight text-text-primary md:text-4xl lg:text-5xl">
             {post.title}
           </h1>
@@ -227,12 +228,12 @@ export default async function BlogPost({
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
               Get Started
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-6 py-3 text-[14px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </article>

--- a/website/src/app/compare/arize/page.tsx
+++ b/website/src/app/compare/arize/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -276,12 +277,12 @@ export default function CompareArize(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/braintrust/page.tsx
+++ b/website/src/app/compare/braintrust/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -273,12 +274,12 @@ export default function CompareBraintrust(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/confident-ai/page.tsx
+++ b/website/src/app/compare/confident-ai/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -265,12 +266,12 @@ export default function CompareConfidentAI(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/deepeval/page.tsx
+++ b/website/src/app/compare/deepeval/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -157,7 +158,7 @@ export default function CompareDeepeval(): React.ReactElement {
             If you want every production output scored automatically, Iris. If
             you want deep semantic evaluation in your test pipeline, DeepEval.
             <p className="mt-4 text-[13px] text-text-muted">
-              For background on heuristic vs semantic evaluation, see our <a href="/blog/heuristic-vs-semantic-eval" className="text-iris-400 hover:text-iris-300 transition-colors">evaluation methodology guide</a>.
+              For background on heuristic vs semantic evaluation, see our <Link href="/blog/heuristic-vs-semantic-eval" className="text-iris-400 hover:text-iris-300 transition-colors">evaluation methodology guide</Link>.
             </p>
           </div>
         </div>
@@ -269,12 +270,12 @@ export default function CompareDeepeval(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/helicone/page.tsx
+++ b/website/src/app/compare/helicone/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -270,12 +271,12 @@ export default function CompareHelicone(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/langfuse/page.tsx
+++ b/website/src/app/compare/langfuse/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -282,12 +283,12 @@ export default function CompareLangfuse(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/langsmith/page.tsx
+++ b/website/src/app/compare/langsmith/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -272,12 +273,12 @@ export default function CompareLangsmith(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/compare/patronus-ai/page.tsx
+++ b/website/src/app/compare/patronus-ai/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { Footer } from "@/components/footer";
 import { IrisLogo } from "@/components/iris-logo";
@@ -266,12 +267,12 @@ export default function ComparePatronusAI(): React.ReactElement {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
               Try Iris
             </a>
-            <a
+            <Link
               href="/#waitlist"
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Join Cloud Waitlist
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/website/src/app/pricing/page.tsx
+++ b/website/src/app/pricing/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { RULE_COUNT_BUILT_IN } from "@/lib/claims";
 import { OG_IMAGE_URL } from "@/lib/og";
@@ -152,12 +153,12 @@ export default function PricingPage(): React.ReactElement {
           >
             Start with the Free tier &rarr;
           </a>
-          <a
+          <Link
             href="/#waitlist"
             className="rounded-lg border border-border-subtle bg-bg-base px-6 py-3 text-sm font-semibold text-text-primary transition-colors hover:bg-border-subtle"
           >
             Join Cloud Starter waitlist &rarr;
-          </a>
+          </Link>
         </div>
       </section>
 

--- a/website/src/components/animated-counter.tsx
+++ b/website/src/components/animated-counter.tsx
@@ -22,11 +22,9 @@ export function AnimatedCounter({
   const [display, setDisplay] = useState(0);
 
   useEffect(() => {
-    if (!inView) return;
-    if (reduce) {
-      setDisplay(value);
-      return;
-    }
+    // Reduced-motion renders the final value directly (derived below) — the
+    // rAF loop only runs for animated counting.
+    if (!inView || reduce) return;
 
     let start: number | null = null;
     const step = (ts: number): void => {
@@ -39,9 +37,10 @@ export function AnimatedCounter({
     requestAnimationFrame(step);
   }, [inView, value, duration, reduce]);
 
+  const shown = reduce ? value : display;
   const formatted = decimals !== undefined
-    ? display.toFixed(decimals)
-    : Math.round(display).toLocaleString();
+    ? shown.toFixed(decimals)
+    : Math.round(shown).toLocaleString();
 
   return (
     <span ref={ref}>

--- a/website/src/components/nav.tsx
+++ b/website/src/components/nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { useTheme } from "./theme-provider";
 import { IrisLogo } from "./iris-logo";
 import { MCP_TOOL_COUNT, VERSION_MCP_SERVER } from "@/lib/claims";
@@ -40,10 +41,10 @@ export function Nav(): React.ReactElement {
 
       <header className={`sticky top-0 z-40 transition-all duration-300 ${scrolled ? "border-b border-border-subtle bg-bg-base/80 backdrop-blur-xl" : "bg-transparent"}`}>
         <nav className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8" aria-label="Primary">
-          <a href="/" className="flex items-center gap-2.5">
+          <Link href="/" className="flex items-center gap-2.5">
             <IrisLogo size={30} />
             <span className="font-display text-[22px] font-bold tracking-tight text-text-primary">Iris</span>
-          </a>
+          </Link>
 
           <div className="hidden items-center gap-1 md:flex">
             {NAV_LINKS.map((l) => (
@@ -60,7 +61,7 @@ export function Nav(): React.ReactElement {
               )}
             </button>
             <a href="https://github.com/iris-eval/mcp-server" target="_blank" rel="noopener noreferrer" className="rounded-lg px-4 py-2 text-[14px] font-medium text-text-secondary transition-colors hover:bg-border-subtle hover:text-text-primary">GitHub</a>
-            <a href="/#open-source" className="rounded-lg bg-iris-600 px-5 py-2.5 text-[14px] font-semibold text-white shadow-sm shadow-iris-600/20 transition-all hover:bg-iris-500">Get Started</a>
+            <Link href="/#open-source" className="rounded-lg bg-iris-600 px-5 py-2.5 text-[14px] font-semibold text-white shadow-sm shadow-iris-600/20 transition-all hover:bg-iris-500">Get Started</Link>
           </div>
 
           <button onClick={() => setMobileOpen(!mobileOpen)} className="rounded-lg p-2 text-text-secondary md:hidden" aria-label="Toggle menu" aria-expanded={mobileOpen}>
@@ -80,7 +81,7 @@ export function Nav(): React.ReactElement {
                 <button onClick={toggle} className="rounded-lg px-4 py-3 text-left text-[15px] text-text-secondary hover:bg-border-subtle">
                   {theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
                 </button>
-                <a href="/#open-source" onClick={() => setMobileOpen(false)} className="rounded-lg bg-iris-600 px-5 py-3 text-center text-[15px] font-semibold text-white">Get Started</a>
+                <Link href="/#open-source" onClick={() => setMobileOpen(false)} className="rounded-lg bg-iris-600 px-5 py-3 text-center text-[15px] font-semibold text-white">Get Started</Link>
               </div>
             </div>
           </div>

--- a/website/src/components/playground/act-three.tsx
+++ b/website/src/components/playground/act-three.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 import { EvalScoreGauge } from "./eval-score-gauge";
 import { TrendChartSvg } from "./trend-chart-svg";
@@ -293,12 +294,12 @@ export function ActThree({ track }: { track: (event: string, data?: Record<strin
               >
                 <p className="text-[12px] text-text-muted">
                   Want to share eval results with your team?{" "}
-                  <a
+                  <Link
                     href="/#pricing"
                     className="text-text-accent transition-colors hover:text-iris-300"
                   >
                     Cloud team dashboards coming soon →
-                  </a>
+                  </Link>
                 </p>
               </motion.div>
             </div>

--- a/website/src/components/playground/live-playground.tsx
+++ b/website/src/components/playground/live-playground.tsx
@@ -231,7 +231,7 @@ export function LivePlayground(): React.ReactElement {
           </p>
           {!result && !error && !loading && (
             <div className="rounded-lg border border-dashed border-border-default bg-bg-surface/50 p-8 text-center text-text-muted">
-              Paste output + click "Run evaluation" to see rule results here.
+              Paste output + click &ldquo;Run evaluation&rdquo; to see rule results here.
             </div>
           )}
           {error && (

--- a/website/src/components/playground/playground-cta.tsx
+++ b/website/src/components/playground/playground-cta.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 import { SCENARIOS } from "./playground-data";
 
@@ -126,13 +127,13 @@ export function PlaygroundCta({ session, track }: { session: PlaygroundSession; 
             >
               Star on GitHub
             </a>
-            <a
+            <Link
               href="/#pricing"
               onClick={() => track("cta_clicked", { target: "pricing" })}
               className="inline-flex items-center rounded-xl border border-border-default px-8 py-4 text-[15px] font-semibold text-text-secondary transition-all hover:border-border-glow hover:text-text-primary"
             >
               Managed hosting?
-            </a>
+            </Link>
           </div>
 
           {/* Social proof */}

--- a/website/src/components/playground/playground-shell.tsx
+++ b/website/src/components/playground/playground-shell.tsx
@@ -43,6 +43,9 @@ export function PlaygroundShell() {
   useEffect(() => {
     track("playground_loaded");
     const prev = localStorage.getItem("iris-playground-best");
+    // Mount-time sync from localStorage — SSR renders without a best score
+    // and hydrates it in; a lazy initializer would mismatch server HTML.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (prev) setPreviousBest(parseInt(prev));
   }, [track]);
 

--- a/website/src/components/playground/timing-comparison.tsx
+++ b/website/src/components/playground/timing-comparison.tsx
@@ -14,14 +14,10 @@ export function TimingComparison({ humanSeconds }: TimingComparisonProps) {
   const startedRef = useRef(false);
 
   useEffect(() => {
-    if (startedRef.current) return;
+    // Reduced-motion renders the final numbers directly (derived below) —
+    // the rAF count-up only runs for the animated path.
+    if (startedRef.current || reduce) return;
     startedRef.current = true;
-
-    if (reduce) {
-      setHumanDisplay(humanSeconds);
-      setHumanDone(true);
-      return;
-    }
 
     let start: number | null = null;
     const duration = 1500; // 1.5s to count up
@@ -40,6 +36,8 @@ export function TimingComparison({ humanSeconds }: TimingComparisonProps) {
     requestAnimationFrame(step);
   }, [humanSeconds, reduce]);
 
+  const shownHuman = reduce ? humanSeconds : humanDisplay;
+  const done = reduce || humanDone;
   const speedMultiplier = Math.round(humanSeconds / 0.003);
 
   return (
@@ -51,7 +49,7 @@ export function TimingComparison({ humanSeconds }: TimingComparisonProps) {
             Human Reviewer
           </div>
           <div className="mt-2 font-mono text-3xl font-bold tabular-nums text-text-primary">
-            {humanDisplay}
+            {shownHuman}
             <span className="text-lg text-text-muted">s</span>
           </div>
           <div className="mt-1 text-[12px] text-text-muted">Manual review</div>
@@ -70,9 +68,9 @@ export function TimingComparison({ humanSeconds }: TimingComparisonProps) {
           <motion.div
             className="mt-2 font-mono text-3xl font-bold tabular-nums text-text-accent"
             initial={reduce ? {} : { opacity: 0, scale: 0.5 }}
-            animate={humanDone ? { opacity: 1, scale: 1 } : {}}
+            animate={done ? { opacity: 1, scale: 1 } : {}}
             transition={{ type: "spring", stiffness: 300, damping: 20 }}
-            style={!humanDone && !reduce ? { opacity: 0 } : undefined}
+            style={!done ? { opacity: 0 } : undefined}
           >
             0.003
             <span className="text-lg text-text-muted">s</span>

--- a/website/src/components/playground/use-playground-analytics.ts
+++ b/website/src/components/playground/use-playground-analytics.ts
@@ -8,8 +8,10 @@ export function usePlaygroundAnalytics() {
   const track = useCallback((event: string, data?: Record<string, string | number>) => {
     if (tracked.current.has(event)) return;
     tracked.current.add(event);
-    if (typeof window !== "undefined" && (window as any).va) {
-      (window as any).va("event", { name: event, ...data });
+    if (typeof window === "undefined") return;
+    const va = (window as Window & { va?: (kind: string, payload: Record<string, unknown>) => void }).va;
+    if (va) {
+      va("event", { name: event, ...data });
     }
   }, []);
 

--- a/website/src/components/research.tsx
+++ b/website/src/components/research.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 const PUBS = [
   {
     type: "Report",
@@ -60,10 +62,10 @@ export function Research(): React.ReactElement {
         </div>
 
         <div className="mt-10 text-center">
-          <a href="/blog" className="inline-flex items-center gap-1.5 text-[14px] font-semibold text-text-accent transition-colors hover:text-iris-400">
+          <Link href="/blog" className="inline-flex items-center gap-1.5 text-[14px] font-semibold text-text-accent transition-colors hover:text-iris-400">
             View all posts
             <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
-          </a>
+          </Link>
         </div>
 
         {/* Survey */}

--- a/website/src/components/theme-provider.tsx
+++ b/website/src/components/theme-provider.tsx
@@ -28,6 +28,11 @@ export function ThemeProvider({
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    // Mount-time sync from localStorage/matchMedia. SSR must render the
+    // default theme and swap after hydration — a lazy initializer reading
+    // localStorage would mismatch the server HTML. The sync setState here
+    // is deliberate; the rule's cascading-render cost is one swap on mount.
+    /* eslint-disable react-hooks/set-state-in-effect */
     const stored = localStorage.getItem("iris-theme") as Theme | null;
     if (stored) {
       setTheme(stored);
@@ -35,6 +40,7 @@ export function ThemeProvider({
       setTheme("light");
     }
     setMounted(true);
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Follow-up promised in #248's 'known debt' section.

## The gap
The website had **no CI gate at all**: `lint-and-typecheck` runs the root workspace, `lighthouse` targets the dashboard, and Vercel builds without linting. 26 lint errors accumulated invisibly — surfaced during the S54 exhaust pass when a piped exit code was caught masking the local gate.

## Fixes (all 26 → 0)
- **18× `no-html-link-for-pages`**: internal `<a>` → `<Link>` from `next/link` across nav, blog, pricing, all 8 compare pages, playground CTAs, research (props/onClick preserved verbatim).
- **2× `no-unescaped-entities`**: live-playground quotes → `&ldquo;…&rdquo;`.
- **2× `no-explicit-any`**: `window.va` typed properly in the analytics hook.
- **4× `react-hooks/set-state-in-effect`**, split by what's actually right:
  - `animated-counter` + `timing-comparison`: the reduced-motion path now **derives the final value at render** instead of setState-in-effect — strictly better (reduced-motion users see the number on first paint, no post-mount swap).
  - `theme-provider` + `playground-shell`: the mount-time localStorage sync is the canonical SSR-safe pattern (a lazy initializer reading localStorage would mismatch server HTML) — kept, with narrowly-scoped justified disables.

## The gate
New CI job **`website-lint-and-typecheck`** (`npm ci` + `eslint` + `tsc --noEmit` in `website/`) so this class can never accumulate invisibly again. Website tsc was verified clean before wiring.

## Verification
- `npm run lint` exit 0 (checked unpiped)
- `npx tsc --noEmit` clean
- production build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)