### PR TITLE
release: v0.4.5 — security release

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-07T17:14:06.762Z",
-  "generatedFromCommit": "8d5a72e",
+  "generatedAt": "2026-08-07T18:53:10.648Z",
+  "generatedFromCommit": "d0ef438",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -102,8 +102,8 @@
     ]
   },
   "release": {
-    "currentReleaseDate": "2026-06-12",
-    "currentReleaseVersion": "0.4.4",
+    "currentReleaseDate": "2026-08-07",
+    "currentReleaseVersion": "0.4.5",
     "nextPlannedScope": "Cloud SKU foundation",
     "nextPlannedVersion": "0.5.0"
   },
@@ -130,8 +130,8 @@
       "total": 111
     },
     "vitestRoot": {
-      "failed": 0,
-      "passed": 511,
+      "failed": 1,
+      "passed": 510,
       "total": 511
     }
   },
@@ -139,7 +139,7 @@
     "dashboardPackage": "0.1.0",
     "initPackage": "0.1.0",
     "langchainPackage": "0.1.0",
-    "mcpServer": "0.4.4",
+    "mcpServer": "0.4.5",
     "websitePackage": "0.1.0"
   }
 }

--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-07T18:53:10.648Z",
-  "generatedFromCommit": "d0ef438",
+  "generatedAt": "2026-08-07T19:01:10.301Z",
+  "generatedFromCommit": "55d3a38",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -130,8 +130,8 @@
       "total": 111
     },
     "vitestRoot": {
-      "failed": 1,
-      "passed": 510,
+      "failed": 0,
+      "passed": 511,
       "total": 511
     }
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Unreleased content rolls forward to the next non-RC release.)
 
+## [0.4.5] - 2026-08-07
+
+**Security release.** Fixes three vulnerabilities present in 0.4.4, two of them found by driving iris the way a real user does — a live MCP session over stdio and an operator poking the HTTP transport — rather than by reading the code. Every dependency advisory across all four workspaces is also closed: `npm audit` reports **0 vulnerabilities** in the root, website, dashboard and `packages/init`.
+
+No MCP surface changes: the same 9 tools, same schemas, same eval rules.
+
+### Security
+
+- **DNS rebinding on the MCP HTTP transport.** The MCP spec requires servers to validate `Origin` on HTTP transports; iris validated nothing. Because `security.apiKey` is `undefined` by default (making the auth middleware a pass-through), a default `--transport http` server was reachable from **any web page the operator visited** via a hostname rebound to `127.0.0.1` — exposing traces and eval history, and allowing rule deployment and trace deletion. Reproduced against 0.4.4 (`Origin: https://evil.example.com` → **200, request executed**); now **403**. Enabled the SDK's DNS-rebinding protection with an `Origin` allowlist, plus a `Host` allowlist when bound to loopback. Real MCP clients (Claude Desktop, Cursor, the CLI) send no `Origin` header and are unaffected — verified. `IRIS_ALLOWED_ORIGINS` now feeds this allowlist; it previously reached only the dashboard despite being advertised in `--help`. PR #283.
+- **Absolute install path disclosed in dashboard 404s (CWE-209).** Any unmatched route returned `ENOENT: ... stat 'C:\...\dist\dashboard\index.html'`, leaking the install directory and OS username to anyone who could reach the dashboard. Two causes: the SPA fallback was gated on the `dist/dashboard` *directory* (which exists after `npm run build` even when the UI bundle does not), and the error handler echoed `err.message` verbatim below HTTP 500. Node system errors are now answered generically; genuine 4xx messages (body-parser size limits, Zod validation) still surface. PR #286.
+- **`@hono/node-server` → 2.1.0** closes GHSA-frvp-7c67-39w9 (`serveStatic` path traversal on Windows via encoded backslash). This package sits on the real request path — SDK 1.29+ made `StreamableHTTPServerTransport` a thin wrapper that statically imports `getRequestListener` — so the upgrade was validated by exercising the transport, not just the unit suite. Requires SDK ≥ 1.30.0, which widens the constraint. PR #288.
+- **Dependency advisories closed across every workspace:** `fast-uri` → 3.1.5, `ip-address` → 10.4.0, `postcss` → 8.5.26, `brace-expansion` → 5.0.9 (both major lines in website, via version-scoped overrides), `next` → 16.2.11, `sharp` → 0.35.0, `undici` → 7.29.0, `js-yaml` → 4.3.1, `ws` → 8.21.3, `body-parser` → 2.3.0, `hono` → 4.13.1. PRs #271, #274, #281, #288, #294 and the Dependabot drain.
+
+### Fixed
+
+- **Custom rules built from iris's own documentation never worked.** The `deploy_rule` tool description — the text an LLM agent reads to construct its call — specified `config.min` and `config.max_usd`, while the evaluator read `config.min_length` and `config.max_cost`. Deploy-time validation accepted any object, so a rule written from our docs deployed cleanly and then failed on *every* evaluation, forever. Worse, a rule that cannot run returned `score: 0` rather than skipping, so one broken rule silently deflated every aggregate score with no sign the rule (not the agent) was at fault. A correct output scored **0.304 / FAILED**; the same rules now score **1.0 / PASSED** and do what their author asked. Config keys now come from one shared module so the evaluator, the deploy validator and the tool description cannot drift apart; the spellings the old docs taught are honoured as aliases so already-deployed rules start working. Invalid configs are rejected at deploy time with the offending field named. PR #282.
+- **Misleading regex errors.** `safe-regex2` returns false for anything it cannot parse, so a plainly broken pattern like `(` was reported as *"catastrophic backtracking"* — sending the author after a performance problem they did not have. Syntax is now checked before safety in both the evaluator and the deploy validator. PR #282.
+- `docs/api-reference.md` taught the wrong `min_length` config key. PR #282.
+
+### Changed
+
+- **`zod` 3.25.76 → 4.4.3** and **`react-router` 7 → 8** (the dashboard drops `react-router-dom`, which has no 8.x). Internal only — no change to the MCP tool surface. PRs #292, #293.
+- **CI can no longer deadlock against itself.** `npm audit --audit-level=high` ran inside `lint-and-typecheck` and fails on the *whole set* of open advisories, so four HIGHs turned **every** PR red — including each Dependabot PR that fixed one of them. No single PR could go green, so nothing merged and nothing drained: 4 advisories froze 40 PRs. Removed, with the invariant recorded in three places: *a blocking gate must be satisfiable by a change made inside the pull request it blocks.* Dependency-security enforcement remains in the `security-exposure` job, which is stricter (≥moderate, and demands documented threat-model analysis) and cannot deadlock. PR #271.
+- Release workflows no longer `npm install -g npm@latest` before publishing; Node 24 ships a new-enough npm, so the unpinnable supply-chain dependency in the OIDC publish job is gone. The Docker dashboard build uses `npm ci` instead of `npm install`, making the image reproducible. PRs #285, #290.
+
+### Added
+
+- **A drift guard that deploys every rule-config example in our documentation** (51 of them) through the real schema. Numeric claims already had gates; nothing checked that the examples we tell users to copy actually run. Verified to fail, not just pass. PR #284.
+- Regression coverage for all of the above: config errors skip instead of scoring 0, documented aliases are honoured, deploy rejects each invalid config shape, the rebinding attack is refused while Origin-less clients are not, and 404s carry no filesystem path. Root suite 434 → 511.
+
+
 ## [0.4.4] - 2026-06-12
 
 Recovery release completing v0.4.3's distribution. v0.4.3 published to Docker (GHCR) and the GitHub Release, but its **npm publish silently failed** — the `NPM_TOKEN` secret had expired, npm returned `E404` on the publish PUT, and the pre-#176 `npm publish ... || echo "skipping"` step swallowed the failure into a green run. npm `@latest` (and therefore the MCP Registry + downstream mirrors) stalled at 0.4.2, so the v0.4.3 LLM-judge prompt-injection hardening never reached npm installs. v0.4.4 carries all v0.4.3 runtime content forward and is the first complete distribution since 0.4.2. **No runtime code changes versus 0.4.3.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iris-eval/mcp-server",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iris-eval/mcp-server",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "mcpName": "io.github.iris-eval/mcp-server",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/iris-eval/mcp-server",
     "source": "github"
   },
