### PR TITLE
fix(dashboard): migrate to react-router v8 — closes the last Dependabot alert

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -21,7 +21,7 @@
         "lucide-react": "^1.23.0",
         "react": "^19.0.0",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.18.2",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -3737,18 +3737,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6073,41 +6066,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
-      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recast": {
@@ -6299,12 +6275,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -28,7 +28,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.18.2",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.1"
   },
   "devDependencies": {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router';
 import { Shell } from './components/layout/Shell';
 import { ThemeProvider } from './components/layout/ThemeProvider';
 import { DensitySync } from './components/layout/DensitySync';

--- a/dashboard/src/components/audit/AuditPage.tsx
+++ b/dashboard/src/components/audit/AuditPage.tsx
@@ -12,7 +12,7 @@
  *   - error: retry button
  */
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { History, Download } from 'lucide-react';
 import { useAuditLog } from '../../api/hooks';
 import type { AuditAction, AuditLogEntry } from '../../api/types';

--- a/dashboard/src/components/command/CommandPalette.tsx
+++ b/dashboard/src/components/command/CommandPalette.tsx
@@ -22,7 +22,7 @@
  *   - Focus restored to trigger on close
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTheme } from '../layout/ThemeProvider';
 import {
   buildCommands,

--- a/dashboard/src/components/command/CommandPaletteProvider.tsx
+++ b/dashboard/src/components/command/CommandPaletteProvider.tsx
@@ -30,7 +30,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { CommandPalette } from './CommandPalette';
 import { KeyboardShortcutsOverlay } from './KeyboardShortcutsOverlay';
 import { useTour } from '../onboarding/TourProvider';

--- a/dashboard/src/components/command/commands.ts
+++ b/dashboard/src/components/command/commands.ts
@@ -12,7 +12,7 @@
  *   - run: function executed when the command is selected
  *   - section: visual grouping in the palette
  */
-import type { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router';
 
 export type CommandSection = 'Navigate' | 'Filter' | 'Action' | 'Help';
 

--- a/dashboard/src/components/dashboard/AgentList.tsx
+++ b/dashboard/src/components/dashboard/AgentList.tsx
@@ -9,7 +9,7 @@
  * segments) gives at-a-glance distribution without a real chart
  * library.
  */
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Users, ChevronRight } from 'lucide-react';
 import { useMoments } from '../../api/hooks';
 import { Icon } from '../shared/Icon';

--- a/dashboard/src/components/dashboard/DashboardPage.tsx
+++ b/dashboard/src/components/dashboard/DashboardPage.tsx
@@ -14,7 +14,7 @@
  * The chrome `<Header>` (v2.B) carries the page identity ("Dashboard").
  * No inline page header — keeps a single h1 per route.
  */
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { ViewTabs, resolveView } from './ViewTabs';
 import { HealthView, HealthViewToolbar } from './HealthView';
 import { DriftView, DriftViewToolbar } from './DriftView';

