### PR TITLE
chore(docker): use npm ci for the dashboard build (Scorecard pinned-deps)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,17 @@ RUN npm run build
 # ../.claims.json for __IRIS_RULE_COUNT__) — must be in the build context.
 COPY .claims.json ./
 COPY dashboard/ dashboard/
-RUN cd dashboard && npm install && npm run build
+# `npm ci` (not `npm install`): installs exactly what dashboard/package-lock.json
+# pins, integrity hashes included, so the image is reproducible and a drifted
+# lockfile fails the build loudly instead of resolving to something else.
+#
+# This used `npm install` because a Windows-generated lockfile prunes the
+# Linux-only @emnapi entries rolldown needs, which made `npm ci` fail here
+# (reference_rolldown_lockfile_trap). Lockfiles are now regenerated on Linux,
+# so that no longer applies — verified on Linux against the current lockfile:
+# `npm ci` installs 420 packages (exit 0) and `npm run build` succeeds.
+# Closes the Scorecard Pinned-Dependencies finding on this file.
+RUN cd dashboard && npm ci && npm run build
 
 FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS production
 


### PR DESCRIPTION
## Summary

Closes the remaining **PinnedDependenciesID** alert, which moved to `Dockerfile:18` once the workflow ones were fixed in #285.

Scorecard flags `npm install` because it can resolve to versions the lockfile doesn't pin. `npm ci` is the hash-pinned form — lines 5 and 26 already use it and were never flagged.

## Why it was `npm install`

A deliberate workaround: a **Windows-generated** lockfile prunes the Linux-only `@emnapi` entries rolldown needs, which made `npm ci` fail inside the image (`reference_rolldown_lockfile_trap`).

Every lockfile touched this session was regenerated on **Linux via WSL**, with the `@emnapi` entries verified present each time. The condition that forced the workaround is gone.

## Verified before changing it

On Linux, against the current `dashboard/package-lock.json`:

| Step | Result |
|---|---|
| `npm ci` | **exit 0** — 420 packages |
| `npm run build` | **succeeds** — built in 29s |

The `docker-build` CI job builds the real image and will confirm end to end.

## Net effect beyond the alert

The published image becomes **reproducible**, and a drifted dashboard lockfile now fails the build **loudly** instead of silently resolving to different versions than CI tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)