### PR TITLE
fix(ci): close four gaps where a gate covered less than it claimed

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-10T16:26:06.394Z",
-  "generatedFromCommit": "5373248",
+  "generatedAt": "2026-08-10T16:38:08.983Z",
+  "generatedFromCommit": "a1073e5",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The agent eval standard for MCP. Score every agent output for quality, safety, and cost.",
   "author": {
     "name": "Iris",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,14 @@ updates:
     ignore:
       - dependency-name: "eslint"
         versions: [">=10.0.0"]  # Blocked by eslint-config-next plugin peer deps (see #54)
+      # Same constraint as the root's #58 ceiling, one directory over — the
+      # root block's ignore does NOT apply here. eslint-config-next bundles
+      # its own typescript-eslint, which throws
+      # "TypeError: Cannot read properties of undefined (reading 'Cjs')"
+      # against TS 7. Without this, Dependabot re-proposes an unmergeable
+      # major every week (PR #300).
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
     groups:
       react:
         patterns:
@@ -83,6 +91,11 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+    # Cap raised from the default 5: the github-actions queue sat saturated
+    # at exactly 5 open PRs, so codeql-action/analyze and upload-sarif had no
+    # PR at all — not because they were current, but because there was no
+    # room. A silently-full queue looks identical to "nothing to update".
+    open-pull-requests-limit: 10
     groups:
       docker:
         patterns:
@@ -90,6 +103,17 @@ updates:
       github:
         patterns:
           - "actions/*"
+      # github/codeql-action/* matched NEITHER pattern above, so Dependabot
+      # opened one PR per step. CodeQL requires every step in a run to be on
+      # the SAME version — a lone init or autobuild bump makes Autobuild fail
+      # with "Not all workflow steps that use github/codeql-action actions use
+      # the same version", and no PR can fix that from inside itself (it is
+      # the four steps across codeql.yml + scorecard.yml that must move
+      # together). This already cost one hand-written batch PR; grouping is
+      # what stops a third round.
+      codeql:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,28 @@ jobs:
       - run: npm test
       - run: npm run clean
       - run: npm run build
+      # The tag IS the release identity — everything downstream (npm dist-tag,
+      # GHCR :vX + :latest, the GitHub release) is named from it. Nothing here
+      # checked that it matched what actually gets published, while the
+      # sibling release-init.yml has always had this guard.
+      #
+      # Without it: tag v0.4.6 at a commit whose package.json still says
+      # 0.4.5 -> npm publish tries 0.4.5 -> EPUBLISHCONFLICT -> the
+      # idempotent-re-run handler downstream swallows it as success -> Docker
+      # is tagged :v0.4.6 AND :latest with the 0.4.5 build, and a GitHub
+      # release is cut for a version that does not exist on npm. Fully green.
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "FATAL: tag v$TAG_VERSION != package.json $PKG_VERSION" && exit 1
+          fi
+      # And every other file carrying the version — server.json (both the
+      # top level and each packages[] entry the registry hands to installers),
+      # the lockfile, .well-known/mcp.json, the Claude Code plugin manifest.
+      - name: Verify all version-carrying files agree
+        run: bash scripts/check-version.sh
 
   publish-npm:
     needs: validate

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -16,7 +16,13 @@ check_version() {
   local actual
 
   if [ ! -f "$file" ]; then
-    echo "SKIP: $file not found"
+    # A missing file is a FAILURE, not a skip. Silently passing over one
+    # means renaming or moving a version-carrying file turns this gate into
+    # a no-op that still reports "PASSED: all files at X" — the same
+    # not-actually-covered failure that let plugin.json sit at 0.4.4 for a
+    # whole release. If a file is genuinely gone, delete its check here.
+    echo "MISSING: $file (expected a version-carrying file)"
+    ERRORS=$((ERRORS + 1))
     return
   fi
 
@@ -40,11 +46,43 @@ check_version "server.json" ".version"
 # said 0.4.5, and this gate passed because it only looked at `.version`.
 # Publishing that to the MCP Registry would have advertised 0.4.5 while
 # pointing installs at the previous (vulnerable) package.
-check_version "server.json" ".packages[0].version"
+#
+# Every entry, not just [0]: sync-versions.mjs loops over the whole array,
+# so pinning the check to one index leaves the checker and the syncer
+# disagreeing about what "all version sites" means. Adding a second package
+# would silently escape the gate.
+check_all_packages() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    echo "MISSING: $file (expected a version-carrying file)"
+    ERRORS=$((ERRORS + 1))
+    return
+  fi
+  local count
+  count=$(node -p "(require('./$file').packages || []).length")
+  if [ "$count" = "0" ]; then
+    echo "MISSING: $file has no packages[] entries to check"
+    ERRORS=$((ERRORS + 1))
+    return
+  fi
+  local i=0
+  while [ "$i" -lt "$count" ]; do
+    check_version "$file" ".packages[$i].version"
+    i=$((i + 1))
+  done
+}
+check_all_packages "server.json"
 check_version "package-lock.json" ".version"
 
 # Agent discovery endpoint
 check_version "website/public/.well-known/mcp.json" ".version"
+
+# Claude Code plugin manifest — the version plugin users see. scripts/
+# sync-versions.mjs has always WRITTEN this file, but nothing checked it,
+# so the syncer moved on and the gate never noticed: it sat at 0.4.4
+# through the entire 0.4.5 release. Checker and syncer must cover the same
+# set of files or the gate is decorative.
+check_version ".claude-plugin/plugin.json" ".version"
 
 # ============================================================
 # Add new version-carrying files here as the project grows:

--- a/scripts/claims/check-no-hardcoded.mjs
+++ b/scripts/claims/check-no-hardcoded.mjs
@@ -31,6 +31,12 @@ const SCAN_DIRS = [
   'packages/langchain/src',
   'packages/init',
   'claude-plugin',
+  // The DOT-prefixed one, which is where the real manifests live —
+  // plugin.json and marketplace.json, the public plugin description Claude
+  // Code users read. 'claude-plugin' above is the skills payload directory;
+  // one missing dot left both manifests unscanned, and marketplace.json
+  // does hardcode a tool count.
+  '.claude-plugin',
   'skills',
 ];
 const SCAN_FILES = ['README.md', 'server.json'];

--- a/scripts/claims/generators/mcp-tools.mjs
+++ b/scripts/claims/generators/mcp-tools.mjs
@@ -10,7 +10,16 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..', '..', '..');
 
 // Matches `server.registerTool('<name>',` or `server.registerTool("<name>",`
-const REGISTER_TOOL_RE = /server\.registerTool\s*\(\s*['"]([a-z_][a-z0-9_]*)['"]/;
+/*
+ * Global: matchAll below collects EVERY registration in a file. The
+ * non-global form with String.match() returned only the first, so a file
+ * registering two tools would undercount the truthbase — while
+ * check-product-claims.sh, which counts call sites in index.ts, kept the
+ * real number and turned CI red for a reason nobody would guess. It happens
+ * to be correct today only because each of the ten files registers exactly
+ * one tool; that is a layout coincidence, not an invariant.
+ */
+const REGISTER_TOOL_RE = /server\.registerTool\s*\(\s*['"]([a-z_][a-z0-9_]*)['"]/g;
 
 export async function generate() {
   const toolsDir = resolve(root, 'src/tools');
@@ -24,8 +33,7 @@ export async function generate() {
 
   for (const f of files) {
     const src = await readFile(resolve(toolsDir, f), 'utf-8');
-    const m = src.match(REGISTER_TOOL_RE);
-    if (m) names.push(m[1]);
+    for (const m of src.matchAll(REGISTER_TOOL_RE)) names.push(m[1]);
     if (/readOnlyHint:\s*true/.test(src)) readOnlyHintCount++;
     if (/destructiveHint:\s*true/.test(src)) destructiveHintCount++;
     if (/openWorldHint:\s*true/.test(src)) openWorldHintCount++;

--- a/scripts/security/check-exposure-coverage.mjs
+++ b/scripts/security/check-exposure-coverage.mjs
@@ -43,7 +43,8 @@
 //   2 — script error (npm audit failed unexpectedly, parse failure, etc.)
 
 import { readFile } from 'node:fs/promises';
-import { resolve, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
@@ -78,13 +79,27 @@ async function getDocumentedGhsas() {
 // Walks `npm audit --json` output to collect every advisory referenced via
 // the `via[].url` chain at >=moderate severity. Returns array of
 // {ghsa, severity, package, title}.
-function getAuditAdvisories() {
+/*
+ * Every workspace with its own lockfile.
+ *
+ * This gate used to audit the ROOT only, while calling itself "the repo's
+ * authoritative dependency-security gate" — authoritative for one workspace
+ * and silent in three. That is exactly how dashboard/ carried 2 HIGHs while
+ * the Dependabot dashboard read 0 alerts. `npm audit` resolves against the
+ * lockfile in its cwd and does not traverse into nested projects, so each
+ * one needs its own run.
+ */
+const AUDIT_WORKSPACES = ['.', 'dashboard', 'website', 'packages/init'];
+
+function auditWorkspace(workspace) {
+  const cwd = resolve(root, workspace);
+  if (!existsSync(join(cwd, 'package-lock.json'))) return null;
   // Windows: shell:true is required for .cmd resolution (npm is npm.cmd).
   // Node 22+ deprecation warning about arg passing with shell:true does not
   // apply here because args are hardcoded literals, not user input. The
   // warning fires only on Windows; CI runs on Linux and uses shell:false.
   const proc = spawnSync('npm', ['audit', '--json'], {
-    cwd: root,
+    cwd,
     encoding: 'utf-8',
     shell: process.platform === 'win32',
     maxBuffer: 50 * 1024 * 1024,
@@ -92,38 +107,52 @@ function getAuditAdvisories() {
   // npm audit exits non-zero when vulnerabilities are found — that's not
   // a script error. Treat exit code 1 as "audit ran and found stuff."
   if (proc.status !== 0 && proc.status !== 1) {
-    err(`npm audit failed (exit ${proc.status}): ${proc.stderr || proc.stdout}`);
+    err(`npm audit failed in ${workspace} (exit ${proc.status}): ${proc.stderr || proc.stdout}`);
   }
-  let parsed;
   try {
-    parsed = JSON.parse(proc.stdout);
+    return JSON.parse(proc.stdout);
   } catch (e) {
-    err(`could not parse npm audit JSON: ${e.message}`);
+    err(`could not parse npm audit JSON from ${workspace}: ${e.message}`);
   }
+}
 
+function getAuditAdvisories() {
   const advisories = [];
   const seen = new Set();
-  for (const [pkg, info] of Object.entries(parsed.vulnerabilities ?? {})) {
-    for (const via of info.via ?? []) {
-      if (typeof via !== 'object' || !via.url) continue;
-      const m = via.url.match(GHSA_RE);
-      if (!m) continue;
-      const ghsa = m[0].toUpperCase();
-      if (seen.has(ghsa)) continue;
-      seen.add(ghsa);
-      const severity = (via.severity ?? '').toLowerCase();
-      if (!SEVERITY_THRESHOLD.has(severity)) continue;
-      advisories.push({
-        ghsa,
-        severity,
-        package: pkg,
-        title: via.title ?? '',
-        // npm sets this on the vulnerability entry, not the advisory:
-        // true | false | {name, version, isSemVerMajor}
-        fixAvailable: info.fixAvailable ?? false,
-      });
+  const audited = [];
+
+  for (const workspace of AUDIT_WORKSPACES) {
+    const parsed = auditWorkspace(workspace);
+    if (!parsed) continue;
+    audited.push(workspace);
+
+    for (const [pkg, info] of Object.entries(parsed.vulnerabilities ?? {})) {
+      for (const via of info.via ?? []) {
+        if (typeof via !== 'object' || !via.url) continue;
+        const m = via.url.match(GHSA_RE);
+        if (!m) continue;
+        const ghsa = m[0].toUpperCase();
+        if (seen.has(ghsa)) continue;
+        seen.add(ghsa);
+        const severity = (via.severity ?? '').toLowerCase();
+        if (!SEVERITY_THRESHOLD.has(severity)) continue;
+        advisories.push({
+          ghsa,
+          severity,
+          package: pkg,
+          workspace,
+          title: via.title ?? '',
+          // npm sets this on the vulnerability entry, not the advisory:
+          // true | false | {name, version, isSemVerMajor}
+          fixAvailable: info.fixAvailable ?? false,
+        });
+      }
     }
   }
+
+  // State which workspaces were covered. A gate that quietly audits a
+  // subset reads exactly like one that audited everything and found nothing.
+  console.log(`[security-gate] audited lockfiles: ${audited.join(', ')}`);
   return advisories;
 }
 


### PR DESCRIPTION
Every item here is a gate that **reported success over something it never checked**.

## Live drift, shipped

`.claude-plugin/plugin.json` was at **0.4.4** through the entire 0.4.5 release — the version Claude Code plugin users see. `sync-versions.mjs` has always *written* that file; `check-version.sh` never *checked* it. Checker and syncer disagreed about what "all version sites" means, so the syncer moved on and the gate stayed quiet. Added to the checker; file synced.

## Three more ways the version gate was decorative

- **Missing file = silent pass.** `check_version` printed `SKIP` and returned *without* incrementing `ERRORS`. Rename or move a version-carrying file and the gate becomes a no-op that still prints "PASSED: all files at 0.4.5". Missing is now a failure.
- **`packages[]` pinned to `[0]`** while `sync-versions.mjs` loops over the whole array. Now checks every entry.
- **`release.yml` had no version guard at all**, while sibling `release-init.yml` has always had one. Failure path: tag `v0.4.6` at a commit whose package.json still says 0.4.5 → `npm publish` attempts 0.4.5 → `EPUBLISHCONFLICT` → the idempotent-re-run handler swallows it as success → Docker still tagged `:v0.4.6` **and `:latest`** with the 0.4.5 build, GitHub release cut for a version that does not exist on npm. **A fully green release run for a phantom version.** Now verifies tag vs package.json and runs `check-version.sh`.

## The security gate audited 1 of 4 lockfiles

`check-exposure-coverage.mjs` calls itself "the repo's authoritative dependency-security gate" in its own header, and ran `npm audit` with `cwd` = root only. `dashboard/`, `website/` and `packages/init/` were never audited — the same shape as the incident where `dashboard/` carried 2 HIGHs while Dependabot showed 0 alerts. Now audits all four and **prints which**, so a partial run can't read like a clean one.

## Dependabot: stop #317/#319 recurring

`github/codeql-action*` matched neither existing group pattern, so Dependabot opens **one PR per step** — but CodeQL requires every step in a run to be on the same version. A lone `init` bump makes Autobuild fail with *"Not all workflow steps that use github/codeql-action actions use the same version"*, and **no PR can fix that from inside itself** (four steps across `codeql.yml` + `scorecard.yml` must move together). This already cost one hand-written batch PR. Now grouped.

The github-actions queue was also saturated at the default limit of 5, which is why `codeql-action/analyze` and `upload-sarif` had no PR at all — not current, just no room. Raised to 10.

Added the **`/website` TypeScript ceiling** as well: the root's #58 ignore does not apply to that directory, and `eslint-config-next` bundles a typescript-eslint that throws `TypeError: Cannot read properties of undefined (reading 'Cjs')` on TS 7 — which is why #300 exists and fails, weekly.

## Two latent truthbase bugs

- `generators/mcp-tools.mjs` used non-global `String.match()`, collecting at most **one tool per file**. Correct today only because each of the ten files registers exactly one — a layout coincidence. Now `matchAll`.
- `check-no-hardcoded.mjs` scanned `claude-plugin` but not `.claude-plugin` — one missing dot left `plugin.json` and `marketplace.json` unscanned, and marketplace.json hardcodes a tool count in its public plugin description.

## Verification

`check-version.sh` **caught the real 0.4.4 drift** before the sync and passes after. Security gate reports all four lockfiles, 0 advisories. Claims regen shows only timestamp/commit deltas — confirming the `matchAll` change is behaviour-preserving today, as predicted. 531/531 tests, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)