--- a/dashboard/src/components/dashboard/DriftView.tsx
+++ b/dashboard/src/components/dashboard/DriftView.tsx
@@ -19,7 +19,7 @@
  * pre-filtered Decision Moments view.
  */
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useMoments } from '../../api/hooks';
 import {
   resolvePeriod,

--- a/dashboard/src/components/dashboard/HealthView.tsx
+++ b/dashboard/src/components/dashboard/HealthView.tsx
@@ -28,7 +28,7 @@
  * for BI dashboards, not a bug.
  */
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import {
   useEvalStats,
   useEvalTrend,

--- a/dashboard/src/components/dashboard/PeriodSelector.tsx
+++ b/dashboard/src/components/dashboard/PeriodSelector.tsx
@@ -10,7 +10,7 @@
  * The selector itself doesn't know which view is active — DashboardPage
  * resolves the right default per view and passes it in.
  */
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 export type Period = '24h' | '7d' | '30d' | '90d';
 

--- a/dashboard/src/components/dashboard/RecentAuditRow.tsx
+++ b/dashboard/src/components/dashboard/RecentAuditRow.tsx
@@ -8,7 +8,7 @@
  * Empty state surfaces the workflow-inversion entry point — same copy
  * pattern as RuleListByCategory's empty custom-rules section.
  */
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { History, ChevronRight } from 'lucide-react';
 import { useAuditLog } from '../../api/hooks';
 import { Icon } from '../shared/Icon';

--- a/dashboard/src/components/dashboard/RecentMomentsRow.tsx
+++ b/dashboard/src/components/dashboard/RecentMomentsRow.tsx
@@ -8,7 +8,7 @@
  * Empty state celebrates: "All systems healthy — no moments require
  * attention since {timestamp}."
  */
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Activity, ChevronRight } from 'lucide-react';
 import { useMoments } from '../../api/hooks';
 import { Icon } from '../shared/Icon';

--- a/dashboard/src/components/dashboard/ViewTabs.tsx
+++ b/dashboard/src/components/dashboard/ViewTabs.tsx
@@ -16,7 +16,7 @@
  * navigations don't fight each other.
  */
 import type { ReactNode } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import { Activity, Heart, Waves } from 'lucide-react';
 import { Icon } from '../shared/Icon';
 

--- a/dashboard/src/components/dashboard/charts/BiggestMoversTable.tsx
+++ b/dashboard/src/components/dashboard/charts/BiggestMoversTable.tsx
@@ -12,7 +12,7 @@
  * period of activity) — empty state is honest about that.
  */
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { TrendingUp, TrendingDown, Minus, Users } from 'lucide-react';
 import { Icon } from '../../shared/Icon';
 import { Sparkline } from '../Sparkline';

