### PR TITLE
fix(dashboard): override brace-expansion to ^5.0.9 — clears the last 2 Scorecard vulns

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -3549,16 +3549,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -55,6 +55,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Summary

The Scorecard `VulnerabilitiesID` alert still named two advisories **after** the dependency drain took Dependabot to 0:

- `GHSA-mh99-v99m-4gvg` — unbounded expansion length → OOM
- `GHSA-rgw5-rvv9-x895` — unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation

Both are `brace-expansion`. Root and website were already on **5.0.9**, but the **dashboard** lockfile sat at **5.0.7** — the version that fixed the earlier `GHSA-3jxr` but *not* these two.

`npm audit` inside `dashboard/` confirmed it directly:
```
high brace-expansion | advisories: GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 | fixAvailable: true
```

## Why the counts disagreed

**Dependabot reads 0 because it auto-dismissed the brace-expansion alerts earlier as `tolerable_risk`** (recorded in `SECURITY-EXPOSURE.md`). Scorecard doesn't honour those dismissals and kept counting them.

So *"0 Dependabot alerts"* was **not** the same as *"0 vulnerabilities"* — and only a per-workspace `npm audit` surfaced the gap. Worth remembering: the dashboard number is a count of *undismissed* alerts, not of vulnerable packages.

## Fix

Aligns dashboard with the override already used at root and in website. `npm audit` in `dashboard/` now reports **`found 0 vulnerabilities`**.

## Verification

| Check | Result |
|---|---|
| dashboard `typecheck` / `lint` | 0 / 0 |
| dashboard tests | **111/111** |
| dashboard `build` | 0 |
| dashboard e2e (running server) | **10/10** |

Lockfile regenerated on **Linux** — `@emnapi` still **20**, **zero** package entries removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)