### PR TITLE
fix(dashboard): every "vs prior period" delta has never worked

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-11T03:27:15.942Z",
-  "generatedFromCommit": "5e32950",
+  "generatedAt": "2026-08-11T18:58:53.611Z",
+  "generatedFromCommit": "225750e",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 13
     },
-    "totalCombined": 690,
+    "totalCombined": 693,
     "vitestDashboard": {
       "failed": 0,
       "passed": 111,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 566,
-      "total": 566
+      "passed": 569,
+      "total": 569
     }
   },
   "version": {

--- a/src/dashboard/validation.ts
+++ b/src/dashboard/validation.ts
@@ -25,10 +25,10 @@ export const summaryQuerySchema = z.object({
 });
 
 export const evalStatsPeriodSchema = z.object({
-  period: z.enum(['24h', '7d', '30d', 'all']).default('24h'),
+  period: z.enum(['24h', '2d', '7d', '14d', '30d', '60d', '90d', '180d', 'all']).default('24h'),
 });
 
 export const evalStatsFailuresSchema = z.object({
-  period: z.enum(['24h', '7d', '30d', 'all']).default('24h'),
+  period: z.enum(['24h', '2d', '7d', '14d', '30d', '60d', '90d', '180d', 'all']).default('24h'),
   limit: z.coerce.number().int().min(1).max(100).default(10),
 });

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -364,9 +364,25 @@ export class SqliteAdapter implements IStorageAdapter {
   // Eval-stats endpoints (v0.2.0 dashboard)
   // ---------------------------------------------------------------------------
 
+  /*
+   * Table-driven rather than a nested ternary: the old form silently fell
+   * through to 720 hours for anything that wasn't '24h' or '7d', so a new
+   * period value would have quietly returned 30d data rather than failing.
+   */
+  private static readonly PERIOD_HOURS: Record<Exclude<EvalStatsPeriod, 'all'>, number> = {
+    '24h': 24,
+    '2d': 48,
+    '7d': 168,
+    '14d': 336,
+    '30d': 720,
+    '60d': 1440,
+    '90d': 2160,
+    '180d': 4320,
+  };
+
   private periodToSince(period: EvalStatsPeriod): string {
     if (period === 'all') return '1970-01-01T00:00:00.000Z';
-    const hours = period === '24h' ? 24 : period === '7d' ? 168 : 720;
+    const hours = SqliteAdapter.PERIOD_HOURS[period];
     return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
   }
 

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -27,7 +27,26 @@ export interface TraceQueryResult {
   offset: number;
 }
 
-export type EvalStatsPeriod = '24h' | '7d' | '30d' | 'all';
+/*
+ * Windows the eval-stats endpoints accept.
+ *
+ * The doubled values (2d / 14d / 60d / 180d) are not decorative: the Health
+ * view derives a prior-period comparison by requesting a DOUBLE-width window
+ * and subtracting the current one. That arithmetic was always correct, but
+ * the server rejected the doubled window with a 400, so every "vs prior
+ * period" delta on the default screen rendered "—" and had never once
+ * worked. 90d was likewise offered by the period selector and rejected.
+ */
+export type EvalStatsPeriod =
+  | '24h'
+  | '2d'
+  | '7d'
+  | '14d'
+  | '30d'
+  | '60d'
+  | '90d'
+  | '180d'
+  | 'all';
 
 export interface EvalStats {
   passRate: number;

--- a/tests/unit/dashboard/period-windows.test.ts
+++ b/tests/unit/dashboard/period-windows.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { evalStatsPeriodSchema } from '../../../src/dashboard/validation.js';
+
+/*
+ * The Health view derives its "vs prior period" comparison by requesting a
+ * DOUBLE-WIDTH window and subtracting the current one. That arithmetic was
+ * always right — but the server's enum only accepted 24h/7d/30d/all, so the
+ * doubled window came back 400 and EVERY delta on the default screen
+ * rendered "—". It had never worked once. The selector also offered 90d,
+ * which the server rejected outright.
+ *
+ * Two bugs, one shape: the UI's vocabulary was wider than the server's, and
+ * nothing tested the two against each other.
+ *
+ * This test reads the ACTUAL selector source rather than restating its
+ * options here. A copy of the list would drift the moment someone adds a
+ * period to the UI — which is precisely the bug being fixed.
+ */
+
+function periodsOfferedByTheUI(): Array<{ id: string; days: number }> {
+  const source = readFileSync(
+    resolve(import.meta.dirname, '../../../dashboard/src/components/dashboard/PeriodSelector.tsx'),
+    'utf-8',
+  );
+  const options = [...source.matchAll(/\{\s*id:\s*'([^']+)'\s*,\s*label:\s*'[^']*'\s*,\s*days:\s*(\d+)\s*\}/g)];
+  if (options.length === 0) {
+    throw new Error('could not parse PERIOD_OPTIONS — the selector shape changed, update this test');
+  }
+  return options.map((m) => ({ id: m[1], days: Number(m[2]) }));
+}
+
+describe('period vocabulary: the UI and the server agree', () => {
+  it('the server accepts every period the selector can produce', () => {
+    for (const { id } of periodsOfferedByTheUI()) {
+      expect(
+        evalStatsPeriodSchema.safeParse({ period: id }).success,
+        `the selector offers "${id}" but the server rejects it`,
+      ).toBe(true);
+    }
+  });
+
+  it('the server accepts the DOUBLED window behind every selector period', () => {
+    // HealthView asks for `${periodToDays(p) * 2}d` to compute the prior
+    // window. If the server can't answer that, the delta silently dies.
+    for (const { id, days } of periodsOfferedByTheUI()) {
+      const prior = `${days * 2}d`;
+      expect(
+        evalStatsPeriodSchema.safeParse({ period: prior }).success,
+        `comparison for "${id}" requests "${prior}", which the server rejects — the delta renders "—"`,
+      ).toBe(true);
+    }
+  });
+
+  it('still rejects nonsense', () => {
+    for (const bad of ['5d', 'yesterday', '30D', 'ALL', 'drop table']) {
+      expect(evalStatsPeriodSchema.safeParse({ period: bad }).success).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Two bugs with one shape: **the UI's period vocabulary was wider than the server's, and nothing tested the two against each other.**

## 1. Every KPI delta on the default screen was dead

`HealthView` computes its prior-period comparison by requesting a **double-width window** and subtracting the current one. That arithmetic is correct. But `${days * 2}d` produces `2d` / `14d` / `60d` / `180d`, and the server enum accepted only `24h` / `7d` / `30d` / `all`.

**Verified live before the fix:** `period=60d` → **HTTP 400**. So every "vs prior 30d" delta rendered `—`. It had never worked once.

## 2. The period selector offered a period the server rejects

`period=90d` → **HTTP 400**, breaking the primary stats and trend calls for anyone who clicked it.

## The fix

Widened the accepted windows to `24h/2d/7d/14d/30d/60d/90d/180d/all` across the type, the request validation and the adapter.

**Verified after:** all nine return **200**; `5d` still returns **400**.

Also replaced `periodToSince`'s nested ternary with a lookup table — the old form fell through to 720 hours for anything that wasn't `24h` or `7d`, so a newly added period would have silently returned 30-day data instead of failing. That is how a bug like this survives.

## The test

It **reads the selector source** and derives both the offered periods and their doubled windows from it, rather than restating the list. A copied list would drift the moment someone adds a period to the UI — which is precisely the bug being fixed.

Verified: 569/569 tests, typecheck + lint clean in both workspaces, both claims gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)