### PR TITLE
fix(release): server.json advertised 0.4.5 but pointed installs at 0.4.4

### DIFF
--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -35,6 +35,12 @@ echo ""
 
 # Core manifests
 check_version "server.json" ".version"
+# server.json ALSO carries the npm version inside packages[] — the reference
+# clients follow to install. It drifted to 0.4.4 while the top-level version
+# said 0.4.5, and this gate passed because it only looked at `.version`.
+# Publishing that to the MCP Registry would have advertised 0.4.5 while
+# pointing installs at the previous (vulnerable) package.
+check_version "server.json" ".packages[0].version"
 check_version "package-lock.json" ".version"
 
 # Agent discovery endpoint

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@iris-eval/mcp-server",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Caught while verifying the release end to end

Found before publishing to the MCP Registry — which is **non-reversible**.

`server.json` carries the version **twice**:

| Field | Was | Meaning |
|---|---|---|
| `.version` | `0.4.5` ✅ | bumped by the release |
| `.packages[0].version` | **`0.4.4`** ❌ | the npm reference clients actually follow to install |

`check-version.sh` only asserted `.version`, so the gate went green on a manifest that would have told every MCP client *"iris 0.4.5"* and then installed **`@iris-eval/mcp-server@0.4.4`** — the exact release we just published to fix three vulnerabilities.

Registry publishes can't be retracted, so this would have been fixed-forward in a later patch at best, with clients installing the vulnerable version in the meantime.

## Fix

- `server.json` `.packages[0].version` → `0.4.5`
- `check-version.sh` now asserts `.packages[0].version` as well, so the two can't drift again

## Gate verified both directions

Reintroducing `0.4.4`:
```
MISMATCH: server.json (0.4.4) != package.json (0.4.5)
Version check FAILED with 1 mismatch(es).   exit 1
```
Restoring → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)