### PR TITLE
fix(dashboard): override ws to ^8.21.0 (GHSA-96hv-2xvq-fx4p)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -7121,9 +7121,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -54,6 +54,7 @@
     "vitest": "^4.1.1"
   },
   "overrides": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary

Closes **GHSA-96hv-2xvq-fx4p** (high) — the last remaining alert fixable without a major-version migration.

`ws@8.20.0` arrives transitively under `storybook@10.4.3` (dev-only, exercised by the `build-storybook` CI step). The advisory is patched in `8.21.0`; the override resolves to **8.21.3** — an in-major bump with no API change.

Transitive with no direct dependency to bump, so `overrides` is the correct lever, matching the pattern used at root.

## Lockfile provenance

Regenerated under **Linux (WSL)** with `--package-lock-only`. Verified: `@emnapi` entries still **20**, **zero** package entries removed vs `main`, and the *only* lockfile change is the `ws` version/resolved/integrity triple.

Verified with `npm ci` (which never rewrites the lockfile) rather than `npm install`, since `npm install` on Windows prunes the Linux-only `@emnapi` entries.

## Verification

| Check | Result |
|---|---|
| `npm ci` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run lint` | exit 0 |
| `npm test` | **111/111 passing** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)