-  "version": "0.4.4",
+  "version": "0.4.5",
   "packages": [
     {
       "registryType": "npm",

--- a/website/public/.well-known/mcp.json
+++ b/website/public/.well-known/mcp.json
@@ -4,7 +4,7 @@
   "homepage": "https://iris-eval.com",
   "repository": "https://github.com/iris-eval/mcp-server",
   "npm": "@iris-eval/mcp-server",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "license": "MIT",
   "transport": [
     "stdio",


### PR DESCRIPTION
## Why this needs to ship

Every fix from this session is on `main`, but **npm still serves 0.4.4** — so users remain exposed to all three vulnerabilities. I verified that directly by running `npx @iris-eval/mcp-server` against the published package: it still returns the pre-fix behaviour.

Fixing `main` without publishing protects nobody.

## What ships

| | |
|---|---|
| **DNS rebinding** | A default `--transport http` server was reachable from any web page the operator visited (no `Origin` validation + auth off by default). Reproduced on 0.4.4 as **200, executed** → now **403**. |
| **Path disclosure (CWE-209)** | Dashboard 404s returned the absolute install path and OS username. |
| **`@hono/node-server` → 2.1.0** | `serveStatic` path traversal. This sits on the **real request path**, so it was validated by exercising the transport, not just unit tests. |
| **Broken custom rules** | Rules built from iris's own docs never worked (`config.min` vs `config.min_length`). A correct output scored **0.304/FAILED**; now **1.0/PASSED**. |
| **Dependencies** | **0 vulnerabilities** across root, website, dashboard and `packages/init`. |

## Compatibility

**No MCP surface change** — same 9 tools, same schemas, same eval rules.

⚠️ **One behaviour change**, documented in the CHANGELOG: the HTTP transport now refuses requests carrying a **foreign `Origin`**. Real MCP clients (Claude Desktop, Cursor, CLI) send no `Origin` and are unaffected — verified. Browser callers on another origin must be added via `IRIS_ALLOWED_ORIGINS`.

That is a deliberate hardening of the vulnerability, not a regression.

## Verification on this branch

| Gate | Result |
|---|---|
| `check-version` (4 files must agree) | 0 |
| `check-product-claims` / `claims:check` / `claims:check-hardcoded` | 0 / 0 / 0 |
| `lint` / `typecheck` / `build` | 0 / 0 / 0 |
| `npm audit --audit-level=high` | 0 |
| Unit suite | **511/511** |
| MCP stdio · HTTP · rebinding · dashboard e2e | **11/11 · 14/14 · 3/3 · 10/10** |

The built server reports **`{"name":"iris-eval","version":"0.4.5"}`** over a live MCP `initialize`, and `.claims.json` regenerated to match.

## After merge

Publishing is a **tag push** (`v0.4.5`), which fires `release.yml`: `validate` (npm ci → typecheck → test → build) must pass before the OIDC publish to npm, GHCR and the GitHub Release. That tag is the one irreversible step in this whole session, so I'm surfacing it rather than firing it unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)