--- a/dashboard/src/components/dashboard/charts/Donut.tsx
+++ b/dashboard/src/components/dashboard/charts/Donut.tsx
@@ -20,7 +20,7 @@
  *   Caller can override `emptyMessage` to make it onboarding-shaped.
  */
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { pie as d3pie, arc as d3arc } from 'd3-shape';
 
 export interface DonutSlice {

--- a/dashboard/src/components/dashboard/charts/HorizontalBarChart.tsx
+++ b/dashboard/src/components/dashboard/charts/HorizontalBarChart.tsx
@@ -9,7 +9,7 @@
  * accept a per-bar color override (e.g., to match verdict semantics).
  */
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 export interface HorizontalBar {
   id: string;

--- a/dashboard/src/components/dashboard/charts/LiveTraceTail.tsx
+++ b/dashboard/src/components/dashboard/charts/LiveTraceTail.tsx
@@ -15,7 +15,7 @@
  * stream here once an MCP-compatible agent posts.
  */
 import { useTraces } from '../../../api/hooks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Activity, ChevronRight } from 'lucide-react';
 import { Icon } from '../../shared/Icon';
 import { Tooltip } from '../../shared/Tooltip';

--- a/dashboard/src/components/dashboard/charts/PassRateAreaChart.tsx
+++ b/dashboard/src/components/dashboard/charts/PassRateAreaChart.tsx
@@ -20,7 +20,7 @@
  * the full list on hover.
  */
 import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { area as d3area, line as d3line, curveMonotoneX } from 'd3-shape';
 import { scaleLinear, scaleTime } from 'd3-scale';
 import { extent } from 'd3-array';

--- a/dashboard/src/components/dashboard/charts/PerRuleMeterGrid.tsx
+++ b/dashboard/src/components/dashboard/charts/PerRuleMeterGrid.tsx
@@ -15,7 +15,7 @@
  * filtered moment set client-side.
  */
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Sparkline } from '../Sparkline';
 import { drillToMoments } from '../../../utils/drillThrough';
 import {

--- a/dashboard/src/components/dashboard/charts/StackedBarByDay.tsx
+++ b/dashboard/src/components/dashboard/charts/StackedBarByDay.tsx
@@ -10,7 +10,7 @@
  * Click a segment → also filters by verdict.
  */
 import { useMemo, useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router';
 import { utcDay } from 'd3-time';
 import { utcFormat } from 'd3-time-format';
 import { drillToMoments } from '../../../utils/drillThrough';

--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -10,7 +10,7 @@
  * v2.C (2026-04-23): Notifications + Account are now real popovers.
  * Theme toggle moved from header into AccountMenu per R2.5 spec.
  */
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Tooltip } from '../shared/Tooltip';
 import { CommandPaletteTrigger } from '../command/CommandPaletteTrigger';
 import { NotificationsPopover } from './NotificationsPopover';

--- a/dashboard/src/components/layout/NavItem.tsx
+++ b/dashboard/src/components/layout/NavItem.tsx
@@ -7,7 +7,7 @@
  * is collapsed (icon-only at 64px), the label is replaced with a
  * native `title` tooltip.
  */
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import type { LucideIcon } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { Icon } from '../shared/Icon';

--- a/dashboard/src/components/layout/NotificationsPopover.tsx
+++ b/dashboard/src/components/layout/NotificationsPopover.tsx
@@ -11,7 +11,7 @@
  * we never write "notification objects" separately.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Bell, Sparkles, Trash2, ToggleRight, PencilLine } from 'lucide-react';
 import { Icon } from '../shared/Icon';
 import { useAuditLog } from '../../api/hooks';

--- a/dashboard/src/components/layout/WelcomeBanner.tsx
+++ b/dashboard/src/components/layout/WelcomeBanner.tsx
@@ -11,7 +11,7 @@
  *   - where to go next
  */
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 const STORAGE_KEY = 'iris-welcome-banner-dismissed';
 

--- a/dashboard/src/components/moments/MomentCard.tsx
+++ b/dashboard/src/components/moments/MomentCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { DecisionMoment } from '../../api/types';
 import { formatCost, formatLatency, formatTimeAgo } from '../../utils/formatters';
 import { getSignificanceVisual, getVerdictVisual } from './significance';

--- a/dashboard/src/components/moments/MomentDetailPage.tsx
+++ b/dashboard/src/components/moments/MomentDetailPage.tsx
@@ -12,7 +12,7 @@
  * the page header for this resource route.
  */
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useMomentDetail } from '../../api/hooks';
 import { CopyableId } from '../shared/CopyableId';
 import { LoadingSpinner } from '../shared/LoadingSpinner';

--- a/dashboard/src/components/moments/MomentsTimelinePage.tsx
+++ b/dashboard/src/components/moments/MomentsTimelinePage.tsx
@@ -16,7 +16,7 @@
  *   - error: retry button
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useMoments, useFilters } from '../../api/hooks';
 import { usePreferences } from '../../hooks/usePreferences';
 import { api } from '../../api/client';

--- a/dashboard/src/components/onboarding/WelcomeTour.tsx
+++ b/dashboard/src/components/onboarding/WelcomeTour.tsx
@@ -21,7 +21,7 @@
  * survives across browser reloads AND iris-mcp restarts.
  */
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { usePreferences } from '../../hooks/usePreferences';
 import { useCommandPalette } from '../command/CommandPaletteProvider';
 import { useFocusTrap } from '../shared/useFocusTrap';

--- a/dashboard/src/components/rules/RulesPage.tsx
+++ b/dashboard/src/components/rules/RulesPage.tsx
@@ -6,7 +6,7 @@
  * editing of existing rules is deferred to v0.4.1 (full editor surface).
  */
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Sparkles } from 'lucide-react';
 import { useCustomRules } from '../../api/hooks';
 import { api } from '../../api/client';

