### PR TITLE
fix(transport): MCP HTTP transport had no Origin validation (DNS rebinding)

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-07T16:06:04.113Z",
-  "generatedFromCommit": "602e162",
+  "generatedAt": "2026-08-07T16:28:40.527Z",
+  "generatedFromCommit": "d0b2519",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 577,
+    "totalCombined": 581,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 453,
-      "total": 453
+      "passed": 457,
+      "total": 457
     }
   },
   "version": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,9 @@ Environment variables (CLI flags take precedence):
   IRIS_DASHBOARD                       true to enable web dashboard
   IRIS_DASHBOARD_PORT                  Dashboard port (1-65535, default: 6920)
   IRIS_API_KEY                         API key for HTTP authentication
-  IRIS_ALLOWED_ORIGINS                 Comma-separated CORS origin allowlist
+  IRIS_ALLOWED_ORIGINS                 Comma-separated origin allowlist. Dashboard: CORS headers (supports globs, e.g. http://localhost:*).
+                                       HTTP transport: exact-match Origin allowlist for DNS-rebinding protection (globs ignored;
+                                       this server's own loopback origins are always allowed).
   IRIS_NO_AUTO_LAUNCH                  Set to 1 to disable first-run dashboard auto-launch
   IRIS_ANTHROPIC_API_KEY               Required by evaluate_with_llm_judge + verify_citations (provider=anthropic)
   IRIS_OPENAI_API_KEY                  Required by evaluate_with_llm_judge + verify_citations (provider=openai)

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -42,7 +42,80 @@ export async function createHttpTransport(
   // Authentication
   app.use(createAuthMiddleware(config));
 
-  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => crypto.randomUUID() });
+  /*
+   * DNS-rebinding protection (MCP spec: servers MUST validate Origin on
+   * HTTP transports; when local, SHOULD bind loopback).
+   *
+   * iris bound loopback but validated nothing, and `security.apiKey` is
+   * undefined by default — so `createAuthMiddleware` is a pass-through. A
+   * default `--transport http` server was therefore reachable from any web
+   * page the operator visited: the page resolves an attacker-controlled
+   * hostname to 127.0.0.1, the browser treats it as same-origin, and the
+   * request carries no credentials to be missing. That exposes traces and
+   * eval history and allows rule deployment.
+   *
+   * Origin validation is the fix, and it is safe to switch on by default
+   * because the SDK only rejects when an Origin header is PRESENT (see
+   * validateRequestHeaders). Real MCP clients — Claude Desktop, Cursor, the
+   * CLI — send none, so they are unaffected; browsers always do.
+   *
+   * Host validation is applied only when bound to loopback. Binding
+   * elsewhere is a deliberate network deployment that usually sits behind a
+   * proxy rewriting Host, and an exact-match list would break it — the case
+   * where the operator has already taken ownership of the boundary.
+   */
+  const isLoopbackBind =
+    config.transport.host === '127.0.0.1' ||
+    config.transport.host === 'localhost' ||
+    config.transport.host === '::1';
+
+  /*
+   * Bind FIRST, then build the allowlists from the port actually bound.
+   * `config.transport.port` is 0 when the caller wants an ephemeral port
+   * (tests and embedders do this), and the OS then picks something else —
+   * so allowlists derived from the configured value would contain
+   * `127.0.0.1:0` and reject every real request with a 403 that looks
+   * exactly like an attack. Routes are registered immediately after, and
+   * the port is not discoverable by any client until this function returns.
+   */
+  const httpServer = await new Promise<Server>((resolve) => {
+    const server = app.listen(config.transport.port, config.transport.host, () => resolve(server));
+  });
+  const address = httpServer.address();
+  const port = typeof address === 'object' && address ? address.port : config.transport.port;
+
+  const loopbackOrigins = [
+    `http://127.0.0.1:${port}`,
+    `http://localhost:${port}`,
+    `http://[::1]:${port}`,
+  ];
+  /*
+   * The SDK matches origins EXACTLY (`allowedOrigins.includes(origin)`),
+   * while iris's own CORS allowlist accepts glob patterns like the shipped
+   * default `http://localhost:*`. A pattern entry can never match here, so
+   * it is dropped rather than passed through to sit in the list looking
+   * effective. The concrete loopback origins added above already express
+   * what `http://localhost:*` means for this server's port.
+   *
+   * Note this rejection is what actually stops the attack. Emitting CORS
+   * headers would not: the browser only withholds the RESPONSE, after the
+   * server has already executed the request — so a rebound page could still
+   * deploy rules or delete traces and simply not read the reply.
+   */
+  const configuredOrigins = (config.security.allowedOrigins ?? []).filter(
+    (origin) => !origin.includes('*'),
+  );
+  const allowedOrigins = [...new Set([...loopbackOrigins, ...configuredOrigins])];
+  const allowedHosts = isLoopbackBind
+    ? [`127.0.0.1:${port}`, `localhost:${port}`, `[::1]:${port}`]
+    : undefined;
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+    enableDnsRebindingProtection: true,
+    allowedOrigins,
+    ...(allowedHosts ? { allowedHosts } : {}),
+  });
 
   // Rate limiter for MCP POST/DELETE (not GET — SSE streaming)
   const mcpLimiter = createMcpRateLimiter(config);
