### PR TITLE
ci: bump all four github/codeql-action steps to v4.37.6 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,14 +30,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to GitHub code-scanning
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Replaces **#317** and **#319**, which cannot be merged individually.

CodeQL requires every step in a run to be on the **same version**. Dependabot opened them separately — `github/codeql-action*` matched neither existing group pattern — and each one turns Autobuild red with:

> `Not all workflow steps that use github/codeql-action actions use the same version`

Neither PR can fix that from inside itself: it is the four steps across `codeql.yml` (init, autobuild, analyze) and `scorecard.yml` (upload-sarif) that have to move together. A hand-written batch was already needed once for this exact reason (37504a6).

This lands the bump those two PRs were reaching for. **#325** adds the `codeql` Dependabot group so a third round doesn't happen.

The pin `5595ccaf912efad79be6eef63a5619ff05969be3` is v4.37.6 dereferenced from the annotated tag, and matches byte-for-byte what Dependabot proposed in #317.

Close #317 and #319 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)