### PR TITLE
fix(tests): IRIS_HOME override — stop test runs mutating the user's real ~/.iris

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-07T19:26:15.144Z",
-  "generatedFromCommit": "02029ff",
+  "generatedAt": "2026-08-10T15:15:23.115Z",
+  "generatedFromCommit": "0300151",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 641,
+    "totalCombined": 644,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 517,
-      "total": 517
+      "passed": 520,
+      "total": 520
     }
   },
   "version": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@
  * run alongside tests without colliding.
  */
 import { defineConfig, devices } from '@playwright/test';
-import { E2E_PORT, E2E_DB_PATH, E2E_BASE_URL } from './tests/e2e/_constants.js';
+import { E2E_PORT, E2E_DB_DIR, E2E_DB_PATH, E2E_BASE_URL } from './tests/e2e/_constants.js';
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -45,6 +45,16 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,
     env: {
+      /*
+       * IRIS_HOME confines EVERY per-user file (config.json, iris.db,
+       * custom-rules.json, audit.log, preferences.json) to the temp dir.
+       * Before this, only the DB was isolated: each run WIPED the real
+       * ~/.iris/audit.log, deployed make-rule test rules into the real
+       * custom-rules.json (8 pieces of april-2026 debris shipped in the
+       * founder's live store for months), and overwrote the real
+       * preferences.json via the globalSetup PATCH.
+       */
+      IRIS_HOME: E2E_DB_DIR,
       IRIS_DB_PATH: E2E_DB_PATH,
       IRIS_NO_AUTO_LAUNCH: '1',
     },

--- a/src/audit-log-reader.ts
+++ b/src/audit-log-reader.ts
@@ -12,7 +12,7 @@
  */
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { irisHome } from './utils/iris-home.js';
 import { z } from 'zod';
 import type { AuditLogEntry } from './types/custom-rule.js';
 
