### PR TITLE
fix(dashboard): null costUsd/latencyMs white-screened the landing view

### DIFF
--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -163,8 +163,9 @@ export interface DecisionMoment {
   timestamp: string;
   input?: string;
   output?: string;
-  costUsd?: number;
-  latencyMs?: number;
+  /** Serialized as explicit null when the trace reported no cost — guard with != null, not !== undefined. */
+  costUsd?: number | null;
+  latencyMs?: number | null;
   verdict: MomentVerdict;
   overallScore: number;
   evalCount: number;

--- a/dashboard/src/components/dashboard/RecentMomentsRow.tsx
+++ b/dashboard/src/components/dashboard/RecentMomentsRow.tsx
@@ -185,7 +185,7 @@ export function RecentMomentsRow() {
             </Tooltip>
             <span style={styles.agent}>{m.agentName}</span>
             <span style={styles.failedRules}>{failedRulesPreview}</span>
-            {m.costUsd !== undefined ? (
+            {m.costUsd != null ? (
               <Tooltip content={TT.costPerTrace}>
                 <span style={styles.cost} tabIndex={0}>{formatCost(m.costUsd)}</span>
               </Tooltip>

--- a/dashboard/src/components/moments/MomentCard.tsx
+++ b/dashboard/src/components/moments/MomentCard.tsx
@@ -134,12 +134,12 @@ export function MomentCard({
 
       <div className="moment-card__meta iris-num iris-num--right">
         <span>{formatTimeAgo(moment.timestamp)}</span>
-        {moment.costUsd !== undefined && (
+        {moment.costUsd != null && (
           <Tooltip content={TT.costPerTrace}>
             <span tabIndex={0}>{formatCost(moment.costUsd)}</span>
           </Tooltip>
         )}
-        {moment.latencyMs !== undefined && (
+        {moment.latencyMs != null && (
           <Tooltip content={TT.latencyMs}>
             <span tabIndex={0}>{formatLatency(moment.latencyMs)}</span>
           </Tooltip>

--- a/dashboard/src/components/moments/MomentDetailPage.tsx
+++ b/dashboard/src/components/moments/MomentDetailPage.tsx
@@ -297,12 +297,12 @@ export function MomentDetailPage() {
             <span style={{ color: verdict.color, fontWeight: 700 }}>{verdict.label}</span>
             <span>{data.agentName}</span>
             <span>{formatTimestamp(data.timestamp)}</span>
-            {data.costUsd !== undefined && (
+            {data.costUsd != null && (
               <Tooltip content={TT.costPerTrace}>
                 <span tabIndex={0}>{formatCost(data.costUsd)}</span>
               </Tooltip>
             )}
-            {data.latencyMs !== undefined && (
+            {data.latencyMs != null && (
               <Tooltip content={TT.latencyMs}>
                 <span tabIndex={0}>{formatLatency(data.latencyMs)}</span>
               </Tooltip>

--- a/dashboard/tests/components/dashboard/FailuresView.test.tsx
+++ b/dashboard/tests/components/dashboard/FailuresView.test.tsx
@@ -76,6 +76,23 @@ beforeEach(() => {
 });
 
 describe('FailuresView', () => {
+  it('survives explicit null costUsd/latencyMs — the shape the server actually serializes', () => {
+    /*
+     * Regression: the /failures API sends costUsd: null (not undefined) for
+     * traces that reported no cost. A `!== undefined` guard let null through
+     * into formatCost → null.toFixed() → the landing view white-screened.
+     * Caught live against demo data on 2026-08-11; unit mocks had only ever
+     * omitted the fields.
+     */
+    useFailuresMock.mockReturnValue(
+      apiResult([makeFailure('t-null', { costUsd: null, latencyMs: null })]),
+    );
+    renderView();
+
+    expect(screen.getByText('agent-t-null')).toBeInTheDocument();
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument(); // no cost chip rendered
+  });
+
   it('renders each failure with agent, failed rule, and time — and links to the detail view', () => {
     useFailuresMock.mockReturnValue(apiResult([makeFailure('t-1'), makeFailure('t-2')]));
     renderView();


### PR DESCRIPTION
Live verification against --demo data caught the new default view white-screening: the /failures API serializes \`costUsd: null\` (not undefined) for traces with no reported cost, the \`!== undefined\` guards let null through, and \`formatCost(null).toFixed()\` killed the render with no error boundary.

- \`DecisionMoment.costUsd/latencyMs\` typed \`number | null\` so the compiler flags every unsafe call site (it found three: MomentCard, RecentMomentsRow, MomentDetailPage)
- Guards changed to \`!= null\`
- Regression test feeds the REAL serialized shape (explicit nulls) through FailuresView — the prior mocks only ever omitted the fields, which is why 152 passing tests missed a crash on the first screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)