### PR TITLE
chore(ci): pin npm in release workflows instead of installing @latest

### DIFF
--- a/.github/workflows/release-init.yml
+++ b/.github/workflows/release-init.yml
@@ -38,9 +38,13 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
       # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      # Pinned to an exact version, not `@latest`: a release job that installs
+      # whatever npm publishes at tag-time takes an untested (and unreviewable)
+      # supply-chain dependency on the npm CLI right before it publishes with
+      # our OIDC identity. Bump deliberately; keep it >= 11.5.1.
       - name: Upgrade npm for Trusted Publishing (OIDC, >= 11.5.1)
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.19.0
           npm --version
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,13 @@ jobs:
       # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x.
       # Without this upgrade `npm publish` cannot perform the OIDC token exchange
       # and — with NPM_TOKEN now gone — would fail auth outright.
+      # Pinned to an exact version, not `@latest`: a release job that installs
+      # whatever npm publishes at tag-time takes an untested (and unreviewable)
+      # supply-chain dependency on the npm CLI right before it publishes with
+      # our OIDC identity. Bump deliberately; keep it >= 11.5.1.
       - name: Upgrade npm for Trusted Publishing (OIDC, >= 11.5.1)
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.19.0
           npm --version
       - run: npm ci
       - run: npm run clean


### PR DESCRIPTION
## Summary

Closes OpenSSF Scorecard code-scanning alert **#48** (`PinnedDependenciesID`, medium) — *"npmCommand not pinned by hash"* at `release-init.yml:43`.

Both release workflows ran `npm install -g npm@latest` immediately before `npm publish --provenance`. That takes an **unreviewable supply-chain dependency on the npm CLI at tag time**, in the one job that wields our OIDC publishing identity. If a bad npm release ever landed, it would execute inside the publish job.

Scorecard flagged only `release-init.yml:43`, but `release.yml:69` had the **identical** command on the main package's release path. Fixing only the flagged line would have left the same defect on the more important workflow, so both are pinned.

## Version choice

Pinned to **`npm@11.19.0`** — the latest 11.x, satisfying the documented `>= 11.5.1` floor required for OIDC Trusted Publishing.

Deliberately **not** `12.0.2` (current `latest`): these workflows fire only on `v*` / `init-v*` tags, so they cannot be exercised without cutting a real release. A major-version npm bump on an untestable publish path is the wrong risk to absorb for a lint finding. Bump to 12.x separately, when a release is actually being cut and the output can be watched.

`npm install -g @lhci/cli@0.15.0` in `lighthouse.yml` was already pinned — no change needed.

## Risk

Low. The diff is comments plus a version string inside an existing `run: |` block; no YAML structure changes, no job/step/permission changes. Nothing in this PR executes until a release tag is pushed.

> ⚠️ **CI note:** opened during a GitHub-wide [Actions outage](https://www.githubstatus.com) (*"Incident with Actions"*, impact **critical**). Checks may fail at the *"Set up job"* step with `Service Unavailable` for reasons unrelated to this change. Re-run once Actions recovers: `gh run rerun <id> --failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)