### PR TITLE
fix(storage): evals silently dropped from every time window + rule store destroying user data

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-10T16:20:58.517Z",
-  "generatedFromCommit": "e9dad05",
+  "generatedAt": "2026-08-10T16:26:06.394Z",
+  "generatedFromCommit": "5373248",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 655,
+    "totalCombined": 662,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 531,
-      "total": 531
+      "passed": 538,
+      "total": 538
     }
   },
   "version": {

--- a/src/custom-rule-store.ts
+++ b/src/custom-rule-store.ts
@@ -192,11 +192,6 @@ const DeployedRuleSchema = z.object({
   version: z.number().int().positive(),
 });
 
-const FileSchema = z.object({
-  version: z.literal(1),
-  rules: z.array(DeployedRuleSchema),
-});
-
 /**
  * Default file path for a tenant. LOCAL_TENANT keeps the v0.4 path
  * (zero migration); others get a per-tenant suffix.
@@ -258,18 +253,59 @@ function appendAudit(auditPath: string, entry: AuditLogEntry): void {
   }
 }
 
-function loadRulesFromDisk(rulesPath: string): DeployedCustomRule[] {
-  if (!existsSync(rulesPath)) return [];
+interface LoadedRules {
+  /** Rules that validated — these are the ones that fire. */
+  rules: DeployedCustomRule[];
+  /**
+   * Entries that did NOT validate, preserved byte-for-byte. They never
+   * fire, but persist() writes them back so a later deploy cannot delete
+   * them. Without this the store silently destroys user data (below).
+   */
+  quarantined: unknown[];
+  /**
+   * False when the file exists but could not be read or JSON-parsed at
+   * all. persist() refuses to write in that state rather than replacing
+   * a file it never understood.
+   */
+  readable: boolean;
+}
+
+/*
+ * Read leniently, one rule at a time.
+ *
+ * This used to validate the whole array with a single safeParse and return
+ * [] if ANY element failed. The empty result was then cached, and the next
+ * deploy/delete/toggle called persist(), which wrote {version:1, rules:[]}
+ * over the file — permanently destroying every valid rule alongside the
+ * bad one. The old comment ("do NOT overwrite the file") described an
+ * intent the write path did not honour.
+ *
+ * It was reachable, not theoretical: DefinitionSchema's superRefine now
+ * runs on READ as well as WRITE, and eval/rules/custom.ts notes that rules
+ * predating that validation — e.g. {type:'min_length', config:{}} — are
+ * already sitting in users' files.
+ */
+function loadRulesFromDisk(rulesPath: string): LoadedRules {
+  if (!existsSync(rulesPath)) return { rules: [], quarantined: [], readable: true };
+
+  let parsedJson: unknown;
   try {
-    const raw = readFileSync(rulesPath, 'utf-8');
-    const parsed = FileSchema.safeParse(JSON.parse(raw));
-    if (parsed.success) return parsed.data.rules;
-    // Malformed: leave rules empty; do NOT overwrite the file.
-    return [];
+    parsedJson = JSON.parse(readFileSync(rulesPath, 'utf-8'));
   } catch {
-    // Unreadable: leave rules empty.
-    return [];
+    return { rules: [], quarantined: [], readable: false };
   }
+
+  const envelope = z.object({ rules: z.array(z.unknown()).optional() }).safeParse(parsedJson);
+  if (!envelope.success) return { rules: [], quarantined: [], readable: false };
+
+  const rules: DeployedCustomRule[] = [];
+  const quarantined: unknown[] = [];
+  for (const entry of envelope.data.rules ?? []) {
+    const rule = DeployedRuleSchema.safeParse(entry);
+    if (rule.success) rules.push(rule.data);
+    else quarantined.push(entry);
+  }
+  return { rules, quarantined, readable: true };
 }
 
 export function createCustomRuleStore(opts?: {
@@ -288,20 +324,41 @@ export function createCustomRuleStore(opts?: {
 
   // In-memory cache keyed by tenant. Lazy-loaded on first access per
   // tenant; subsequent calls hit the cache.
-  const tenantRules = new Map<TenantId, DeployedCustomRule[]>();
+  const tenantState = new Map<TenantId, LoadedRules>();
+
+  function state(tenantId: TenantId): LoadedRules {
+    let loaded = tenantState.get(tenantId);
+    if (loaded === undefined) {
+      loaded = loadRulesFromDisk(pathFor(tenantId));
+      tenantState.set(tenantId, loaded);
+    }
+    return loaded;
+  }
 
   function load(tenantId: TenantId): DeployedCustomRule[] {
-    let rules = tenantRules.get(tenantId);
-    if (rules === undefined) {
-      rules = loadRulesFromDisk(pathFor(tenantId));
-      tenantRules.set(tenantId, rules);
-    }
-    return rules;
+    return state(tenantId).rules;
   }
 
   function persist(tenantId: TenantId): void {
-    const rules = tenantRules.get(tenantId) ?? [];
-    const file: CustomRulesFile = { version: 1, rules };
+    const loaded = state(tenantId);
+    if (!loaded.readable) {
+      /*
+       * The file exists but never parsed. Overwriting it would replace
+       * content we could not read — exactly the data loss this store used
+       * to cause silently. Fail loudly so the caller surfaces a 500 and
+       * the operator can fix or move the file.
+       */
+      throw new Error(
+        `Refusing to write ${pathFor(tenantId)}: the existing file could not be parsed. ` +
+          `Fix or move it, then retry — writing now would destroy its contents.`,
+      );
+    }
+    // Quarantined entries ride along untouched so a deploy never deletes
+    // rules this version could not validate.
+    const file: CustomRulesFile = {
+      version: 1,
+      rules: [...loaded.rules, ...loaded.quarantined] as DeployedCustomRule[],
+    };
     writeAtomic(pathFor(tenantId), JSON.stringify(file, null, 2));
   }
 

--- a/src/storage/migrations/005-normalize-created-at.ts
+++ b/src/storage/migrations/005-normalize-created-at.ts
@@ -1,0 +1,37 @@
+import type Database from 'better-sqlite3';
+
+export const id = '005-normalize-created-at';
+
+/*
+ * Normalize created_at to ISO-8601 UTC.
+ *
+ * The column's DEFAULT is `datetime('now')`, which SQLite renders as
+ * "2026-08-09 15:00:00" — space separator, no milliseconds, no Z. Nothing
+ * ever wrote the column explicitly, so every row carried that shape. But
+ * every query compares it against a JS `toISOString()` value
+ * ("2026-08-09T15:00:00.000Z") using plain string comparison.
+ *
+ * ' ' is 0x20 and 'T' is 0x54, so the stored value sorts BEFORE any
+ * same-date boundary. Result: every eval whose calendar date equalled the
+ * window boundary's date was silently dropped from the window. A 20-hour-old
+ * eval vanished from "last 24h"; at 01:00 UTC the 24h view showed only what
+ * had happened since midnight. Traces were unaffected — log-trace writes a
+ * real ISO string — which is why this presented as "my evals are missing but
+ * my traces aren't".
+ *
+ * Fix in two halves: the adapter now writes ISO explicitly (so the DEFAULT
+ * never fires), and this migration rewrites the rows already on disk.
+ * strftime with %f gives milliseconds; SQLite stores UTC, so the literal Z
+ * is accurate. Rows already in ISO form are left alone — the LIKE guard
+ * matches only the space-separated shape, which keeps this idempotent and
+ * safe to run against a partially-migrated DB.
+ */
+export function up(db: Database.Database): void {
+  for (const table of ['traces', 'eval_results']) {
+    db.exec(`
+      UPDATE ${table}
+         SET created_at = strftime('%Y-%m-%dT%H:%M:%fZ', created_at)
+       WHERE created_at LIKE '____-__-__ __:__:__%'
+    `);
+  }
+}

--- a/src/storage/migrations/index.ts
+++ b/src/storage/migrations/index.ts
@@ -3,13 +3,20 @@ import * as migration001 from './001-initial-schema.js';
 import * as migration002 from './002-eval-skip-fields.js';
 import * as migration003 from './003-eval-passed-index.js';
 import * as migration004 from './004-tenant-id.js';
+import * as migration005 from './005-normalize-created-at.js';
 
 interface Migration {
   id: string;
   up(db: Database.Database): void;
 }
 
-const migrations: Migration[] = [migration001, migration002, migration003, migration004];
+const migrations: Migration[] = [
+  migration001,
+  migration002,
+  migration003,
+  migration004,
+  migration005,
+];
 
 export function runMigrations(db: Database.Database): void {
   db.exec(`

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -224,9 +224,17 @@ export class SqliteAdapter implements IStorageAdapter {
 
   async insertEvalResult(tenantId: TenantId, result: EvalResult): Promise<void> {
     assertTenant(tenantId);
+    /*
+     * created_at is written EXPLICITLY as ISO-8601. Leaving it to the
+     * column DEFAULT (datetime('now')) stored "2026-08-09 15:00:00", which
+     * every period query then compared as a string against a JS
+     * toISOString() boundary — and ' ' sorts before 'T', so any eval whose
+     * calendar date matched the boundary's date was dropped from the
+     * window. Migration 005 rewrites rows written before this line existed.
+     */
     this.db.prepare(`
-      INSERT INTO eval_results (tenant_id, id, trace_id, eval_type, output_text, expected_text, score, passed, rule_results, suggestions, rules_evaluated, rules_skipped, insufficient_data)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO eval_results (tenant_id, id, trace_id, eval_type, output_text, expected_text, score, passed, rule_results, suggestions, rules_evaluated, rules_skipped, insufficient_data, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       tenantId,
       result.id,
@@ -241,6 +249,7 @@ export class SqliteAdapter implements IStorageAdapter {
       result.rules_evaluated ?? null,
       result.rules_skipped ?? null,
       result.insufficient_data ? 1 : 0,
+      new Date().toISOString(),
     );
   }
 

--- a/tests/unit/custom-rule-store.test.ts
+++ b/tests/unit/custom-rule-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createCustomRuleStore } from '../../src/custom-rule-store.js';
@@ -226,5 +226,90 @@ describe('createCustomRuleStore (single-tenant / OSS)', () => {
       definition: { name: 'short', type: 'regex_no_match', config: { pattern: 'x' } },
     });
     expect(rule.name).toBe('short');
+  });
+});
+
+/*
+ * Regression: a single unparseable rule used to wipe the whole file.
+ *
+ * loadRulesFromDisk validated the entire array with one safeParse and
+ * returned [] if ANY element failed. That empty result was cached, and the
+ * next deploy called persist(), which wrote {version:1, rules:[]} over the
+ * file — destroying every valid rule alongside the bad one, with no error
+ * anywhere. The old comment claimed "do NOT overwrite the file"; the write
+ * path did not honour it.
+ *
+ * Reachable in the field: DefinitionSchema's superRefine runs on READ as
+ * well as WRITE, and eval/rules/custom.ts documents that rules predating
+ * that validation (e.g. {type:'min_length', config:{}}) already exist in
+ * users' files.
+ */
+describe('lenient load — one bad rule must not destroy the file', () => {
+  const validRule = {
+    id: 'rule-keepme',
+    name: 'keep-me',
+    description: 'a perfectly good rule',
+    evalType: 'custom',
+    severity: 'medium',
+    definition: { name: 'keep-me', type: 'min_length', config: { min_length: 10 } },
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    version: 1,
+  };
+  // Exactly the legacy shape custom.ts says is already on disk.
+  const legacyRule = {
+    id: 'rule-legacy',
+    name: 'legacy-no-config',
+    description: 'deployed before config validation existed',
+    evalType: 'custom',
+    severity: 'medium',
+    definition: { name: 'legacy-no-config', type: 'min_length', config: {} },
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    version: 1,
+  };
+
+  it('keeps the valid rules and quarantines only the invalid one', () => {
+    writeFileSync(rulesPath, JSON.stringify({ version: 1, rules: [validRule, legacyRule] }));
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    const listed = store.list(LOCAL_TENANT);
+    expect(listed.map((r) => r.id)).toEqual(['rule-keepme']);
+  });
+
+  it('a later deploy does NOT delete the valid rule or the quarantined one', () => {
+    writeFileSync(rulesPath, JSON.stringify({ version: 1, rules: [validRule, legacyRule] }));
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    store.deploy(LOCAL_TENANT, {
+      name: 'brand-new',
+      description: 'deployed after the bad rule was already on disk',
+      evalType: 'custom',
+      severity: 'medium',
+      definition: { name: 'brand-new', type: 'min_length', config: { min_length: 5 } },
+    } as Parameters<typeof store.deploy>[1]);
+
+    const onDisk = JSON.parse(readFileSync(rulesPath, 'utf-8'));
+    const ids = onDisk.rules.map((r: { id: string }) => r.id);
+    expect(ids).toContain('rule-keepme'); // survived — this is the data-loss guard
+    expect(ids).toContain('rule-legacy'); // preserved verbatim, never activated
+    expect(onDisk.rules).toHaveLength(3);
+  });
+
+  it('refuses to write over a file it could not parse at all', () => {
+    writeFileSync(rulesPath, '{ this is not json');
+    const store = createCustomRuleStore({ pathFor: () => rulesPath, auditPath });
+    expect(store.list(LOCAL_TENANT)).toEqual([]);
+    expect(() =>
+      store.deploy(LOCAL_TENANT, {
+        name: 'should-not-land',
+        description: 'writing here would destroy unreadable content',
+        evalType: 'custom',
+        severity: 'medium',
+        definition: { name: 'should-not-land', type: 'min_length', config: { min_length: 5 } },
+      } as Parameters<typeof store.deploy>[1]),
+    ).toThrow(/could not be parsed/);
+    // The unreadable file is still exactly as the user left it.
+    expect(readFileSync(rulesPath, 'utf-8')).toBe('{ this is not json');
   });
 });

--- a/tests/unit/storage/created-at-format.test.ts
+++ b/tests/unit/storage/created-at-format.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SqliteAdapter } from '../../../src/storage/sqlite-adapter.js';
+import { LOCAL_TENANT } from '../../../src/types/tenant.js';
+import type { Trace } from '../../../src/types/trace.js';
+import type { EvalResult } from '../../../src/types/eval.js';
+
+/*
+ * eval_results.created_at silently dropped rows from every time window.
+ *
+ * The INSERT never set the column, so SQLite's DEFAULT datetime('now')
+ * stored "2026-08-09 15:00:00" — space separator, no ms, no Z. Every
+ * period query compares that against a JS toISOString() boundary
+ * ("2026-08-09T15:00:00.000Z") with plain string comparison, and ' ' (0x20)
+ * sorts before 'T' (0x54). So any eval whose CALENDAR DATE equalled the
+ * boundary's date fell outside the window: a 20-hour-old eval disappeared
+ * from "last 24h", and at 01:00 UTC that view showed only what had happened
+ * since midnight. Traces were fine — log_trace writes a real ISO string —
+ * so it looked like "evals go missing but traces don't".
+ */
+
+let tmpDir: string;
+let dbPath: string;
+let adapter: SqliteAdapter;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'iris-createdat-'));
+  dbPath = join(tmpDir, 'iris.db');
+  adapter = new SqliteAdapter(dbPath);
+  await adapter.initialize();
+});
+
+afterEach(async () => {
+  await adapter.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeTrace(id: string, hoursAgo: number): Trace {
+  return {
+    trace_id: id,
+    agent_name: 'test-agent',
+    framework: 'mcp',
+    input: 'in',
+    output: 'out',
+    cost_usd: 0.001,
+    latency_ms: 100,
+    timestamp: new Date(Date.now() - hoursAgo * 3_600_000).toISOString(),
+  };
+}
+
+function makeEval(id: string, traceId: string): EvalResult {
+  return {
+    id,
+    trace_id: traceId,
+    eval_type: 'completeness',
+    output_text: 'out',
+    score: 0.9,
+    passed: true,
+    rule_results: [],
+    suggestions: [],
+  };
+}
+
+describe('created_at is stored as ISO-8601', () => {
+  it('writes an ISO timestamp, not SQLite datetime() format', async () => {
+    await adapter.insertTrace(LOCAL_TENANT, makeTrace('t1', 0));
+    await adapter.insertEvalResult(LOCAL_TENANT, makeEval('e1', 't1'));
+
+    const raw = new Database(dbPath);
+    try {
+      const row = raw.prepare('SELECT created_at FROM eval_results WHERE id = ?').get('e1') as {
+        created_at: string;
+      };
+      expect(row.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(row.created_at).not.toContain(' ');
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('counts a 20-hour-old eval inside the 24h window', async () => {
+    /*
+     * The exact bug. 20h < 24h, so this row belongs in the window; under
+     * the old format it was excluded whenever the boundary landed on the
+     * same calendar date, which is most of the day.
+     */
+    await adapter.insertTrace(LOCAL_TENANT, makeTrace('t-old', 20));
+    await adapter.insertEvalResult(LOCAL_TENANT, makeEval('e-old', 't-old'));
+
+    const raw = new Database(dbPath);
+    try {
+      raw
+        .prepare('UPDATE eval_results SET created_at = ? WHERE id = ?')
+        .run(new Date(Date.now() - 20 * 3_600_000).toISOString(), 'e-old');
+    } finally {
+      raw.close();
+    }
+
+    const stats = await adapter.getEvalStats(LOCAL_TENANT, '24h');
+    expect(stats.totalEvals).toBe(1);
+  });
+
+  it('still excludes an eval genuinely older than the window', async () => {
+    await adapter.insertTrace(LOCAL_TENANT, makeTrace('t-ancient', 30));
+    await adapter.insertEvalResult(LOCAL_TENANT, makeEval('e-ancient', 't-ancient'));
+
+    const raw = new Database(dbPath);
+    try {
+      raw
+        .prepare('UPDATE eval_results SET created_at = ? WHERE id = ?')
+        .run(new Date(Date.now() - 30 * 3_600_000).toISOString(), 'e-ancient');
+    } finally {
+      raw.close();
+    }
+
+    const stats = await adapter.getEvalStats(LOCAL_TENANT, '24h');
+    expect(stats.totalEvals).toBe(0);
+  });
+});
+
+describe('migration 005 — legacy rows', () => {
+  it('normalizes rows already stored in SQLite datetime() format', async () => {
+    await adapter.insertTrace(LOCAL_TENANT, makeTrace('t-legacy', 20));
+    await adapter.insertEvalResult(LOCAL_TENANT, makeEval('e-legacy', 't-legacy'));
+
+    // Rewrite to the pre-fix shape, then re-run migrations the way a real
+    // upgrade does: same file, fresh adapter.
+    const raw = new Database(dbPath);
+    try {
+      raw.prepare("UPDATE eval_results SET created_at = datetime('now', '-20 hours')").run();
+      raw.prepare('DELETE FROM _iris_migrations WHERE id = ?').run('005-normalize-created-at');
+      const before = raw.prepare('SELECT created_at FROM eval_results').get() as {
+        created_at: string;
+      };
+      expect(before.created_at).toContain(' '); // legacy shape confirmed
+    } finally {
+      raw.close();
+    }
+
+    const upgraded = new SqliteAdapter(dbPath);
+    await upgraded.initialize();
+    try {
+      const stats = await upgraded.getEvalStats(LOCAL_TENANT, '24h');
+      expect(stats.totalEvals).toBe(1); // was 0 before the migration
+    } finally {
+      await upgraded.close();
+    }
+  });
+});


### PR DESCRIPTION
Two data-integrity bugs, both silent.

## 1. `eval_results.created_at` dropped rows from every time window

The INSERT never set `created_at`, so SQLite's `DEFAULT datetime('now')` stored `"2026-08-09 15:00:00"` — space separator, no milliseconds, no Z. Every period query compares that against a JS `toISOString()` boundary (`"2026-08-09T15:00:00.000Z"`) with **plain string comparison**, and `' '` (0x20) sorts before `'T'` (0x54).

So any eval whose **calendar date** equalled the boundary's date fell outside the window:

```
row 20h old:  "2026-08-09 19:49:26"
24h boundary: "2026-08-09T15:49:26.396Z"
row >= boundary?  false     <- 20h < 24h, but excluded
```

A 20-hour-old eval vanished from "last 24h". At 01:00 UTC the 24h view showed only what had happened since midnight. Traces were unaffected — `log_trace` writes a real ISO string — which is why this presents as *"my evals go missing but my traces don't"*.

Fixed in two halves: `insertEvalResult` now writes ISO explicitly so the DEFAULT never fires, and **migration 005** rewrites the rows already on disk. The migration is idempotent — its `LIKE` guard matches only the space-separated shape, so it is safe against a partially-migrated DB.

## 2. One bad rule wiped the entire rule store

`loadRulesFromDisk` validated the whole array with a single `safeParse` and returned `[]` if **any** element failed. That empty result was cached, and the next deploy/delete/toggle called `persist()`, which wrote `{version:1, rules:[]}` over the file — destroying every valid rule alongside the bad one, with no error surfaced anywhere. The old comment claimed "do NOT overwrite the file"; the write path did not honour it.

Reachable in the field, not theoretical: `DefinitionSchema`'s `superRefine` now runs on **read** as well as write, and `eval/rules/custom.ts` documents that rules predating that validation — e.g. `{type:'min_length', config:{}}` — are already sitting in users' files.

Now reads per-rule:
- valid rules load and fire
- invalid ones are **quarantined and written back verbatim**, so a deploy can never delete them (they just never activate)
- a file that will not JSON-parse at all makes `persist()` **throw** rather than replace content it never read

## Verification

**538/538** root tests, 7 new:
- 3 rule-store regressions — valid rule survives a bad neighbour, a later deploy preserves both, and an unparseable file is left byte-identical
- 4 `created_at` — ISO shape on write, a 20h eval counted in the 24h window, a 30h eval still excluded, and the **migration upgrade path** taking a legacy row from invisible to counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)