### PR TITLE
fix(dashboard): 404s leaked the absolute install path (CWE-209)

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-07T16:28:40.527Z",
-  "generatedFromCommit": "d0b2519",
+  "generatedAt": "2026-08-07T16:58:03.539Z",
+  "generatedFromCommit": "0ead8d6",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 581,
+    "totalCombined": 583,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 457,
-      "total": 457
+      "passed": 459,
+      "total": 459
     }
   },
   "version": {

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -103,14 +103,27 @@ export function createDashboardServer(
   registerAuditRoutes(router, options?.customRuleStore);
   app.use('/api/v1', router);
 
-  // Serve static dashboard files if built (rate limited)
+  // Serve static dashboard files if built (rate limited).
+  //
+  // Gate on index.html, not on the directory: `npm run build` compiles the
+  // dashboard SERVER into dist/dashboard (server.js, routes/) without the UI
+  // bundle, which is built separately by `cd dashboard && npm run build`. The
+  // directory therefore exists while index.html does not, so the SPA fallback
+  // was registered and every unmatched route hit res.sendFile on a missing
+  // file. The resulting ENOENT carries an absolute path, and the error
+  // handler returned it verbatim to the client:
+  //   {"error":"ENOENT: ... stat 'C:\\...\\dist\\dashboard\\index.html'"}
+  // — leaking the install path (and the OS user) to anyone who can reach the
+  // dashboard. Without the UI built there is nothing to fall back TO, so the
+  // route simply should not exist, and unmatched paths get Express's own 404.
   const currentDir = dirname(fileURLToPath(import.meta.url));
   const staticDir = join(currentDir, '..', '..', 'dist', 'dashboard');
-  if (existsSync(staticDir)) {
+  const indexHtml = join(staticDir, 'index.html');
+  if (existsSync(indexHtml)) {
     app.use(createApiRateLimiter(config));
     app.use(express.static(staticDir));
     app.get('/{*path}', (_req, res) => {
-      res.sendFile(join(staticDir, 'index.html'));
+      res.sendFile(indexHtml);
     });
   }
 

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -13,7 +13,27 @@ export function createErrorHandler(logger: Logger): ErrorRequestHandler {
     }
 
     const status = err.status ?? err.statusCode ?? 500;
-    const message = status >= 500 ? 'Internal server error' : (err.message ?? 'Unknown error');
+
+    /*
+     * Never echo a Node system error to the client. Their messages embed
+     * absolute paths — an ENOENT from res.sendFile returned
+     *   "ENOENT: no such file or directory, stat 'C:\...\dist\dashboard\index.html'"
+     * with a 404, disclosing the install path and OS user to anyone who
+     * could reach the dashboard (CWE-209). 5xx was already masked; the leak
+     * was in the 4xx branch, where echoing err.message is otherwise useful
+     * (body-parser's "request entity too large", Zod messages, etc.).
+     *
+     * Identify system errors by the shape Node gives them — a string `code`
+     * plus `syscall` — rather than by matching path-ish text, which would
+     * miss cases and mangle legitimate messages.
+     */
+    const isSystemError = typeof err?.code === 'string' && typeof err?.syscall === 'string';
+    const message =
+      status >= 500 || isSystemError
+        ? status >= 500
+          ? 'Internal server error'
+          : 'Not found'
+        : (err.message ?? 'Unknown error');
 
     logger.error(`Request error: ${err.message}`, { status, stack: err.stack });
 

--- a/tests/unit/middleware/error-handler.test.ts
+++ b/tests/unit/middleware/error-handler.test.ts
@@ -21,6 +21,44 @@ async function testError(app: express.Application, path: string) {
 }
 
 describe('error handler middleware', () => {
+  /*
+   * CWE-209 regression. res.sendFile on a missing index.html raises an
+   * ENOENT whose message embeds an ABSOLUTE path, and the handler returned
+   * err.message verbatim for any status < 500 — so an unmatched dashboard
+   * route answered with the install path and OS user:
+   *   {"error":"ENOENT: ... stat 'C:\...\dist\dashboard\index.html'"}
+   */
+  it('does not leak filesystem paths from system errors', async () => {
+    const app = express();
+    app.get('/test', async () => {
+      const err = Object.assign(
+        new Error("ENOENT: no such file or directory, stat 'C:\srv\iris\dist\dashboard\index.html'"),
+        { code: 'ENOENT', syscall: 'stat', status: 404 },
+      );
+      throw err;
+    });
+    app.use(createErrorHandler(mockLogger));
+    const { status, body } = await testError(app, '/test');
+    expect(status).toBe(404);
+    expect(body.error).toBe('Not found');
+    expect(JSON.stringify(body)).not.toMatch(/ENOENT/);
+    expect(JSON.stringify(body)).not.toMatch(/dist/);
+    expect(JSON.stringify(body)).not.toMatch(/[A-Za-z]:\\|\/home\/|\/Users\//);
+  });
+
+  // The 4xx branch stays useful for errors we DO want surfaced — masking
+  // everything would turn body-parser's size limit into an unexplained 413.
+  it('still surfaces non-system 4xx messages', async () => {
+    const app = express();
+    app.get('/test', async () => {
+      throw Object.assign(new Error('request entity too large'), { status: 413 });
+    });
+    app.use(createErrorHandler(mockLogger));
+    const { status, body } = await testError(app, '/test');
+    expect(status).toBe(413);
+    expect(body.error).toBe('request entity too large');
+  });
+
   it('should return 500 for unhandled errors', async () => {
     const app = express();
     app.get('/test', async () => { throw new Error('boom'); });


### PR DESCRIPTION
## Found by driving the dashboard as an operator

Any unmatched route answered with the server's filesystem path:

```
GET /api/v1/definitely-not-a-route
404 {"error":"ENOENT: no such file or directory,
     stat 'C:\dev\project_new_idea\iris\dist\dashboard\index.html'"}
```

That discloses the **install directory and the OS username** to anyone who can reach the dashboard.

## Two causes, both fixed

**1. The SPA fallback was gated on the wrong thing.**
It checked whether the `dist/dashboard` **directory** exists. But `npm run build` compiles the dashboard *server* there (`server.js`, `routes/`) while the UI bundle is built separately by `cd dashboard && npm run build`. So the directory exists without `index.html`, the catch-all registered anyway, and every unmatched path hit `res.sendFile` on a missing file.

Now gated on `index.html`: with no UI built there is nothing to fall back *to*, so the route shouldn't exist and Express's own 404 answers.

**2. The error handler echoed `err.message` verbatim below 500.**
5xx was already masked — the leak was in the 4xx branch. Node system errors are now identified by their **shape** (string `code` + `syscall`) and answered generically.

Detecting by shape rather than by matching path-ish text avoids both missed cases and mangled legitimate messages: body-parser's `request entity too large` and Zod validation details still come through, which is the reason that branch echoes at all.

## Verified

- Unmatched routes → Express's default 404, **no path**
- `/api/v1/rules/custom` → still **200** with the rule list

*(An earlier probe of `/api/v1/rules` 404'd simply because the route is `/rules/custom` — that part was never broken.)*

**Gate verified in both directions:** disabling the system-error check turns the new test red; restoring it returns 5/5. A second test pins that non-system 4xx messages are still surfaced, so the fix can't be "improved" into masking everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)