### PR TITLE
fix(deps): force @hono/node-server v2 — root audit reaches 0 vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "better-sqlite3": "^12.8.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.2",
@@ -671,12 +671,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -763,12 +763,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,11 @@
     "brace-expansion": "^5.0.7",
     "fast-uri": "^3.1.5",
     "ip-address": "^10.4.0",
-    "postcss": "^8.5.25"
+    "postcss": "^8.5.25",
+    "@hono/node-server": "^2.1.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "better-sqlite3": "^12.8.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.2",


### PR DESCRIPTION
## Summary

Closes **GHSA-frvp-7c67-39w9** (`serveStatic` path traversal on Windows via encoded backslash) — the last patchable root advisory.

`npm audit` at root now reports **`found 0 vulnerabilities`** (was 4 moderate + 1 low).

## Two steps were needed — neither works alone

1. **`@modelcontextprotocol/sdk` `^1.29.0` → `^1.30.0`.** 1.30.0 widens its constraint to `"^1.19.9 || ^2.0.5"`.
2. **`overrides."@hono/node-server" = "^2.1.0"`** to actually move it.

> ⚠️ Worth knowing: **Dependabot PR #277 does only step 1**, despite being titled *"bump @hono/node-server and @modelcontextprotocol/sdk"*. It does **not** move `@hono/node-server` — npm keeps the already-locked `1.19.13`, which still satisfies the widened range. Merging #277 alone would have left the alert open while looking like it closed it.

## Why a green unit suite wasn't sufficient evidence

This is a **major** bump of the bridge iris's HTTP transport actually runs on. SDK 1.29+ made `StreamableHTTPServerTransport` a thin wrapper that **statically imports** `getRequestListener` from `@hono/node-server` (`streamableHttp.js:9`) — so this package sits on the real request path.

Exercised the transport directly:

| Harness | Result |
|---|---|
| **HTTP transport e2e** | **14/14** — boots · `/health` unauthenticated · `/mcp` rejects missing (401) and wrong (403) keys · full `initialize` + session id · `tools/list` → 9 tools · `evaluate_output` → score 0.978 · foreign Origin → 403 · CSP present · 5MB body → 413 with server still healthy |
| **DNS-rebinding e2e** | **3/3** — attacker Origin 403, Origin-less client 200, same-origin 200 |
| **stdio MCP e2e** | **11/11** |
| **Dashboard e2e** | **10/10** |
| **Unit suite** | **509/509** |

## Lockfile

Regenerated under **Linux (WSL)**: `@emnapi` entries still **11**, **zero** package entries removed.

## Harness corrections

Two of my own assertions were wrong and are fixed rather than left red:
- The SSE response escapes quotes, so `/"score"/` never matched a **working** call.
- The MCP transport deliberately emits **no** CORS headers (that's the dashboard's job) — it enforces Origin by **rejecting**, which is what the test now asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)