### PR TITLE
chore(lint): drop stale eslint-disable in tenant.ts

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -35,7 +35,6 @@ import { LOCAL_TENANT } from '../types/tenant.js';
  * without depending on the transitive package being hoisted.
  */
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       tenantId?: TenantId;


### PR DESCRIPTION
The `@typescript-eslint/no-namespace` disable no longer suppresses anything — the rule stopped flagging the global Express augmentation after a linting-group bump, and eslint now reports the directive itself as the root workspace's last lint warning. Removing it takes root lint to zero warnings.

Verified: `npm run lint` (0 problems) + `npm run typecheck` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)