### PR TITLE
fix(eval): custom rules discarded or evicted; safety violations undercounted

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-10T16:38:08.983Z",
-  "generatedFromCommit": "a1073e5",
+  "generatedAt": "2026-08-10T16:47:30.752Z",
+  "generatedFromCommit": "0a3f039",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 662,
+    "totalCombined": 669,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 538,
-      "total": 538
+      "passed": 545,
+      "total": 545
     }
   },
   "version": {

--- a/src/eval/engine.ts
+++ b/src/eval/engine.ts
@@ -31,16 +31,31 @@ export class EvalEngine {
       };
     }
 
-    let rules: EvalRule[];
-
-    if (evalType === 'custom' && customRules) {
-      rules = customRules.map((def) => createCustomRule(def));
-    } else {
-      rules = [
-        ...getRulesForType(evalType),
-        ...(this.additionalRules.get(evalType) ?? []),
-      ];
-    }
+    /*
+     * Inline custom_rules are ADDITIVE, which is what evaluate_output's
+     * description promises in two places: "fires REGARDLESS of eval_type"
+     * and "otherwise both your rules AND the eval_type bundle run together".
+     *
+     * The old branch did neither. `evalType === 'custom' && customRules`
+     * meant:
+     *   - evaluate('safety', ctx, [myRule]) silently DISCARDED myRule and
+     *     returned a plausible score that never applied it. An agent
+     *     following the tool description got a wrong answer with no warning.
+     *   - evaluate('custom', ctx, [myRule]) replaced the rule list entirely,
+     *     EVICTING every rule the user had deployed and which the server
+     *     registers at boot. Passing one ad-hoc rule disabled their whole
+     *     library for that call.
+     *
+     * getRulesForType('custom') is [] (rules/index.ts), so eval_type="custom"
+     * still runs no built-in bundle — the documented "ONLY these" behaviour
+     * holds. What it now also includes is the caller's own deployed rules,
+     * which is the least surprising reading of having deployed them.
+     */
+    const rules: EvalRule[] = [
+      ...getRulesForType(evalType),
+      ...(this.additionalRules.get(evalType) ?? []),
+      ...(customRules ?? []).map((def) => createCustomRule(def)),
+    ];
 
     if (rules.length === 0) {
       return {

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -395,12 +395,28 @@ export class SqliteAdapter implements IStorageAdapter {
       WHERE tenant_id = ? AND timestamp >= ?
     `).get(tenantId, since) as { agent_count: number };
 
+    /*
+     * No `AND passed = 0` here — deliberately.
+     *
+     * A safety eval's score is the average across its rules, so a single
+     * violation is routinely outvoted: output containing "Your SSN is
+     * 123-45-6789" fails no_pii (score 0) while the three other safety
+     * rules pass, giving 0.733 overall — above the 0.7 threshold, so
+     * passed = 1. Filtering to failed evals therefore reported
+     * {pii: 0, injection: 0, hallucination: 0} for a trace that leaked a
+     * social security number.
+     *
+     * For a product whose job is catching PII, injection and hallucination,
+     * that error ran in the direction that HIDES problems. The count is
+     * per-VIOLATION, not per-failed-eval; the per-rule loop below already
+     * skips rules that passed, so scanning every safety eval in the window
+     * is both correct and sufficient.
+     */
     const safetyRows = this.db.prepare(`
       SELECT rule_results
       FROM eval_results
       WHERE tenant_id = ? AND created_at >= ?
         AND eval_type = 'safety'
-        AND passed = 0
     `).all(tenantId, since) as Array<{ rule_results: string }>;
 
     const violations = { pii: 0, injection: 0, hallucination: 0 };

--- a/tests/unit/eval/custom-rules-additive.test.ts
+++ b/tests/unit/eval/custom-rules-additive.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { EvalEngine } from '../../../src/eval/engine.js';
+import { createCustomRule } from '../../../src/eval/rules/index.js';
+import type { CustomRuleDefinition, EvalContext } from '../../../src/types/eval.js';
+
+/*
+ * evaluate_output's description promises, twice, that inline custom_rules
+ * are ADDITIVE:
+ *
+ *   "custom_rules — fires REGARDLESS of eval_type"
+ *   "otherwise both your rules AND the eval_type bundle run together"
+ *
+ * The engine did neither. `evalType === 'custom' && customRules` meant a
+ * rule passed alongside eval_type="safety" was silently discarded, and a
+ * rule passed alongside eval_type="custom" REPLACED the user's deployed
+ * library for that call. Both returned a plausible score with no warning,
+ * which is the worst shape for an eval tool: the caller cannot tell the
+ * difference between "your rule passed" and "your rule never ran".
+ */
+
+const ctx: EvalContext = {
+  output: 'Some agent output text that is reasonably long for evaluation purposes.',
+  input: 'a question',
+};
+
+const inlineRule: CustomRuleDefinition = {
+  name: 'my_inline_rule',
+  type: 'contains_keywords',
+  config: { keywords: ['definitely-not-present-anywhere'] },
+};
+
+function ranRules(result: { rule_results: Array<{ ruleName: string }> }): string[] {
+  return result.rule_results.map((r) => r.ruleName);
+}
+
+describe('inline custom_rules are additive', () => {
+  it('fires alongside a built-in bundle (eval_type="safety")', () => {
+    const engine = new EvalEngine();
+    const result = engine.evaluate('safety', ctx, [inlineRule]);
+
+    expect(ranRules(result)).toContain('my_inline_rule');
+    // …and the safety bundle still ran.
+    expect(ranRules(result)).toContain('no_pii');
+  });
+
+  it('fires alongside the completeness bundle too', () => {
+    const engine = new EvalEngine();
+    const result = engine.evaluate('completeness', ctx, [inlineRule]);
+
+    expect(ranRules(result)).toContain('my_inline_rule');
+    expect(ranRules(result).length).toBeGreaterThan(1);
+  });
+
+  it('does NOT evict deployed rules when eval_type="custom"', () => {
+    /*
+     * Deployed rules are registered at server boot (src/index.ts). Passing
+     * one ad-hoc rule used to disable the entire deployed library for that
+     * call — the user's own standing rules silently stopped applying.
+     */
+    const engine = new EvalEngine();
+    engine.registerRule(
+      'custom',
+      createCustomRule({
+        name: 'my_deployed_rule',
+        type: 'min_length',
+        config: { min_length: 5 },
+      }),
+    );
+
+    const withInline = engine.evaluate('custom', ctx, [inlineRule]);
+    expect(ranRules(withInline)).toContain('my_deployed_rule');
+    expect(ranRules(withInline)).toContain('my_inline_rule');
+  });
+
+  it('runs no built-in bundle for eval_type="custom" (the documented "ONLY these")', () => {
+    const engine = new EvalEngine();
+    const result = engine.evaluate('custom', ctx, [inlineRule]);
+
+    expect(ranRules(result)).toEqual(['my_inline_rule']);
+  });
+
+  it('still evaluates the plain bundle when no custom rules are passed', () => {
+    const engine = new EvalEngine();
+    const result = engine.evaluate('safety', ctx);
+
+    expect(ranRules(result)).toContain('no_pii');
+    expect(ranRules(result)).not.toContain('my_inline_rule');
+  });
+});

--- a/tests/unit/storage/safety-violations-count.test.ts
+++ b/tests/unit/storage/safety-violations-count.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SqliteAdapter } from '../../../src/storage/sqlite-adapter.js';
+import { EvalEngine } from '../../../src/eval/engine.js';
+import { LOCAL_TENANT } from '../../../src/types/tenant.js';
+import type { Trace } from '../../../src/types/trace.js';
+
+/*
+ * getEvalStats counted safety violations only inside evals that FAILED
+ * overall (`AND passed = 0`). But a safety eval scores the average across
+ * its rules, so one violation is routinely outvoted: a leaked SSN fails
+ * no_pii while the three other safety rules pass, landing at 0.733 — over
+ * the 0.7 threshold, so passed = 1 and the dashboard reported zero PII
+ * violations for a trace that leaked a social security number.
+ *
+ * For a product whose whole job is catching PII, this erred in the
+ * direction that hides problems.
+ *
+ * The eval is produced by the REAL EvalEngine here rather than a
+ * hand-written rule_results fixture — the bug lives in the relationship
+ * between per-rule outcomes and the aggregate verdict, which a fixture
+ * would let us assert into existence rather than observe.
+ */
+
+let tmpDir: string;
+let adapter: SqliteAdapter;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'iris-safety-'));
+  adapter = new SqliteAdapter(join(tmpDir, 'iris.db'));
+  await adapter.initialize();
+});
+
+afterEach(async () => {
+  await adapter.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const trace: Trace = {
+  trace_id: 'trace-pii',
+  agent_name: 'leaky-agent',
+  framework: 'mcp',
+  input: 'what is the customer record',
+  output: 'Your SSN is 123-45-6789',
+  cost_usd: 0.001,
+  latency_ms: 100,
+  timestamp: new Date().toISOString(),
+};
+
+describe('safety violation counting', () => {
+  it('counts a PII violation even when the eval passed overall', async () => {
+    const engine = new EvalEngine();
+    const result = engine.evaluate('safety', { output: trace.output!, input: trace.input });
+
+    // The precondition that makes this bug possible: no_pii failed, yet the
+    // averaged verdict is a pass. If this ever stops holding, the assertion
+    // below would pass for the wrong reason.
+    const pii = result.rule_results.find((r) => r.ruleName === 'no_pii');
+    expect(pii?.passed).toBe(false);
+    expect(result.passed).toBe(true);
+
+    await adapter.insertTrace(LOCAL_TENANT, trace);
+    await adapter.insertEvalResult(LOCAL_TENANT, { ...result, trace_id: trace.trace_id });
+
+    const stats = await adapter.getEvalStats(LOCAL_TENANT, '24h');
+    expect(stats.safetyViolations.pii).toBe(1);
+  });
+
+  it('still reports zero when nothing violated', async () => {
+    const engine = new EvalEngine();
+    const clean: Trace = {
+      ...trace,
+      trace_id: 'trace-clean',
+      output: 'The customer record was updated successfully with no issues to report.',
+    };
+    const result = engine.evaluate('safety', { output: clean.output!, input: clean.input });
+
+    await adapter.insertTrace(LOCAL_TENANT, clean);
+    await adapter.insertEvalResult(LOCAL_TENANT, { ...result, trace_id: clean.trace_id });
+
+    const stats = await adapter.getEvalStats(LOCAL_TENANT, '24h');
+    expect(stats.safetyViolations.pii).toBe(0);
+    expect(stats.safetyViolations.injection).toBe(0);
+    expect(stats.safetyViolations.hallucination).toBe(0);
+  });
+});


### PR DESCRIPTION
Three bugs where the code disagreed with what it tells callers.

## 1 + 2. Inline `custom_rules` were discarded, or evicted the user's deployed rules

`evaluate_output`'s description states, twice, that inline rules are additive:

> `custom_rules` — fires **REGARDLESS** of eval_type
> …otherwise **both your rules AND the eval_type bundle** run together

The engine did neither. The branch was `evalType === 'custom' && customRules`:

- `evaluate('safety', ctx, [myRule])` → **myRule silently discarded.** The caller gets a plausible score that never applied their rule, and cannot tell the difference between "your rule passed" and "your rule never ran" — the worst possible shape for an eval tool.
- `evaluate('custom', ctx, [myRule])` → inline rules **replaced** the list, evicting every rule the user deployed (registered at boot in `src/index.ts`). Passing one ad-hoc rule disabled their entire standing library for that call.

Fixed by making inline rules additive. `getRulesForType('custom')` is `[]`, so `eval_type="custom"` still runs no built-in bundle — the documented "ONLY these" behaviour holds. It now also includes the caller's own deployed rules, which is the least surprising reading of having deployed them.

## 3. Safety violations invisible whenever the eval passed overall

`getEvalStats` filtered violation counting to failed evals (`AND passed = 0`). But a safety eval's score is the **average across its rules**, so a single violation is routinely outvoted:

```
output: "Your SSN is 123-45-6789"
  no_pii                      FAIL  0.0
  no_injection_patterns       pass  1.0
  no_hallucination_markers    pass  1.0
  no_stub_output              pass  1.0
                            score = 0.733  -> above 0.7 -> passed = 1
  reported: safetyViolations { pii: 0, injection: 0, hallucination: 0 }
```

Zero PII violations reported for a trace that leaked a social security number. For a product whose entire job is catching PII, injection and hallucination, this erred in the direction that **hides** problems — the same family as `0 alerts ≠ 0 vulnerabilities`. The count is per-violation, not per-failed-eval, and the per-rule loop already skips rules that passed.

## Verification

**545/545** tests, 7 new.

The safety test drives the **real `EvalEngine`** rather than a hand-written `rule_results` fixture — this bug lives in the relationship between per-rule outcomes and the aggregate verdict, and a fixture would let us assert that relationship into existence rather than observe it. It also asserts the precondition explicitly (`no_pii` failed **and** `result.passed === true`) so it cannot pass for the wrong reason if scoring changes later, and was confirmed to **fail** against the unpatched query (`expected +0 to be 1`) before being kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)