### PR TITLE
fix(website): npm version badge cached the OLD version for 24h after release

### DIFF
--- a/website/src/components/hero.tsx
+++ b/website/src/components/hero.tsx
@@ -10,7 +10,12 @@ const COMPAT = ["Claude Desktop", "Cursor", "Claude Code", "Windsurf", "LangChai
 const BADGES = [
   { src: "https://glama.ai/mcp/servers/iris-eval/mcp-server/badges/score.svg", alt: "Glama Score", href: "https://glama.ai/mcp/servers/iris-eval/mcp-server" },
   { src: "https://img.shields.io/badge/Cursor_Directory-Listed-171717?style=flat-square", alt: "Cursor Directory", href: "https://cursor.directory/plugins/iris" },
-  { src: "https://img.shields.io/npm/v/@iris-eval/mcp-server?style=flat-square&color=0d9488&label=npm&cacheSeconds=86400", alt: "npm version", href: "https://www.npmjs.com/package/@iris-eval/mcp-server" },
+  // No cacheSeconds on the VERSION badge. At 86400 shields.io served the
+  // previous version for a full day after a release — the site showed
+  // v0.4.4 while npm, the registry and our own banner all said v0.4.5,
+  // which reads as "the release did not land". Freshness matters here;
+  // it does not for a download counter.
+  { src: "https://img.shields.io/npm/v/@iris-eval/mcp-server?style=flat-square&color=0d9488&label=npm", alt: "npm version", href: "https://www.npmjs.com/package/@iris-eval/mcp-server" },
   { src: "https://img.shields.io/npm/dt/@iris-eval/mcp-server?style=flat-square&color=0d9488&label=downloads&cacheSeconds=86400", alt: "npm downloads", href: "https://www.npmjs.com/package/@iris-eval/mcp-server" },
   { src: "https://img.shields.io/github/stars/iris-eval/mcp-server?style=flat-square&color=0d9488&label=stars", alt: "GitHub stars", href: "https://github.com/iris-eval/mcp-server" },
   { src: "https://img.shields.io/github/actions/workflow/status/iris-eval/mcp-server/ci.yml?style=flat-square&label=CI", alt: "CI status", href: "https://github.com/iris-eval/mcp-server/actions" },


### PR DESCRIPTION
## What you saw

Top banner read **v0.4.5**; the hero's npm badge read **v0.4.4** — in an Incognito window, so not browser cache.

## Cause

The badge URL carried **`cacheSeconds=86400`**, telling shields.io to serve the same SVG for a full day. After any release the site contradicts itself for 24 hours: banner, npm, the MCP Registry and `.well-known/mcp.json` all say the new version while the most eye-catching badge says the old one. It reads as *"the release didn't land."*

## Confirmed, not assumed

Same badge, same moment:

| URL | Result |
|---|---|
| `...&cacheSeconds=86400` | **v0.4.4** |
| same URL without it | **v0.4.5** |

And shields returns `cache-control: max-age=86400, s-maxage=86400` for the cached variant.

## Fix

Removed `cacheSeconds` from the **version** badge only. The **downloads** badge keeps it — a stale download counter costs nothing; a stale version number tells visitors the current release isn't out.

## Why my earlier checks missed it

I grepped the page HTML, where the version lives inside an `<img>` pointing at shields.io — the number is rendered in the **SVG**, never in the markup. Checking a page for a version means checking what its badges *resolve to*, not just its text. Good catch.

Verified: website `lint` 0, `tsc --noEmit` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)