### PR TITLE
fix(security): bound PII pattern quantifiers — ReDoS via attacker-controlled agent output

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-10T16:47:30.752Z",
-  "generatedFromCommit": "0a3f039",
+  "generatedAt": "2026-08-10T16:58:54.198Z",
+  "generatedFromCommit": "33e4174",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 669,
+    "totalCombined": 684,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 545,
-      "total": 545
+      "passed": 560,
+      "total": 560
     }
   },
   "version": {

--- a/src/eval/rules/safety.ts
+++ b/src/eval/rules/safety.ts
@@ -7,14 +7,50 @@ import type { EvalRule, EvalContext, EvalRuleResult } from '../../types/eval.js'
  * patterns evaluate. Word-boundary anchors avoid matching inside larger
  * strings where appropriate.
  */
-// Exported so the claims drift test can assert .claims.json counts against
-// the runtime truth (tests/claims-eval-rules-counts.test.ts).
+/*
+ * Every pattern here runs against ATTACKER-CONTROLLED text — agent output is
+ * untrusted by definition (resolve.ts states this outright), and any agent
+ * that summarises a web page, reads email, or handles user tickets can be
+ * fed a crafted string straight into evaluate_output.
+ *
+ * So: no ambiguous quantifiers. The rule that bit us was `\s*[:.]?\s*` in
+ * DOB and Medical Record Number — two adjacent unbounded whitespace
+ * quantifiers give the engine N+1 ways to split a run of N spaces, each of
+ * which fails at the trailing character class. Cost was quadratic in the
+ * input: 'MRN' + N spaces + '!' measured 31ms at 4k, 118ms at 8k, 468ms at
+ * 16k, and did not finish at the 1MB body limit. Node is single-threaded,
+ * so one call wedged the whole server.
+ *
+ * Bounded quantifiers ({0,8}) keep the alternatives constant regardless of
+ * input length. When adding a pattern, check for: adjacent quantifiers over
+ * overlapping character classes, nested quantifiers, and a character that
+ * can match both inside a + and as the following literal.
+ *
+ * Exported so the claims drift test can assert .claims.json counts against
+ * the runtime truth (tests/claims-eval-rules-counts.test.ts).
+ */
 export const PII_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   // Original v0.3.0 patterns
   { name: 'SSN', pattern: /\b\d{3}-\d{2}-\d{4}\b/ },
   { name: 'Credit Card', pattern: /\b(?:\d{4}[-\s]?){3}\d{4}\b/ },
   { name: 'Phone', pattern: /\b(?:\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/ },
-  { name: 'Email', pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z]{2,}\b/i },
+  /*
+   * Every quantifier is bounded, at the RFC 5321 limits (local part 64,
+   * DNS label 63, TLD 24). Unbounded ones made this quadratic on text with
+   * no '@' in it: from EVERY starting position the local part consumed the
+   * rest of the string before failing, so N start positions each did O(N)
+   * work. 'a@' + 'a.'×32000 measured 3.5 seconds. Bounding the local part
+   * caps per-position work at a constant, which is what makes the whole
+   * scan linear.
+   *
+   * The domain is also written as explicit dot-separated labels rather than
+   * [A-Za-z0-9.-]+\. — that form lets '.' match both inside the + and as
+   * the following literal, which is its own source of splits to try.
+   */
+  {
+    name: 'Email',
+    pattern: /\b[A-Za-z0-9._%+-]{1,64}@(?:[A-Za-z0-9-]{1,63}\.){1,8}[A-Z]{2,24}\b/i,
+  },
 
   // v0.3.1 additions
   // IBAN: 2 letters + 2 digits + 1-30 alphanumeric (international bank account number)
@@ -22,9 +58,9 @@ export const PII_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   // US passport: 9 digits, optionally prefixed with letter (modern format C12345678)
   { name: 'Passport', pattern: /\b[A-Z]?\d{9}\b/ },
   // Date of birth contextual — DOB or "Born:" / "Birthday:" + date
-  { name: 'DOB', pattern: /\b(?:DOB|D\.O\.B\.|Date of Birth|Born|Birthday)\s*[:.]?\s*\d{1,2}[\/\-.]\d{1,2}[\/\-.](?:\d{2}|\d{4})\b/i },
+  { name: 'DOB', pattern: /\b(?:DOB|D\.O\.B\.|Date of Birth|Born|Birthday)\s{0,8}[:.]?\s{0,8}\d{1,2}[\/\-.]\d{1,2}[\/\-.](?:\d{2}|\d{4})\b/i },
   // Medical record number — MRN: + alphanumeric (common format)
-  { name: 'Medical Record Number', pattern: /\b(?:MRN|Medical Record (?:Number|No\.?|#))\s*[:.]?\s*[A-Z0-9]{6,12}\b/i },
+  { name: 'Medical Record Number', pattern: /\b(?:MRN|Medical Record (?:Number|No\.?|#))\s{0,8}[:.]?\s{0,8}[A-Z0-9]{6,12}\b/i },
   // IPv4 address
   { name: 'IP Address', pattern: /\b(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}\b/ },
   // API key heuristic — looks for sk-/pk-/api_/Bearer + long alphanumeric

--- a/tests/unit/eval/pii-pattern-redos.test.ts
+++ b/tests/unit/eval/pii-pattern-redos.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { PII_PATTERNS } from '../../../src/eval/rules/safety.js';
+
+/*
+ * PII patterns run against ATTACKER-CONTROLLED text. Agent output is
+ * untrusted by definition, and any agent that summarises a web page, reads
+ * email, or handles user tickets can be handed a crafted string that
+ * reaches evaluate_output. Node is single-threaded, so one pathological
+ * match wedges the entire server — no crash, no error, just a server that
+ * stops answering.
+ *
+ * Two patterns were superlinear:
+ *   - Medical Record Number / DOB used `\s*[:.]?\s*`. Two adjacent
+ *     unbounded whitespace quantifiers give N+1 ways to split a run of N
+ *     spaces, each failing at the trailing class. 'MRN' + N spaces + '!'
+ *     measured 31ms @4k, 118ms @8k, 468ms @16k — quadratic — and did not
+ *     finish at the 1MB express.json body limit.
+ *   - Email's local part was unbounded, so on text with no '@' every one
+ *     of N start positions consumed the rest of the string before failing.
+ *     'a@' + 'a.'x32000 took 3.5 seconds.
+ *
+ * Thresholds below are deliberately loose (CI runners are noisy and slow).
+ * They are not benchmarks — they are a tripwire. Quadratic behaviour on
+ * these payload sizes takes minutes, so anything under a second means the
+ * pattern is still linear-ish; anything over means a quantifier regressed.
+ */
+
+const BUDGET_MS = 1_000;
+
+function timeMatch(pattern: RegExp, text: string): number {
+  const started = Date.now();
+  pattern.test(text);
+  return Date.now() - started;
+}
+
+function patternNamed(name: string): RegExp {
+  const found = PII_PATTERNS.find((p) => p.name === name);
+  if (!found) throw new Error(`no PII pattern named ${name}`);
+  return found.pattern;
+}
+
+describe('PII patterns resist ReDoS', () => {
+  const payloads: Array<[string, string]> = [
+    ['Medical Record Number', 'MRN' + ' '.repeat(200_000) + '!'],
+    ['DOB', 'DOB' + ' '.repeat(200_000) + '!'],
+    ['Email', 'a@' + 'a.'.repeat(100_000) + '!'],
+  ];
+
+  for (const [name, payload] of payloads) {
+    it(`${name} completes on a ${payload.length}-char adversarial payload`, () => {
+      expect(timeMatch(patternNamed(name), payload)).toBeLessThan(BUDGET_MS);
+    });
+  }
+
+  it('every pattern completes on a large benign payload', () => {
+    // Realistic worst case: a long document with no PII in it at all.
+    const document = 'The quick brown fox jumps over the lazy dog. '.repeat(5_000);
+    for (const { name, pattern } of PII_PATTERNS) {
+      expect(timeMatch(pattern, document), `${name} exceeded the budget`).toBeLessThan(BUDGET_MS);
+    }
+  });
+});
+
+describe('PII patterns still detect what they claim to', () => {
+  // Bounding a quantifier is only correct if detection is unchanged — this
+  // is the half a pure timing test would miss.
+  const cases: Array<[string, string, boolean]> = [
+    ['Email', 'contact jane.doe%test+x@sub.example.co.uk please', true],
+    ['Email', 'a@b.io', true],
+    ['Email', 'no address in this sentence', false],
+    ['DOB', 'DOB: 01/02/1990', true],
+    ['DOB', 'Date of Birth 1-2-90', true],
+    ['DOB', 'Born. 12.31.2001', true],
+    ['DOB', 'born yesterday', false],
+    ['Medical Record Number', 'MRN: A1B2C3D4', true],
+    ['Medical Record Number', 'Medical Record No. 123456', true],
+    ['Medical Record Number', 'MRN 9988776655', true],
+    ['Medical Record Number', 'no record here', false],
+  ];
+
+  for (const [name, text, expected] of cases) {
+    it(`${name} ${expected ? 'matches' : 'ignores'} ${JSON.stringify(text)}`, () => {
+      expect(patternNamed(name).test(text)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Why this is reachable

PII patterns run against **agent output**, which is untrusted by definition — `citation-verify/resolve.ts` states this outright. Any agent that summarises a web page, reads email, or handles user tickets can be fed a crafted string that lands in `evaluate_output`, and `output` is `z.string()` with no length cap. Node is single-threaded, so one pathological match wedges the **entire server**: no crash, no error, just a server that stops answering.

## Two superlinear patterns

**Medical Record Number and DOB** used `\s*[:.]?\s*`. Two adjacent unbounded whitespace quantifiers give N+1 ways to split a run of N spaces, each failing at the trailing character class.

| payload | before | after |
|---|---|---|
| `'MRN' + 4k spaces + '!'` | 31ms | — |
| `'MRN' + 8k spaces + '!'` | 118ms | — |
| `'MRN' + 16k spaces + '!'` | 468ms | 0ms |
| `'MRN' + 256k spaces + '!'` | did not finish | 1ms |

Doubling the input quadrupled the time. At the 1MB `express.json` body limit it never returned.

**Email's local part was unbounded**, so on text containing no `@` every one of N start positions consumed the rest of the string before failing — N positions × O(N) work. `'a@' + 'a.'×32000` took **3.5 seconds**; now **19ms**.

## The fix

- `\s{0,8}[:.]?\s{0,8}` — bounded, so the number of alternatives is constant regardless of input length.
- Email bounded at the RFC 5321 limits (local part 64, DNS label 63, TLD 24). Bounding the **local part** is what makes the whole scan linear, by capping per-start-position work at a constant.
- Email's domain written as explicit dot-separated labels rather than `[A-Za-z0-9.-]+\.`, so `.` cannot match both inside the `+` **and** as the following literal.

Added a note at the pattern table on what to check when adding one: adjacent quantifiers over overlapping classes, nested quantifiers, and a character that can match both inside a `+` and as the next literal.

## Verification

**560/560** tests, 15 new — timing tripwires **and** 11 detection cases asserting the exact formats each pattern must still catch (plus three it must ignore). Bounding a quantifier is only correct if detection is unchanged, and a pure timing test would miss that half.

Thresholds are deliberately loose (1s for a 200k-char payload). They are a tripwire, not a benchmark: quadratic behaviour on these payloads takes minutes, so the budget cannot flake on a slow CI runner while still catching a regressed quantifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)