### PR TITLE
fix(tests): confine in-process tests to a scratch IRIS_HOME

### DIFF
--- a/tests/setup/iris-home.ts
+++ b/tests/setup/iris-home.ts
@@ -1,0 +1,32 @@
+/*
+ * Global vitest setup: point IRIS_HOME at a scratch directory before any
+ * test file loads.
+ *
+ * PR #321 routed every per-user path (config.json, iris.db default,
+ * custom-rules.json, audit.log, preferences.json) through irisHome(), and
+ * isolated the two harnesses that SPAWN a server — Playwright's webServer
+ * and the stdio integration test. It missed the in-process case: a unit or
+ * integration test that builds a server directly from defaultConfig gets
+ * the real ~/.iris, because vitest runs in the developer's own process.
+ *
+ * tests/integration/mcp-protocol.test.ts does exactly that. Its
+ * deploy_rule/delete_rule round trip appended two rows to the developer's
+ * REAL ~/.iris/audit.log on every run — caught by hashing the file before
+ * and after a suite run, not by any assertion.
+ *
+ * Doing it here rather than per-file is the point: a future test that
+ * forgets to pass a custom path is contained by default instead of
+ * quietly writing to real user data. Set at module scope so it lands
+ * before any import that reads the env.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll } from 'vitest';
+
+const scratchHome = mkdtempSync(join(tmpdir(), 'iris-vitest-home-'));
+process.env.IRIS_HOME = scratchHome;
+
+afterAll(() => {
+  rmSync(scratchHome, { recursive: true, force: true });
+});

--- a/tests/unit/custom-rule-store-tenant.test.ts
+++ b/tests/unit/custom-rule-store-tenant.test.ts
@@ -16,8 +16,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { createCustomRuleStore } from '../../src/custom-rule-store.js';
+import { irisHome } from '../../src/utils/iris-home.js';
 import { LOCAL_TENANT, asTenantId, type TenantId } from '../../src/types/tenant.js';
 
 let tmpDir: string;
@@ -148,13 +149,15 @@ describe('CustomRuleStore — tenant isolation', () => {
   });
 
   it('LOCAL_TENANT continues to use the v0.4 file path (zero migration)', () => {
-    // Spot-check the default `defaultPathFor` semantics by NOT passing
-    // a `pathFor` factory — uses the production default which lives in
-    // ~/.iris/. Verify it resolves to a path with `/.iris/custom-rules.json`
-    // for LOCAL_TENANT and `/.iris/custom-rules-<id>.json` otherwise.
+    // Spot-check the default `defaultPathFor` semantics by NOT passing a
+    // `pathFor` factory. Assert against the RESOLVED iris home rather than
+    // a literal '.iris' segment: the directory is IRIS_HOME-overridable
+    // (and the test suite sets it), while the guarantee under test is the
+    // FILENAME — LOCAL_TENANT keeps the unsuffixed v0.4 name so upgrading
+    // users need no migration, and other tenants get a suffix.
     const store = createCustomRuleStore({ auditPath });
-    expect(store.pathFor(LOCAL_TENANT)).toMatch(/[\\/]\.iris[\\/]custom-rules\.json$/);
-    expect(store.pathFor(TENANT_A)).toMatch(/[\\/]\.iris[\\/]custom-rules-tenant-a\.json$/);
+    expect(store.pathFor(LOCAL_TENANT)).toBe(join(irisHome(), 'custom-rules.json'));
+    expect(store.pathFor(TENANT_A)).toBe(join(irisHome(), 'custom-rules-tenant-a.json'));
   });
 
   it('sanitizes tenant ids to prevent directory traversal', () => {
@@ -162,8 +165,10 @@ describe('CustomRuleStore — tenant isolation', () => {
     // The TenantId brand doesn't enforce a charset; the store does.
     const evil = asTenantId('../../etc/passwd');
     const path = store.pathFor(evil);
-    // Path must NOT escape ~/.iris/ — the slashes/dots get sanitized to underscores.
-    expect(path).toMatch(/[\\/]\.iris[\\/]custom-rules-[a-zA-Z0-9._]+\.json$/);
+    // The invariant is containment: whatever the home directory is, the
+    // resolved path must stay inside it.
+    expect(resolve(path).startsWith(resolve(irisHome()))).toBe(true);
+    expect(path).toMatch(/custom-rules-[a-zA-Z0-9._]+\.json$/);
     expect(path).not.toContain('etc/passwd');
     expect(path).not.toMatch(/\.\.[\\/]/);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   test: {
     globals: true,
     include: ['tests/**/*.test.ts'],
+    /*
+     * Confines every in-process test to a scratch IRIS_HOME. Without it, a
+     * test that builds a server from defaultConfig writes to the developer's
+     * real ~/.iris — mcp-protocol.test.ts was appending to their actual
+     * audit.log on every run. See tests/setup/iris-home.ts.
+     */
+    setupFiles: ['./tests/setup/iris-home.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
Completes #321, which missed a case.

#321 routed every per-user path through `irisHome()` and isolated the two harnesses that **spawn** a server — Playwright's webServer and the stdio integration test. But vitest runs in the developer's **own process**, so any test that builds a server directly from `defaultConfig` still got the real `~/.iris`.

`tests/integration/mcp-protocol.test.ts` does exactly that: its `deploy_rule` / `delete_rule` round trip appended two rows to the real `~/.iris/audit.log` **on every run**. `custom-rules.json` survived only because deploy-then-delete happens to restore it; the append-only audit log did not.

Caught by hashing the three real files before and after a suite run — **no assertion would have found it**. That is exactly why the fix is global (a `setupFiles` entry pointing `IRIS_HOME` at a scratch dir) rather than per-file: a future test that forgets to pass a custom path is now contained by default instead of quietly writing to real user data.

## Two test rewrites

`custom-rule-store-tenant.test.ts` asserted a literal `.iris` path segment, which no longer holds once the home is overridable. They now assert against the **resolved** home, and their real invariants come out clearer:

- LOCAL_TENANT keeps the unsuffixed v0.4 **filename** — the zero-migration guarantee, which is the thing that actually matters
- a hostile tenant id stays **contained** within the home directory — a `startsWith` check, strictly stronger than the old regex it replaces

## Verification

566/566 tests, and sha256 of the real `audit.log` / `custom-rules.json` / `preferences.json` **byte-identical** across a full suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)