### PR TITLE
fix(security): bind the dashboard to loopback + add DNS-rebinding guard

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-10T15:15:23.115Z",
-  "generatedFromCommit": "0300151",
+  "generatedAt": "2026-08-10T16:20:58.517Z",
+  "generatedFromCommit": "e9dad05",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 644,
+    "totalCombined": 655,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 520,
-      "total": 520
+      "passed": 531,
+      "total": 531
     }
   },
   "version": {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -33,6 +33,7 @@ export const defaultConfig: IrisConfig = {
   dashboard: {
     enabled: false,
     port: 6920,
+    host: '127.0.0.1',
   },
   eval: {
     defaultThreshold: 0.7,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -76,6 +76,12 @@ function loadEnvVars(): Partial<IrisConfig> {
       port: parsePortEnv(process.env.IRIS_DASHBOARD_PORT, 'IRIS_DASHBOARD_PORT'),
     };
   }
+  if (process.env.IRIS_DASHBOARD_HOST) {
+    config.dashboard = {
+      ...(config.dashboard as object),
+      host: process.env.IRIS_DASHBOARD_HOST,
+    };
+  }
   if (process.env.IRIS_API_KEY) {
     config.security = { ...(config.security as object), apiKey: process.env.IRIS_API_KEY };
   }
@@ -96,6 +102,7 @@ export interface CliArgs {
   dbPath?: string;
   dashboard?: boolean;
   dashboardPort?: number;
+  dashboardHost?: string;
   apiKey?: string;
 }
 
@@ -116,6 +123,9 @@ function cliArgsToConfig(args: CliArgs): Partial<IrisConfig> {
   }
   if (args.dashboardPort) {
     config.dashboard = { ...(config.dashboard as object), port: args.dashboardPort };
+  }
+  if (args.dashboardHost) {
+    config.dashboard = { ...(config.dashboard as object), host: args.dashboardHost };
   }
   if (args.apiKey) {
     config.security = { ...(config.security as object), apiKey: args.apiKey };

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -12,6 +12,7 @@ import { createCorsMiddleware } from '../middleware/cors.js';
 import { createErrorHandler } from '../middleware/error-handler.js';
 import { createApiRateLimiter } from '../middleware/rate-limit.js';
 import { createTenantMiddleware } from '../middleware/tenant.js';
+import { createRebindingGuard, isLoopbackHost } from '../middleware/rebinding-guard.js';
 import { registerTraceRoutes } from './routes/traces.js';
 import { registerSummaryRoutes } from './routes/summary.js';
 import { registerEvaluationRoutes } from './routes/evaluations.js';
@@ -67,6 +68,21 @@ export function createDashboardServer(
 
   // Body parser with size limit
   app.use(express.json({ limit: config.security.requestSizeLimit }));
+
+  /*
+   * DNS-rebinding guard BEFORE anything that reads or writes state. CORS
+   * runs after it and only decorates responses the guard already allowed —
+   * on its own CORS cannot stop a rebound page, because the write executes
+   * before the browser withholds the reply.
+   */
+  let boundPort: number | undefined;
+  app.use(
+    createRebindingGuard({
+      port: () => boundPort ?? config.dashboard.port,
+      host: config.dashboard.host,
+      allowedOrigins: config.security.allowedOrigins,
+    }),
+  );
 
   // CORS
   app.use(createCorsMiddleware(config.security.allowedOrigins));
@@ -144,8 +160,29 @@ export function createDashboardServer(
   return {
     app,
     start() {
-      const server = app.listen(config.dashboard.port, () => {
-        logger.info(`Dashboard available at http://localhost:${config.dashboard.port}`);
+      /*
+       * Bind to config.dashboard.host (loopback by default). Omitting the
+       * host argument makes Node listen on 0.0.0.0 AND [::], which put an
+       * unauthenticated API — full trace history plus rule deploy/delete —
+       * on every interface. That happened silently whenever `--transport
+       * http` started the dashboard implicitly, so binding the MCP
+       * transport to loopback still left a wide-open second server.
+       */
+      const server = app.listen(config.dashboard.port, config.dashboard.host, () => {
+        // Record the port actually bound so the rebinding guard builds its
+        // allowlist from it rather than from a configured 0.
+        const addr = server.address();
+        if (typeof addr === 'object' && addr) boundPort = addr.port;
+
+        const shown = isLoopbackHost(config.dashboard.host) ? 'localhost' : config.dashboard.host;
+        logger.info(`Dashboard available at http://${shown}:${boundPort ?? config.dashboard.port}`);
+        if (!isLoopbackHost(config.dashboard.host) && !config.security.apiKey) {
+          logger.warn(
+            `Dashboard is bound to ${config.dashboard.host} with NO api key — the full trace ` +
+              `history and rule management are reachable by anyone who can route to this host. ` +
+              `Set --api-key / IRIS_API_KEY, or bind to 127.0.0.1.`,
+          );
+        }
       });
       /*
        * F-006: surface listen() errors instead of swallowing them.

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ const CliSchema = z
     'api-key': z.string().min(1).optional(),
     dashboard: z.boolean().optional(),
     'dashboard-port': PortSchema.optional(),
+    'dashboard-host': z.string().min(1).optional(),
     help: z.boolean().optional(),
   })
   .strict();
@@ -47,6 +48,7 @@ try {
       'api-key': { type: 'string' },
       dashboard: { type: 'boolean', default: false },
       'dashboard-port': { type: 'string' },
+      'dashboard-host': { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
     strict: true,
@@ -80,6 +82,9 @@ Options:
   --api-key <key>          API key for HTTP authentication
   --dashboard              Enable web dashboard
   --dashboard-port <port>  Dashboard port 1-65535 (default: 6920)
+  --dashboard-host <host>  Dashboard bind address (default: 127.0.0.1). The dashboard is
+                           unauthenticated unless --api-key is set — binding it beyond
+                           loopback exposes your full trace history to the network.
   -h, --help               Show this help message
 
 Environment variables (CLI flags take precedence):
@@ -92,6 +97,7 @@ Environment variables (CLI flags take precedence):
   IRIS_LOG_LEVEL                       debug | info | warn | error
   IRIS_DASHBOARD                       true to enable web dashboard
   IRIS_DASHBOARD_PORT                  Dashboard port (1-65535, default: 6920)
+  IRIS_DASHBOARD_HOST                  Dashboard bind address (default: 127.0.0.1)
   IRIS_API_KEY                         API key for HTTP authentication
   IRIS_ALLOWED_ORIGINS                 Comma-separated origin allowlist. Dashboard: CORS headers (supports globs, e.g. http://localhost:*).
                                        HTTP transport: exact-match Origin allowlist for DNS-rebinding protection (globs ignored;
@@ -122,6 +128,7 @@ const config = loadConfig({
   apiKey: values['api-key'],
   dashboard: values.dashboard,
   dashboardPort: values['dashboard-port'],
+  dashboardHost: values['dashboard-host'],
 });
 
 const logger = createLogger(config);

--- a/src/middleware/rebinding-guard.ts
+++ b/src/middleware/rebinding-guard.ts
@@ -1,0 +1,102 @@
+import type { RequestHandler } from 'express';
+
+/*
+ * DNS-rebinding protection for the dashboard HTTP API.
+ *
+ * v0.4.5 closed this hole on the MCP transport (/mcp) by handing
+ * allowedOrigins + allowedHosts to the SDK. The dashboard — same data,
+ * plus every mutating endpoint — never got the equivalent, and it starts
+ * implicitly alongside `--transport http`. So a browser on any page could
+ * POST a rule deployment to http://localhost:6920 and the server would
+ * execute it.
+ *
+ * CORS does not substitute, for the reason already written down in
+ * transport/http.ts: the browser withholds the RESPONSE, but the write has
+ * already happened. The request has to be REJECTED.
+ *
+ * Two checks, mirroring the SDK's semantics:
+ *
+ *   Origin — enforced whenever the header is present. Absent means a
+ *   non-browser client (curl, an MCP client, a health probe), which is not
+ *   the threat model here; browsers always send it on cross-origin
+ *   requests. Exact match only — glob patterns from the CORS allowlist are
+ *   meaningless against a single concrete Origin and are dropped rather
+ *   than left in the list looking effective.
+ *
+ *   Host — enforced only when bound to loopback. A non-loopback bind is a
+ *   deliberate network deployment, usually behind a proxy that rewrites
+ *   Host, and an exact-match list would break it.
+ */
+export function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+}
+
+/** Concrete origins/hosts this server answers to on `port`. */
+export function loopbackOriginsFor(port: number): string[] {
+  return [`http://127.0.0.1:${port}`, `http://localhost:${port}`, `http://[::1]:${port}`];
+}
+
+export function loopbackHostsFor(port: number): string[] {
+  return [`127.0.0.1:${port}`, `localhost:${port}`, `[::1]:${port}`];
+}
+
+export interface RebindingGuardOptions {
+  /**
+   * Port the server is actually bound to. Accepts a resolver because the
+   * middleware is registered BEFORE listen() — and the configured port is
+   * 0 whenever the caller wants an ephemeral one (tests and embedders do
+   * this). Baking 0 into the allowlist would produce `http://localhost:0`
+   * and reject every real request with a 403 that looks exactly like an
+   * attack. Same trap the MCP transport documents at transport/http.ts.
+   */
+  port: number | (() => number);
+  /** Bind address, used to decide whether Host validation applies. */
+  host: string;
+  /** Operator's configured origins; glob entries are ignored (see above). */
+  allowedOrigins?: string[];
+}
+
+export function createRebindingGuard(options: RebindingGuardOptions): RequestHandler {
+  const { port, host, allowedOrigins = [] } = options;
+  const exactConfigured = allowedOrigins.filter((o) => !o.includes('*'));
+  const enforceHost = isLoopbackHost(host);
+
+  let cache: { port: number; origins: Set<string>; hosts: Set<string> } | undefined;
+
+  function listsFor(resolvedPort: number) {
+    if (cache?.port !== resolvedPort) {
+      cache = {
+        port: resolvedPort,
+        origins: new Set([...loopbackOriginsFor(resolvedPort), ...exactConfigured]),
+        /*
+         * `[::1]:port` is the form Node actually puts in the Host header
+         * for an IPv6 loopback request — brackets included. A guard
+         * written against the bare '::1' would be inert, which is exactly
+         * how the citation-fetch SSRF guard was silently dead before
+         * v0.4.5 (URL.hostname returns '[::1]', never '::1').
+         */
+        hosts: new Set(loopbackHostsFor(resolvedPort)),
+      };
+    }
+    return cache;
+  }
+
+  return (req, res, next) => {
+    const resolvedPort = typeof port === 'function' ? port() : port;
+    const { origins, hosts } = listsFor(resolvedPort);
+
+    const origin = req.headers.origin;
+    if (origin && !origins.has(origin)) {
+      res.status(403).json({ error: 'Forbidden: invalid Origin header' });
+      return;
+    }
+    if (enforceHost) {
+      const hostHeader = req.headers.host;
+      if (hostHeader && !hosts.has(hostHeader)) {
+        res.status(403).json({ error: 'Forbidden: invalid Host header' });
+        return;
+      }
+    }
+    next();
+  };
+}

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -5,9 +5,15 @@
  * downstream code path reads `req.tenantId`; nothing else reads headers
  * or session cookies to figure out which tenant a request belongs to.
  *
- * Current (OSS): always resolves to LOCAL_TENANT. The dashboard is
- * localhost-only; there's no session; there's no multi-tenancy. All
- * data belongs to the single implicit user.
+ * Current (OSS): always resolves to LOCAL_TENANT. There's no session and
+ * no multi-tenancy — all data belongs to the single implicit user.
+ *
+ * This rests on the dashboard binding to loopback (config.dashboard.host,
+ * default 127.0.0.1). That premise used to be asserted here and was FALSE:
+ * app.listen() was called without a host, so Node bound every interface
+ * and an unauthenticated API served the whole trace history to the local
+ * network. An operator who deliberately binds wider is expected to set an
+ * api key; the server warns at startup when they haven't.
  *
  * Future (Cloud): this file is where the swap happens. The resolver
  * reads the authenticated session (set by an upstream auth middleware),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -15,6 +15,13 @@ export interface IrisConfig {
   dashboard: {
     enabled: boolean;
     port: number;
+    /**
+     * Bind address. Defaults to loopback: the dashboard is unauthenticated
+     * by default (security.apiKey is undefined) and serves the full trace
+     * history, so binding it to every interface exposes agent inputs and
+     * outputs to the local network. Set explicitly to share it.
+     */
+    host: string;
   };
   eval: {
     defaultThreshold: number;

--- a/tests/e2e/_constants.ts
+++ b/tests/e2e/_constants.ts
@@ -11,4 +11,15 @@ import { tmpdir } from 'node:os';
 export const E2E_PORT = 6921;
 export const E2E_DB_DIR = join(tmpdir(), 'iris-e2e');
 export const E2E_DB_PATH = join(E2E_DB_DIR, 'iris.db');
-export const E2E_BASE_URL = `http://localhost:${E2E_PORT}`;
+/*
+ * 127.0.0.1, not localhost — address the interface the dashboard actually
+ * binds (config.dashboard.host, IPv4 loopback by default) instead of
+ * relying on `localhost` resolving to ::1 first and falling back on
+ * dual-stack hosts.
+ *
+ * Measured, so nobody re-derives it: this does NOT fix the intermittent
+ * Firefox page.reload() timeout in v2c-chrome.spec — that reproduces the
+ * same way against either address, and against a build without the
+ * loopback-bind change. It is a pre-existing flake, tracked separately.
+ */
+export const E2E_BASE_URL = `http://127.0.0.1:${E2E_PORT}`;

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import type { Server } from 'node:http';
 import { request as httpRequest } from 'node:http';
+import { once } from 'node:events';
 import { SqliteAdapter } from '../../src/storage/sqlite-adapter.js';
 import { createDashboardServer } from '../../src/dashboard/server.js';
 import { createHttpTransport } from '../../src/transport/http.js';
@@ -151,6 +152,7 @@ describe('HTTP Transport Integration', () => {
 
     const dashboard = createDashboardServer(storage, testConfig, mockLogger);
     httpServer = dashboard.start();
+    await once(httpServer, 'listening');
 
     const addr = httpServer.address();
     const port = typeof addr === 'object' && addr ? addr.port : 0;
@@ -168,6 +170,7 @@ describe('HTTP Transport Integration', () => {
 
     const dashboard = createDashboardServer(storage, testConfig, mockLogger);
     httpServer = dashboard.start();
+    await once(httpServer, 'listening');
 
     const addr = httpServer.address();
     const port = typeof addr === 'object' && addr ? addr.port : 0;
@@ -184,6 +187,7 @@ describe('HTTP Transport Integration', () => {
 
     const dashboard = createDashboardServer(storage, testConfig, mockLogger);
     httpServer = dashboard.start();
+    await once(httpServer, 'listening');
 
     const addr = httpServer.address();
     const port = typeof addr === 'object' && addr ? addr.port : 0;
@@ -201,6 +205,7 @@ describe('HTTP Transport Integration', () => {
 
     const dashboard = createDashboardServer(storage, testConfig, mockLogger);
     httpServer = dashboard.start();
+    await once(httpServer, 'listening');
 
     const addr = httpServer.address();
     const port = typeof addr === 'object' && addr ? addr.port : 0;
@@ -219,6 +224,7 @@ describe('HTTP Transport Integration', () => {
     const authConfig = { ...testConfig, security: { ...testConfig.security, apiKey: 'test-key' } };
     const dashboard = createDashboardServer(storage, authConfig, mockLogger);
     httpServer = dashboard.start();
+    await once(httpServer, 'listening');
 
     const addr = httpServer.address();
     const port = typeof addr === 'object' && addr ? addr.port : 0;
@@ -244,6 +250,7 @@ describe('HTTP Transport Integration', () => {
 
     const dashboard = createDashboardServer(storage, testConfig, mockLogger);
     httpServer = dashboard.start();
+    await once(httpServer, 'listening');
 
     const addr = httpServer.address();
     const port = typeof addr === 'object' && addr ? addr.port : 0;

--- a/tests/unit/middleware/rebinding-guard.test.ts
+++ b/tests/unit/middleware/rebinding-guard.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import { request as httpRequest } from 'node:http';
+import {
+  createRebindingGuard,
+  isLoopbackHost,
+  loopbackHostsFor,
+} from '../../../src/middleware/rebinding-guard.js';
+
+/*
+ * Every assertion drives a REAL express server over a REAL socket, so the
+ * header values under test are the ones Node actually produces rather than
+ * ones this file invented. That distinction is why the pre-0.4.5 SSRF guard
+ * was inert in production: its test asserted '::1' while URL.hostname
+ * returns '[::1]'.
+ *
+ * node:http rather than fetch, deliberately: `Host` is a forbidden header
+ * name in fetch, which drops it silently. A fetch-based test of the Host
+ * branch passes while asserting nothing — it did, on the first draft of
+ * this file.
+ */
+async function probe(
+  guard: { host: string; allowedOrigins?: string[] },
+  headers: { origin?: string; host?: string } = {},
+): Promise<number> {
+  const app = express();
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise((r) => server.once('listening', r));
+  const port = (server.address() as { port: number }).port;
+
+  // Built against the port actually bound, exactly as dashboard/server.ts does.
+  app.use(createRebindingGuard({ port, host: guard.host, allowedOrigins: guard.allowedOrigins }));
+  app.get('/api/v1/traces', (_req, res) => res.json({ ok: true }));
+
+  try {
+    return await new Promise<number>((resolve, reject) => {
+      const outgoing: Record<string, string> = {};
+      if (headers.origin) outgoing.Origin = headers.origin;
+      if (headers.host) outgoing.Host = headers.host;
+      const req = httpRequest(
+        { host: '127.0.0.1', port, path: '/api/v1/traces', method: 'GET', headers: outgoing },
+        (res) => {
+          res.resume();
+          res.once('end', () => resolve(res.statusCode ?? 0));
+        },
+      );
+      req.once('error', reject);
+      req.end();
+    });
+  } finally {
+    server.close();
+  }
+}
+
+describe('DNS-rebinding guard', () => {
+  it('allows a request with no Origin (curl, MCP client, health probe)', async () => {
+    expect(await probe({ host: '127.0.0.1' })).toBe(200);
+  });
+
+  it("allows this server's own loopback origin", async () => {
+    const app = express();
+    const server = app.listen(0, '127.0.0.1');
+    await new Promise((r) => server.once('listening', r));
+    const port = (server.address() as { port: number }).port;
+    app.use(createRebindingGuard({ port, host: '127.0.0.1' }));
+    app.get('/api/v1/traces', (_req, res) => res.json({ ok: true }));
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/v1/traces`, {
+        headers: { Origin: `http://localhost:${port}` },
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('REJECTS a hostile Origin — the rebinding attack', async () => {
+    expect(await probe({ host: '127.0.0.1' }, { origin: 'http://evil.attacker.com' })).toBe(403);
+  });
+
+  it('rejects a loopback origin on a DIFFERENT port', async () => {
+    // Another local app (or a rebound page that guessed a port) is still
+    // cross-origin to this server.
+    expect(await probe({ host: '127.0.0.1' }, { origin: 'http://localhost:1' })).toBe(403);
+  });
+
+  it('drops glob entries from the operator allowlist instead of honouring them', async () => {
+    // 'http://localhost:*' is the SHIPPED CORS default. Against a single
+    // concrete Origin a glob cannot be matched safely, so it must not pass —
+    // otherwise the default config defeats the guard.
+    expect(
+      await probe(
+        { host: '127.0.0.1', allowedOrigins: ['http://localhost:*'] },
+        { origin: 'http://localhost:9999' },
+      ),
+    ).toBe(403);
+  });
+
+  it('honours an exact operator-configured origin', async () => {
+    expect(
+      await probe(
+        { host: '127.0.0.1', allowedOrigins: ['http://my-proxy.internal:8080'] },
+        { origin: 'http://my-proxy.internal:8080' },
+      ),
+    ).toBe(200);
+  });
+
+  it('rejects a foreign Host header when bound to loopback', async () => {
+    expect(await probe({ host: '127.0.0.1' }, { host: 'attacker-controlled.example.com' })).toBe(
+      403,
+    );
+  });
+
+  it('does NOT enforce Host when bound beyond loopback (proxy deployments)', async () => {
+    expect(await probe({ host: '0.0.0.0' }, { host: 'iris.internal.example.com' })).toBe(200);
+  });
+});
+
+describe('ephemeral-port binding', () => {
+  it('builds the allowlist from the bound port, not the configured 0', async () => {
+    /*
+     * The dashboard registers this middleware BEFORE listen(), and callers
+     * that want an ephemeral port configure 0. A guard that captured the
+     * configured value would allow only `http://localhost:0` and 403 every
+     * legitimate request — an outage dressed as an attack. Same failure the
+     * MCP transport avoids by binding first.
+     */
+    const app = express();
+    let boundPort: number | undefined;
+    app.use(createRebindingGuard({ port: () => boundPort ?? 0, host: '127.0.0.1' }));
+    app.get('/api/v1/traces', (_req, res) => res.json({ ok: true }));
+
+    const server = app.listen(0, '127.0.0.1');
+    await new Promise((r) => server.once('listening', r));
+    const port = (server.address() as { port: number }).port;
+    boundPort = port;
+
+    try {
+      const allowed = await fetch(`http://127.0.0.1:${port}/api/v1/traces`, {
+        headers: { Origin: `http://127.0.0.1:${port}` },
+      });
+      expect(allowed.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe('loopback helpers', () => {
+  it('treats the bracketed IPv6 literal as loopback', () => {
+    // Node reports the IPv6 loopback Host header as '[::1]:port' — brackets
+    // included. A guard written against bare '::1' would never fire.
+    expect(isLoopbackHost('[::1]')).toBe(true);
+    expect(isLoopbackHost('::1')).toBe(true);
+    expect(isLoopbackHost('127.0.0.1')).toBe(true);
+    expect(isLoopbackHost('localhost')).toBe(true);
+    expect(isLoopbackHost('0.0.0.0')).toBe(false);
+    expect(isLoopbackHost('192.168.1.10')).toBe(false);
+  });
+
+  it('builds host allowlists in the bracketed form Node emits', () => {
+    expect(loopbackHostsFor(6920)).toContain('[::1]:6920');
+  });
+});


### PR DESCRIPTION
## The hole

v0.4.5 closed DNS rebinding on `/mcp` and left the dashboard open — same data, plus every mutating endpoint.

`src/dashboard/server.ts` called `app.listen(port)` with **no host argument**, so Node bound `0.0.0.0` and `[::]`. Combined with `security.apiKey` being `undefined` by default (which makes the auth middleware a pass-through), that put the full trace history — agent inputs and outputs — plus rule deploy/delete on every interface, unauthenticated, with no Origin check.

Three aggravators:
- The dashboard starts **implicitly** with `--transport http`, so binding the MCP transport to loopback still left a second wide-open server on the adjacent port.
- No `dashboard.host` config key existed anywhere, so an operator who knew about it could not fix it.
- `src/middleware/tenant.ts` asserted "the dashboard is localhost-only" as the premise the entire tenant model rests on. It was false.

## The fix

- `dashboard.host` config, default `127.0.0.1`, with `IRIS_DASHBOARD_HOST` and `--dashboard-host`, documented in `--help`.
- New `src/middleware/rebinding-guard.ts`: rejects a foreign `Origin` whenever the header is present, and a foreign `Host` when bound to loopback. CORS is **not** a substitute — the browser only withholds the *response*, after the write has already executed (the reasoning `transport/http.ts` already documents). Glob entries from the CORS allowlist are dropped rather than left in the list looking effective, so the shipped default `http://localhost:*` cannot defeat the guard.
- Startup **warns** when bound beyond loopback with no api key.
- Corrected the false premise comment in `tenant.ts`.

## Two traps handled explicitly

**Ephemeral ports.** The guard resolves its port through a callback, because middleware is registered *before* `listen()` and the configured port is `0` whenever the caller wants an ephemeral one. Capturing that would allowlist `http://localhost:0` and 403 every legitimate request — an outage dressed as an attack. Same trap `transport/http.ts` documents.

**Forbidden header names.** The Host tests drive `node:http`, not `fetch`. `Host` is a forbidden header name in fetch and is dropped silently — the first draft of this test passed while sending no Host header at all. Same shape as the `'::1'` vs `'[::1]'` guard that shipped inert before v0.4.5, so the bracketed IPv6 form is asserted directly.

## Verification

- **531/531** root tests (11 new covering: hostile Origin → 403, own loopback origin → 200, foreign Host → 403, Host not enforced off-loopback, glob entries dropped, exact operator origin honoured, ephemeral-port binding, bracketed IPv6)
- 13/13 chromium E2E, typecheck + lint clean
- `http-transport.test.ts` now awaits `'listening'` before reading `address()` — passing a host makes the bind asynchronous, so `address()` is null immediately after `listen()`; the old code read it synchronously and got away with it

**Known unrelated flake:** `v2c-chrome` `page.reload()` on firefox-on-Windows intermittently times out. Reproduced **3/3 on unmodified main**, so it predates this change; CI's ubuntu e2e is green. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)