### PR TITLE
test: gate that every published rule-config example actually deploys

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-07T16:28:40.527Z",
-  "generatedFromCommit": "d0b2519",
+  "generatedAt": "2026-08-07T16:46:22.993Z",
+  "generatedFromCommit": "0ead8d6",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 581,
+    "totalCombined": 633,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 457,
-      "total": 457
+      "passed": 509,
+      "total": 509
     }
   },
   "version": {

--- a/tests/integration/doc-examples-valid.test.ts
+++ b/tests/integration/doc-examples-valid.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createCustomRuleStore } from '../../src/custom-rule-store.js';
+import { LOCAL_TENANT } from '../../src/types/tenant.js';
+
+/*
+ * Every custom-rule config example we publish must actually deploy.
+ *
+ * This exists because it did not hold. `docs/api-reference.md` taught
+ * `config: { "min": 40 }` and the `deploy_rule` tool description taught
+ * `config.min` / `config.max_usd`, while the evaluator read
+ * `config.min_length` / `config.max_cost`. Deploy-time validation accepted
+ * any object, so a rule built from our own documentation deployed cleanly
+ * and then failed on every single evaluation, forever — silently dragging
+ * down aggregate scores with no sign the RULE was the broken part.
+ *
+ * Numeric claims already have a gate (check-product-claims / claims:check).
+ * Nothing checked that our *examples* were runnable. This closes that gap:
+ * if someone edits a doc example into something the schema rejects, or
+ * changes the schema out from under the docs, this fails.
+ */
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+// Files that teach users how to write a rule definition.
+const DOC_SOURCES = [
+  'docs/api-reference.md',
+  'docs/custom-rules.md',
+  'examples/http-transport/README.md',
+  'examples/http-transport/client.ts',
+  'src/tools/deploy-rule.ts',
+];
+
+interface FoundExample {
+  source: string;
+  type: string;
+  config: Record<string, unknown>;
+  raw: string;
+}
+
+/**
+ * Pull `"type": "x", "config": { ... }` pairs out of prose/code. Deliberately
+ * simple: it only matches a config object with no nested braces, which covers
+ * every example we currently ship. If a future example nests an object the
+ * matcher skips it rather than guessing — a miss is safe, a wrong parse is not.
+ */
+function extractExamples(source: string, text: string): FoundExample[] {
+  const out: FoundExample[] = [];
+  const patterns = [
+    /["']?type["']?\s*:\s*["']([a-z_]+)["']\s*,\s*["']?config["']?\s*:\s*(\{[^{}]*\})/g,
+  ];
+  for (const re of patterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const type = m[1];
+      const rawConfig = m[2];
+      // Normalise JS-ish object literals to JSON: quote bare keys, swap
+      // single quotes. Skip anything still unparseable.
+      let jsonish = rawConfig
+        .replace(/([{,]\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:/g, '$1"$2":')
+        .replace(/'/g, '"');
+      // Trailing commas
+      jsonish = jsonish.replace(/,\s*}/g, '}');
+      let config: Record<string, unknown>;
+      try {
+        config = JSON.parse(jsonish);
+      } catch {
+        continue;
+      }
+      out.push({ source, type, config, raw: `${m[0]}` });
+    }
+  }
+  return out;
+}
+
+describe('published rule-config examples are deployable', () => {
+  const examples: FoundExample[] = [];
+  for (const rel of DOC_SOURCES) {
+    const abs = join(REPO_ROOT, rel);
+    if (!existsSync(abs)) continue;
+    examples.push(...extractExamples(rel, readFileSync(abs, 'utf-8')));
+  }
+
+  it('finds rule examples to check (guards against the matcher silently breaking)', () => {
+    expect(examples.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(examples.map((e) => [`${e.source} :: ${e.type} ${JSON.stringify(e.config)}`, e] as const))(
+    'deploys %s',
+    (_label, example) => {
+      const dir = mkdtempSync(join(tmpdir(), 'iris-docex-'));
+      try {
+        const store = createCustomRuleStore({
+          pathFor: () => join(dir, 'custom-rules.json'),
+          auditPath: join(dir, 'audit.log'),
+        });
+        expect(() =>
+          store.deploy(LOCAL_TENANT, {
+            name: `doc-example-${example.type}`,
+            description: 'from published documentation',
+            evalType: 'custom',
+            severity: 'medium',
+            definition: {
+              name: `doc-example-${example.type}`,
+              type: example.type,
+              config: example.config,
+            },
+          } as Parameters<typeof store.deploy>[1]),
+        ).not.toThrow();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});


### PR DESCRIPTION
## The gap this closes

Our numeric gates (`claims:check`, `check-product-claims`, the hardcoded-claim scanner) verify **counts**. Nothing verified that a config block we tell users to **copy** is actually accepted by the schema.

That is how `docs/api-reference.md` came to teach `config: { "min": 40 }` while the evaluator read `config.min_length` — with every gate green. A rule built from our own documentation deployed cleanly and then failed on every evaluation forever.

## What it does

Extracts every `type` + `config` pair from the files that teach rule authoring:

- `docs/api-reference.md`
- `docs/custom-rules.md`
- `examples/http-transport/README.md` + `client.ts`
- `src/tools/deploy-rule.ts` (the description an LLM agent reads)

…and deploys each one through the **real** store. **51 examples found; all deploy.**

## Verified failing, not just passing

Reintroducing `{ "minimum": 40 }` into `api-reference.md`:

```
× deploys docs/api-reference.md :: min_length {"minimum":40}
  Tests  1 failed | 51 passed (52)
```

Restoring it returns **52/52**. The test title names the offending file and config, so a failure points straight at the doc to fix.

## Deliberate limits

The matcher only accepts a config object with **no nested braces**, which covers everything we ship today. A future nested example is **skipped rather than guessed at** — a miss is safe, a wrong parse is not.

To stop that leniency from hiding a broken matcher, a separate assertion fails if fewer than 5 examples are found at all.

Suite: 457 → 509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)