### PR TITLE
chore(deps): zod 3.25.76 → 4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "helmet": "^8.1.0",
         "pino": "^10.3.1",
         "safe-regex2": "^5.1.0",
-        "zod": "^3.25.0"
+        "zod": "^4.4.3"
       },
       "bin": {
         "iris-mcp": "dist/index.js"
@@ -893,9 +893,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -913,9 +910,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -933,9 +927,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -953,9 +944,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,9 +961,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -993,9 +978,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3224,9 +3206,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3248,9 +3227,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3272,9 +3248,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3296,9 +3269,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4946,9 +4916,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "helmet": "^8.1.0",
     "pino": "^10.3.1",
     "safe-regex2": "^5.1.0",
-    "zod": "^3.25.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/audit-log-reader.ts
+++ b/src/audit-log-reader.ts
@@ -31,7 +31,7 @@ const EntrySchema = z.object({
   user: z.string(),
   ruleId: z.string(),
   ruleName: z.string().optional(),
-  details: z.record(z.unknown()).optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
 });
 
 export interface AuditQueryFilter {

--- a/src/custom-rule-store.ts
+++ b/src/custom-rule-store.ts
@@ -93,7 +93,7 @@ const DefinitionSchema = z
   .object({
     name: z.string().min(1).max(80),
     type: z.enum(RULE_TYPE_VALUES),
-    config: z.record(z.unknown()),
+    config: z.record(z.string(), z.unknown()),
     weight: z.number().positive().optional(),
   })
   .superRefine((def, ctx) => {

--- a/src/dashboard/routes/rules.ts
+++ b/src/dashboard/routes/rules.ts
@@ -25,7 +25,7 @@ const RuleTypeSchema = z.enum([
 const DefinitionSchema = z.object({
   name: z.string().min(1).max(80),
   type: RuleTypeSchema,
-  config: z.record(z.unknown()),
+  config: z.record(z.string(), z.unknown()),
   weight: z.number().positive().optional(),
 });
 

--- a/src/tools/deploy-rule.ts
+++ b/src/tools/deploy-rule.ts
@@ -28,7 +28,7 @@ const CustomRuleDefinitionSchema = z.object({
     'json_schema',
     'cost_threshold',
   ]),
-  config: z.record(z.unknown()),
+  config: z.record(z.string(), z.unknown()),
   weight: z.number().optional(),
 });
 

--- a/src/tools/evaluate-output.ts
+++ b/src/tools/evaluate-output.ts
@@ -11,7 +11,7 @@ const CustomRuleSchema = z.object({
     'regex_match', 'regex_no_match', 'min_length', 'max_length',
     'contains_keywords', 'excludes_keywords', 'json_schema', 'cost_threshold',
   ]),
-  config: z.record(z.unknown()),
+  config: z.record(z.string(), z.unknown()),
   weight: z.number().optional(),
 });
 

--- a/src/tools/log-trace.ts
+++ b/src/tools/log-trace.ts
@@ -22,11 +22,11 @@ const SpanSchema = z.object({
   status_message: z.string().optional(),
   start_time: z.string(),
   end_time: z.string().optional(),
-  attributes: z.record(z.unknown()).optional(),
+  attributes: z.record(z.string(), z.unknown()).optional(),
   events: z.array(z.object({
     name: z.string(),
     timestamp: z.string(),
-    attributes: z.record(z.unknown()).optional(),
+    attributes: z.record(z.string(), z.unknown()).optional(),
   })).optional(),
 });
 
@@ -45,7 +45,7 @@ const inputSchema = {
   latency_ms: z.number().optional().describe('Total execution time in milliseconds (end-to-end agent latency)'),
   token_usage: TokenUsageSchema.optional().describe('Token usage breakdown (prompt/completion/total — used for cost analysis)'),
   cost_usd: z.number().optional().describe('Total cost in USD — overrides per-span aggregation when provided (treated as authoritative)'),
-  metadata: z.record(z.unknown()).optional().describe('Opaque key-value tags (e.g. {requestId, userId, env}) — queryable in dashboard, not via get_traces filters'),
+  metadata: z.record(z.string(), z.unknown()).optional().describe('Opaque key-value tags (e.g. {requestId, userId, env}) — queryable in dashboard, not via get_traces filters'),
   spans: z.array(SpanSchema).optional().describe('Detailed execution spans (hierarchical span tree with timings, attributes, events)'),
   timestamp: z.string().optional().describe('Trace timestamp (ISO 8601); defaults to now() when omitted'),
 };


### PR DESCRIPTION
## Summary

Lands the content of Dependabot **#115**, which had gone stale (`DIRTY`) while the backlog was deadlocked.

## The blocking question, checked first

`@modelcontextprotocol/sdk` declares **neither a zod dependency nor a zod peer range**, so nothing in the MCP layer pins us to v3. `zod-to-json-schema@3.25.2` stays in the tree and still produces tool schemas correctly — verified live: all **9 tools expose an `inputSchema`** over the wire.

## One breaking change reached iris

zod 4 requires `z.record()` to take explicit **key and value** types. 8 call sites across 6 files became `z.record(z.string(), z.unknown())`.

Everything else iris uses (`z.string`, `z.enum`, `z.number`, `z.object`, `z.array`, `z.boolean`, `z.literal`, `z.unknown`) is unchanged between majors, and `error-handler.ts` already read `err.errors ?? err.issues`, so the `ZodError` field rename needed no work.

One `z.record(z.unknown())` is left untouched on purpose: it's inside a **comment** describing what the code *used to be*. Rewriting historical prose to match new syntax would make the comment wrong.

## Verification

zod validates every MCP tool's arguments, so a green unit suite isn't sufficient on its own:

| Check | Result |
|---|---|
| typecheck / lint / build | 0 / 0 / 0 |
| unit suite | **511/511, run three times** |
| MCP stdio e2e | **11/11** — 9 tools listed, all with `inputSchema`, `evaluate_output` scores, malformed args still produce structured errors not crashes |
| HTTP transport e2e | **14/14** |
| dashboard e2e | **10/10** |
| `npm audit` | **0 vulnerabilities** |

On the three runs: an earlier run showed 2 failures that did not reproduce. I didn't treat the subsequent green as a pass until it held three times — a major version bump is the wrong place to trust a flaky signal.

Lockfile regenerated on Linux.

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)