### PR TITLE
fix(dashboard): bump react-router-dom to 7.18.2 — closes 4 of 5 advisories

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -21,7 +21,7 @@
         "lucide-react": "^1.14.0",
         "react": "^19.0.0",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.17.0",
+        "react-router-dom": "^7.18.2",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -6050,9 +6050,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6072,12 +6072,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -28,7 +28,7 @@
     "lucide-react": "^1.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.17.0",
+    "react-router-dom": "^7.18.2",
     "recharts": "^3.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why this needed a hand-written PR

**Dependabot never proposed it.** `react-router` is transitive under `react-router-dom`, so the fix requires bumping the *parent* — and no PR existed while the backlog was deadlocked. These 5 alerts were the single largest remaining cluster after the drain.

## Closes 4 of 5

All four are patched in `7.18.0`:

| Advisory | Severity | Vulnerable range |
|---|---|---|
| GHSA-chx6-hx7r-mcp5 | high | `>= 7.0.0, < 7.18.0` |
| GHSA-337j-9hxr-rhxg | medium | `>= 6.4.0, < 7.18.0` |
| GHSA-h8fp-f39c-q6mh | medium | `>= 7.11.0, < 7.18.0` |
| GHSA-wrjc-x8rr-h8h6 | medium | `>= 6.0.0, < 7.18.0` |

## Deliberately NOT closed — needs a founder call

**GHSA-qwww-vcr4-c8h2 (high)** is only patched in **react-router 8.3.0** (vulnerable `>= 7.12.0, < 8.3.0`). No 7.x release fixes it.

Reaching it means a **major upgrade to React Router v8** with breaking routing-API changes across the dashboard. That is a code migration, not a version bump, and the wrong thing to land unsupervised inside a security drain. It stays open **deliberately and visibly** rather than being silently rolled into a dependency PR — it needs its own PR, its own testing, and a decision from you.

## Lockfile provenance

Regenerated under **Linux (WSL)** with `--package-lock-only`.

I first ran `npm install` on Windows to verify the upgrade, and it pruned the `@emnapi` entries **20 → 15** — the Session-28 rolldown trap, reproduced again on the dashboard tree. That lockfile was discarded and regenerated on Linux. Verified after: `@emnapi` back at **20**, **zero** package entries removed vs `main`.

## Verification

Exactly what the `lint-and-typecheck` job runs for the dashboard:

| Check | Result |
|---|---|
| `npm run typecheck` | exit 0 |
| `npm run lint` | exit 0 |
| `npm test` | **111/111 passing** (21 files) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)