@@ -52,7 +52,7 @@ export interface AuditQueryResult {
 }
 
 function defaultAuditPath(): string {
-  return join(homedir(), '.iris', 'audit.log');
+  return join(irisHome(), 'audit.log');
 }
 
 export function readAuditLog(opts?: {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,9 +1,7 @@
 import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import type { IrisConfig } from '../types/index.js';
-
-const irisHome = join(homedir(), '.iris');
+import { irisHome } from '../utils/iris-home.js';
 
 // Read version from package.json to avoid hardcoded drift
 let pkgVersion = '0.1.8';
@@ -21,7 +19,7 @@ export const PKG_VERSION = pkgVersion;
 export const defaultConfig: IrisConfig = {
   storage: {
     type: 'sqlite',
-    path: join(irisHome, 'iris.db'),
+    path: join(irisHome(), 'iris.db'),
   },
   server: {
     name: 'iris-eval',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,8 +1,8 @@
 import { readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
 import type { IrisConfig } from '../types/index.js';
 import { defaultConfig } from './defaults.js';
+import { irisHome } from '../utils/iris-home.js';
 
 function deepMerge(target: any, source: any): any {
   const result = { ...target };
@@ -125,12 +125,12 @@ function cliArgsToConfig(args: CliArgs): Partial<IrisConfig> {
 }
 
 export function loadConfig(cliArgs?: CliArgs): IrisConfig {
-  const irisHome = join(homedir(), '.iris');
-  if (!existsSync(irisHome)) {
-    mkdirSync(irisHome, { recursive: true });
+  const home = irisHome();
+  if (!existsSync(home)) {
+    mkdirSync(home, { recursive: true });
   }
 
-  const configPath = cliArgs?.config ?? join(irisHome, 'config.json');
+  const configPath = cliArgs?.config ?? join(home, 'config.json');
   const fileConfig = loadConfigFile(configPath);
   const envConfig = loadEnvVars();
   const argsConfig = cliArgs ? cliArgsToConfig(cliArgs) : {};

--- a/src/custom-rule-store.ts
+++ b/src/custom-rule-store.ts
@@ -25,8 +25,8 @@
  */
 import { mkdirSync, readFileSync, existsSync, appendFileSync } from 'node:fs';
 import { writeAtomic } from './utils/write-atomic.js';
+import { irisHome } from './utils/iris-home.js';
 import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { z } from 'zod';
 import isSafeRegex from 'safe-regex2';
@@ -203,17 +203,17 @@ const FileSchema = z.object({
  */
 function defaultPathFor(tenantId: TenantId): string {
   if (tenantId === LOCAL_TENANT) {
-    return join(homedir(), '.iris', 'custom-rules.json');
+    return join(irisHome(), 'custom-rules.json');
   }
   // Sanitize tenant id for filesystem safety. TenantId is branded but
   // could in principle contain odd chars on Cloud — limit to a known-safe
   // alphabet so we never write outside the .iris directory.
   const safe = String(tenantId).replace(/[^a-zA-Z0-9._-]/g, '_');
-  return join(homedir(), '.iris', `custom-rules-${safe}.json`);
+  return join(irisHome(), `custom-rules-${safe}.json`);
 }
 
 function defaultAuditPath(): string {
-  return join(homedir(), '.iris', 'audit.log');
+  return join(irisHome(), 'audit.log');
 }
 
 export interface CustomRuleStore {

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -129,8 +129,9 @@ export function createDashboardServer(
     // Without this warning the server logs "Dashboard available at ..."
     // while every page request 404s — an npm install always ships the
     // bundle, so this only bites from-source runs, but when it bites the
-    // failure is opaque (an E2E run once failed all 26 tests with nothing
-    // but element-not-found timeouts before this line existed).
+    // failure is opaque (before this line existed, a UI-less checkout
+    // failed the entire E2E suite with nothing but element-not-found
+    // timeouts).
     logger.warn(
       `Dashboard UI bundle not found at ${indexHtml} — serving API only. ` +
         `Build it with: cd dashboard && npm run build`,

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -125,6 +125,16 @@ export function createDashboardServer(
     app.get('/{*path}', (_req, res) => {
       res.sendFile(indexHtml);
     });
+  } else {
+    // Without this warning the server logs "Dashboard available at ..."
+    // while every page request 404s — an npm install always ships the
+    // bundle, so this only bites from-source runs, but when it bites the
+    // failure is opaque (an E2E run once failed all 26 tests with nothing
+    // but element-not-found timeouts before this line existed).
+    logger.warn(
+      `Dashboard UI bundle not found at ${indexHtml} — serving API only. ` +
+        `Build it with: cd dashboard && npm run build`,
+    );
   }
 
   // Error handler (must be last)

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,9 @@ Environment variables (CLI flags take precedence):
   IRIS_TRANSPORT                       stdio | http
   IRIS_HOST                            Bind address for HTTP transport (default: 127.0.0.1)
   IRIS_PORT                            HTTP transport port (1-65535)
-  IRIS_DB_PATH                         SQLite database path
+  IRIS_HOME                            Directory for all per-user files: config.json, iris.db, custom-rules.json,
+                                       audit.log, preferences.json (default: ~/.iris)
+  IRIS_DB_PATH                         SQLite database path (overrides IRIS_HOME for the DB only)
   IRIS_LOG_LEVEL                       debug | info | warn | error
   IRIS_DASHBOARD                       true to enable web dashboard
   IRIS_DASHBOARD_PORT                  Dashboard port (1-65535, default: 6920)

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -18,10 +18,10 @@
  * /moments), dismissedTours, archivedMoments. These let the dashboard
  * remember the user's last view across reloads + across iris-mcp restarts.
  */
-import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { writeAtomic } from './utils/write-atomic.js';
-import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
+import { irisHome } from './utils/iris-home.js';
+import { join } from 'node:path';
 import { z } from 'zod';
 
 const MomentFiltersSchema = z
@@ -77,7 +77,7 @@ export interface PreferenceState {
 }
 
 function defaultPreferencesPath(): string {
-  return join(homedir(), '.iris', 'preferences.json');
+  return join(irisHome(), 'preferences.json');
 }
 
 function freshPreferences(): Preferences {

--- a/src/utils/iris-home.ts
+++ b/src/utils/iris-home.ts
@@ -1,0 +1,22 @@
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/*
+ * Single resolver for the iris home directory (default: ~/.iris).
+ *
+ * Every per-user file iris touches lives under this directory — the
+ * SQLite DB default, config.json, custom-rules.json, audit.log,
+ * preferences.json. Before this helper each module joined
+ * homedir() + '.iris' itself, which meant there was no way to point a
+ * spawned server at a scratch directory: the E2E suite isolated the DB
+ * via IRIS_DB_PATH but still wiped the real audit.log, deployed test
+ * rules into the real custom-rules.json, and overwrote the real
+ * preferences.json on every run.
+ *
+ * IRIS_HOME redirects all of them at once. Read at call time — not
+ * module load — so a test harness that sets the env var before
+ * spawning (or between in-process calls) always wins.
+ */
+export function irisHome(): string {
+  return process.env.IRIS_HOME ?? join(homedir(), '.iris');
+}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -15,13 +15,12 @@
  */
 import { mkdirSync, appendFileSync, existsSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
 import Database from 'better-sqlite3';
 import { SqliteAdapter } from '../../src/storage/sqlite-adapter.js';
 import { LOCAL_TENANT } from '../../src/types/tenant.js';
 import type { Trace } from '../../src/types/trace.js';
 import type { EvalResult } from '../../src/types/eval.js';
-import { E2E_BASE_URL, E2E_DB_PATH } from './_constants.js';
+import { E2E_BASE_URL, E2E_DB_DIR, E2E_DB_PATH } from './_constants.js';
 
 const AGENTS = ['research-synthesizer', 'content-drafter', 'data-extractor', 'code-reviewer'];
 
@@ -156,10 +155,11 @@ export default async function globalSetup(): Promise<void> {
   }
 
   // 6. Seed one audit entry so PassRateAreaChart renders an annotation.
-  //    The audit log writer uses the real ~/.iris/audit.log path (we
-  //    don't override IRIS_HOME for OSS scope — documented known limit
-  //    in #4b's plan). For deterministic tests we reset then append.
-  const auditLog = join(homedir(), '.iris', 'audit.log');
+  //    The webServer runs with IRIS_HOME=E2E_DB_DIR (playwright.config),
+  //    so its audit log lives in the temp dir — resetting it here touches
+  //    ONLY test state. (Before IRIS_HOME existed this line wiped the
+  //    user's real ~/.iris/audit.log on every run.)
+  const auditLog = join(E2E_DB_DIR, 'audit.log');
   const auditDir = dirname(auditLog);
   if (!existsSync(auditDir)) mkdirSync(auditDir, { recursive: true });
   // Reset — every e2e run starts with a single deterministic entry.

--- a/tests/integration/stdio-transport.test.ts
+++ b/tests/integration/stdio-transport.test.ts
@@ -1,15 +1,40 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { resolve } from 'node:path';
+import {
+  StdioClientTransport,
+  getDefaultEnvironment,
+} from '@modelcontextprotocol/sdk/client/stdio.js';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 describe('Stdio Transport Integration', () => {
+  /*
+   * IRIS_HOME confines the spawned server to a scratch directory.
+   * Without it this test booted the server against the developer's real
+   * ~/.iris — opening (and, on a branch with newer migrations,
+   * silently UPGRADING) their live iris.db, and loading whatever custom
+   * rules they had deployed. getDefaultEnvironment() keeps PATH etc. so
+   * npx still resolves; env fully REPLACES the child environment, so
+   * both must be passed together.
+   */
+  let irisHome: string;
+
+  beforeAll(() => {
+    irisHome = mkdtempSync(join(tmpdir(), 'iris-stdio-test-'));
+  });
+
+  afterAll(() => {
+    rmSync(irisHome, { recursive: true, force: true });
+  });
+
   it('should connect to server via stdio and list tools', async () => {
     const serverPath = resolve(import.meta.dirname, '../../src/index.ts');
 
     const transport = new StdioClientTransport({
       command: 'npx',
       args: ['tsx', serverPath],
+      env: { ...getDefaultEnvironment(), IRIS_HOME: irisHome },
     });
 
     const client = new Client({ name: 'stdio-test', version: '0.1.0' });
@@ -22,6 +47,12 @@ describe('Stdio Transport Integration', () => {
       expect(names).toContain('log_trace');
       expect(names).toContain('evaluate_output');
       expect(names).toContain('get_traces');
+
+      // The spawned process (not this one) must have honoured IRIS_HOME:
+      // storage init creates iris.db under it at boot. This asserts the
+      // isolation through the real child-env path rather than trusting
+      // the in-process unit test for iris-home.
+      expect(existsSync(join(irisHome, 'iris.db'))).toBe(true);
     } finally {
       await client.close();
     }

--- a/tests/unit/utils/iris-home.test.ts
+++ b/tests/unit/utils/iris-home.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { irisHome } from '../../../src/utils/iris-home.js';
+
+const ORIGINAL = process.env.IRIS_HOME;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) {
+    delete process.env.IRIS_HOME;
+  } else {
+    process.env.IRIS_HOME = ORIGINAL;
+  }
+});
+
+describe('irisHome', () => {
+  it('defaults to ~/.iris', () => {
+    delete process.env.IRIS_HOME;
+    expect(irisHome()).toBe(join(homedir(), '.iris'));
+  });
+
+  it('honours IRIS_HOME', () => {
+    process.env.IRIS_HOME = join('C:', 'scratch', 'iris-test-home');
+    expect(irisHome()).toBe(join('C:', 'scratch', 'iris-test-home'));
+  });
+
+  it('reads the env at call time, not module load', () => {
+    // The E2E/stdio harnesses set IRIS_HOME on a CHILD process before
+    // spawn, but in-process callers (and future tests) may flip it
+    // between calls — a module-load snapshot would silently ignore that.
+    delete process.env.IRIS_HOME;
+    const before = irisHome();
+    process.env.IRIS_HOME = join('C:', 'scratch', 'flipped');
+    const after = irisHome();
+    expect(before).toBe(join(homedir(), '.iris'));
+    expect(after).toBe(join('C:', 'scratch', 'flipped'));
+  });
+});


### PR DESCRIPTION
## What

Adds a single `irisHome()` resolver (honours `IRIS_HOME`, read at call time) and routes every per-user path through it: config.json, iris.db default, custom-rules.json, audit.log, preferences.json. Points the Playwright webServer and the stdio integration test at temp homes.

## Why

Test isolation covered only the DB (`IRIS_DB_PATH`). Everything else leaked into the real `~/.iris`:

- **e2e global-setup wiped the real `audit.log`** on every local run (`writeFileSync(auditLog, '')`)
- **make-rule.spec deployed rules into the real `custom-rules.json`** — 8 `e2e-test-rule-*` entries from 2026-04-23 have been loading into every real server boot since
- **globalSetup's preferences PATCH persisted to the real `preferences.json`** (autoLaunch flipped off, seed-fixture agent filter left behind)
- **the stdio integration test booted the server on the real `iris.db`** — a branch with newer migrations would silently upgrade live data

## Also

The dashboard server now **warns** when `--dashboard` is enabled but `dist/dashboard/index.html` is missing, instead of logging "Dashboard available at …" over an Express 404. That silent lie made a UI-less E2E run fail all 26 tests with nothing but element-not-found timeouts.

## Verification

- 520/520 root tests (3 new for the resolver; stdio test now asserts the **child** process honoured `IRIS_HOME` via the temp-home iris.db — real spawn path, not in-process)
- 26/26 Playwright E2E (chromium + firefox)
- sha256 of the real `audit.log` / `custom-rules.json` / `preferences.json` byte-identical across a full E2E run
- `--help` documents `IRIS_HOME`; `IRIS_DB_PATH` still wins for the DB specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)