--- a/dashboard/src/components/traces/TraceDetailPage.tsx
+++ b/dashboard/src/components/traces/TraceDetailPage.tsx
@@ -5,7 +5,7 @@
  * the resource-specific summary card + semantic sections wrapped in
  * <section aria-labelledby> so AT users can navigate by structure.
  */
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useTraceDetail } from '../../api/hooks';
 import { SpanTree } from './SpanTree';
 import { ToolCallCard } from './ToolCallCard';

--- a/dashboard/src/components/traces/TraceListPage.tsx
+++ b/dashboard/src/components/traces/TraceListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTraces } from '../../api/hooks';
 import { TraceFilters } from './TraceFilters';
 import { TraceTable } from './TraceTable';

--- a/dashboard/tests/a11y/charts.test.tsx
+++ b/dashboard/tests/a11y/charts.test.tsx
@@ -24,7 +24,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { axe } from 'jest-axe';
 import { PassRateGauge } from '../../src/components/dashboard/charts/PassRateGauge';
 import { Donut } from '../../src/components/dashboard/charts/Donut';

--- a/dashboard/tests/a11y/chrome.test.tsx
+++ b/dashboard/tests/a11y/chrome.test.tsx
@@ -18,7 +18,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, act } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { axe } from 'jest-axe';
 
 /*

--- a/dashboard/tests/a11y/detail-pages.test.tsx
+++ b/dashboard/tests/a11y/detail-pages.test.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { axe } from 'jest-axe';
 
 /* ═══ Mocks ════════════════════════════════════════════════════════════

--- a/dashboard/tests/components/command/CommandPalette.test.tsx
+++ b/dashboard/tests/components/command/CommandPalette.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { CommandPalette } from '../../../src/components/command/CommandPalette';
 import { ThemeProvider } from '../../../src/components/layout/ThemeProvider';
 


### PR DESCRIPTION
## Summary

**GHSA-qwww-vcr4-c8h2** was the only remaining Dependabot alert. I'd documented it as not-applicable (#287) and queued it for dismissal — but fixing it outright beats carrying a permanent exception, and it turned out to be tractable.

**This takes the repo to 0 open Dependabot alerts.**

## Why it needed a migration, not a bump

`react-router-dom` has **no 8.x**. React Router merged its packages in v7+, so the fixed `react-router@8.3.0` is reached by dropping `react-router-dom` and importing from `react-router` directly.

**35 files** (31 `src` + 4 `tests`), **import paths only**. Every symbol in use is exported by v8 unchanged: `BrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `useNavigate`, `useParams`, `useSearchParams`, `useLocation`, `NavigateFunction`.

## Engine check — done before committing

`react-router@8.3.0` requires **node ≥ 22.22.0**. Verified every place the dashboard is built satisfies it:

| Site | Node |
|---|---|
| `lint-and-typecheck` (dashboard typecheck/lint/test) | 22 → 22.23.2 ✅ |
| `build` | 22 ✅ |
| `docker-build` | 22 + Dockerfile `node:24` ✅ |
| `test (20)` | **never touches the dashboard** — root tests only ✅ |

React is already **19.2.7**, exactly meeting v8's `react >= 19.2.7` peer requirement, so no React bump was needed.

## Verification

| Check | Result |
|---|---|
| dashboard `typecheck` | exit 0 |
| dashboard `lint` | exit 0 |
| dashboard tests | **111/111** |
| dashboard `build` / `build-storybook` | exit 0 / exit 0 |
| root suite | **511/511** |
| dashboard e2e (running server) | **10/10** |

The a11y and command-palette suites **render through the router**, so v8 rendering is genuinely exercised rather than just type-checked.

## Lockfile

Regenerated on **Linux**: `@emnapi` still **20**, and the only removed entries are `react-router-dom` and its own deps (`cookie`, `set-cookie-parser`) — no platform entries lost.

## One behaviour note

The e2e now answers **200** for unknown routes instead of 404, because the UI bundle is present here so the SPA fallback serves `index.html`. That's correct, and it confirms the path-disclosure fix (#286) behaves right in **both** states — clean 404 when no UI is built, SPA fallback when there is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)