@@ -61,10 +134,6 @@ export async function createHttpTransport(
 
   // Error handler (must be last)
   app.use(createErrorHandler(logger));
-
-  const httpServer = await new Promise<Server>((resolve) => {
-    const server = app.listen(config.transport.port, config.transport.host, () => resolve(server));
-  });
 
   return { transport, httpServer };
 }

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import type { Server } from 'node:http';
+import { request as httpRequest } from 'node:http';
 import { SqliteAdapter } from '../../src/storage/sqlite-adapter.js';
 import { createDashboardServer } from '../../src/dashboard/server.js';
+import { createHttpTransport } from '../../src/transport/http.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { defaultConfig } from '../../src/config/defaults.js';
 
 const testConfig = {
@@ -14,6 +17,120 @@ const mockLogger = {
   warn: () => {},
   error: () => {},
 };
+
+/*
+ * DNS-rebinding protection on the MCP HTTP transport.
+ *
+ * The MCP spec requires servers to validate Origin on HTTP transports.
+ * iris bound loopback but validated nothing, and security.apiKey is
+ * undefined by default (auth middleware is then a pass-through) — so a
+ * default `--transport http` server was reachable from any web page the
+ * operator visited, via a hostname rebound to 127.0.0.1.
+ *
+ * Verified against the unpatched build: an `initialize` carrying
+ * `Origin: https://evil.example.com` returned 200 and executed. It must
+ * now be refused, WITHOUT breaking real MCP clients — which send no Origin
+ * header at all, and which the SDK therefore never rejects.
+ */
+describe('MCP HTTP transport — DNS rebinding protection', () => {
+  let httpServer: Server | undefined;
+
+  afterEach(async () => {
+    if (httpServer) {
+      // A successful MCP session leaves a keep-alive connection open, and
+      // server.close() waits for every socket to drain — which never happens
+      // here, so teardown would hang past the hook timeout. Drop the sockets
+      // first; nothing in these tests needs a graceful close.
+      httpServer.closeAllConnections?.();
+      await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+      httpServer = undefined;
+    }
+  });
+
+  async function bootTransport() {
+    const mcpServer = new McpServer({ name: 'iris-eval-test', version: '0.0.0' });
+    const cfg = {
+      ...defaultConfig,
+      transport: { ...defaultConfig.transport, host: '127.0.0.1', port: 0 },
+    };
+    const { httpServer: server } = await createHttpTransport(mcpServer, cfg, mockLogger);
+    httpServer = server;
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  const initBody = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '1' },
+    },
+  };
+
+  function post(base: string, headers: Record<string, string>) {
+    return fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...headers,
+      },
+      body: JSON.stringify(initBody),
+    });
+  }
+
+  it('rejects a cross-origin request (the rebinding attack)', async () => {
+    const base = await bootTransport();
+    const res = await post(base, { origin: 'https://evil.example.com' });
+    expect(res.status).toBe(403);
+  });
+
+  it('allows a real MCP client, which sends no Origin header', async () => {
+    const base = await bootTransport();
+    const res = await post(base, {});
+    expect(res.status).toBe(200);
+  });
+
+  it('allows a browser request from the server own origin', async () => {
+    const base = await bootTransport();
+    const res = await post(base, { origin: base });
+    expect(res.status).toBe(200);
+  });
+
+  // Uses node:http rather than fetch: Host is a forbidden header name, so
+  // fetch silently drops an override and the request would arrive with the
+  // real Host — passing the assertion for the wrong reason.
+  it('rejects a forged Host header when bound to loopback', async () => {
+    const base = await bootTransport();
+    const port = Number(new URL(base).port);
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest(
+        {
+          host: '127.0.0.1',
+          port,
+          path: '/mcp',
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            host: 'evil.example.com',
+          },
+        },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on('error', reject);
+      req.end(JSON.stringify(initBody));
+    });
+    expect(status).toBe(403);
+  });
+});
 
 describe('HTTP Transport Integration', () => {
   let httpServer: Server | undefined;


### PR DESCRIPTION
## The gap

The MCP spec requires servers to **validate `Origin` on HTTP transports** and to bind loopback when local. iris did the second and **none of the first**.

Combined with `security.apiKey` being `undefined` by default — which makes `createAuthMiddleware` a pass-through — a default `--transport http` server was reachable from **any web page the operator happened to visit**. The page resolves an attacker-controlled hostname to `127.0.0.1`, the browser treats it as same-origin, and there are no credentials to be missing.

Impact: read traces and eval history, deploy rules, delete traces.

## Reproduced, then fixed

Verified with **one fresh server per probe** — a shared stateful transport returns `400 "already initialized"` on a second `initialize`, which is easy to mistake for a security rejection (my first harness did exactly that):

| Request | Before | After |
|---|---|---|
| `Origin: https://evil.example.com` | **200 — executed** | **403** |
| No Origin (real MCP client) | 200 | 200 |
| Same-origin browser | 200 | 200 |
| Forged `Host` | accepted | 403 |

## Why this is safe to enable by default

The SDK only rejects when an Origin header is **present**. Real MCP clients — Claude Desktop, Cursor, the CLI — send none, and I verified they still return 200.

**Host** validation is applied **only on a loopback bind**. Binding elsewhere is a deliberate network deployment, usually behind a proxy that rewrites `Host`, where an exact-match list would break a boundary the operator already owns.

## Two things this surfaced

- **`IRIS_ALLOWED_ORIGINS` was advertised in `--help` but never reached the MCP transport** — it was wired only into the dashboard server. It now feeds the transport allowlist too, and the help text states what each surface does with it.
- The shipped default is the glob `http://localhost:*`, but the SDK matches **exactly**. Glob entries are filtered out rather than passed through to sit in the list looking effective; the server's concrete loopback origins are always allowed, which is what that pattern meant.

## CORS headers would not have fixed this

A browser only withholds the **response** — after the server has already executed the request. A rebound page could still deploy a rule or delete traces and simply not read the reply. **Server-side rejection is the control.**

## An ordering bug the new tests caught

Allowlists were built from `config.transport.port`, but that is `0` when the caller wants an ephemeral port (tests and embedders do this) — so the OS picks a different port and **every real request got a 403 indistinguishable from an attack**. The server now binds first and derives the allowlists from the port actually bound.

## Tests: 453 → 457

Attack rejected · Origin-less client allowed · same-origin allowed · forged `Host` rejected.

That last one uses `node:http` rather than `fetch`: `Host` is a forbidden header name, so `fetch` silently drops an override and a fetch-based assertion would have passed for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)