### PR TITLE
fix(security): owner-only data files + close SSRF encoding bypasses

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-12T01:06:59.020Z",
-  "generatedFromCommit": "45db0dc",
+  "generatedAt": "2026-08-12T03:19:07.313Z",
+  "generatedFromCommit": "554cb89",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -123,7 +123,7 @@
       "passed": null,
       "total": 14
     },
-    "totalCombined": 790,
+    "totalCombined": 799,
     "vitestDashboard": {
       "failed": 0,
       "passed": 151,
@@ -131,8 +131,8 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 625,
-      "total": 625
+      "passed": 630,
+      "total": 634
     }
   },
   "version": {

--- a/src/custom-rule-store.ts
+++ b/src/custom-rule-store.ts
@@ -24,7 +24,7 @@
  * leave a half-file.
  */
 import { mkdirSync, readFileSync, existsSync, appendFileSync } from 'node:fs';
-import { writeAtomic } from './utils/write-atomic.js';
+import { writeAtomic, ensureOwnerOnly, OWNER_ONLY_FILE_MODE } from './utils/write-atomic.js';
 import { irisHome } from './utils/iris-home.js';
 import { join, dirname } from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -265,7 +265,13 @@ function generateRuleId(): string {
 function appendAudit(auditPath: string, entry: AuditLogEntry): void {
   try {
     mkdirSync(dirname(auditPath), { recursive: true });
-    appendFileSync(auditPath, `${JSON.stringify(entry)}\n`, 'utf-8');
+    // mode applies only when appendFileSync creates the file; an existing
+    // audit.log keeps its mode, which is why ensureOwnerOnly() also runs at
+    // store construction to repair files created before this change.
+    appendFileSync(auditPath, `${JSON.stringify(entry)}\n`, {
+      encoding: 'utf-8',
+      mode: OWNER_ONLY_FILE_MODE,
+    });
   } catch {
     // Audit best-effort. If filesystem is read-only or full, the deploy
     // still succeeds; the operator just loses the audit trail.
@@ -348,7 +354,11 @@ export function createCustomRuleStore(opts?: {
   function state(tenantId: TenantId): LoadedRules {
     let loaded = tenantState.get(tenantId);
     if (loaded === undefined) {
-      loaded = loadRulesFromDisk(pathFor(tenantId));
+      const path = pathFor(tenantId);
+      loaded = loadRulesFromDisk(path);
+      // Repair permissions on files created before the owner-only change
+      // (and on the audit log, which appendFileSync only modes at creation).
+      ensureOwnerOnly(path, auditPath);
       tenantState.set(tenantId, loaded);
     }
     return loaded;

--- a/src/eval/citation-verify/resolve.ts
+++ b/src/eval/citation-verify/resolve.ts
@@ -90,6 +90,17 @@ const BLOCKED_IPV4 = [
   /^255\.255\.255\.255$/,
   // This-network
   /^0\./,
+  // Carrier-grade NAT (RFC 6598). Routable inside an ISP or a corporate
+  // overlay — Tailscale hands out 100.64/10 addresses, so this range reaches
+  // real internal hosts on a very common setup.
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,
+  // IETF protocol assignments (RFC 6890) incl. 192.0.0.0/24
+  /^192\.0\.0\./,
+  // Benchmarking (RFC 2544) — routed to internal test networks in practice
+  /^198\.(1[89])\./,
+  // Multicast and reserved/future space
+  /^(22[4-9]|23\d)\./,
+  /^(24\d|25[0-5])\./,
 ];
 
 const BLOCKED_HOST_SUBSTRINGS = ['localhost', 'internal', '.local', 'metadata.google', 'metadata.azure'];
@@ -174,6 +185,25 @@ function isBlockedIpv6(addr: string): boolean {
   if (first === 'fe80' || /^fe[89ab]/.test(first)) return true;
   // fc00::/7 unique-local (fc.. / fd..)
   if (first.startsWith('fc') || first.startsWith('fd')) return true;
+  /*
+   * Transition mechanisms tunnel an IPv4 destination inside an IPv6 literal,
+   * so the v4 blocklist has to be applied to the embedded address or the
+   * whole v4 ruleset is bypassable by re-encoding the target.
+   *
+   * 6to4 (2002::/16, RFC 3056): the destination v4 is hextets 1-2, plain.
+   * Teredo (2001:0000::/32, RFC 4380): the client v4 is hextets 6-7, stored
+   * one's-complemented, so it must be un-obfuscated before classification.
+   */
+  if (first === '2002') {
+    return BLOCKED_IPV4.some((re) => re.test(ipv4FromHextets(g[1], g[2])));
+  }
+  if (first === '2001' && g[1] === '0000') {
+    const deobfuscate = (h: string): string =>
+      (parseInt(h, 16) ^ 0xffff).toString(16).padStart(4, '0');
+    const client = ipv4FromHextets(deobfuscate(g[6]), deobfuscate(g[7]));
+    const server = ipv4FromHextets(g[2], g[3]);
+    return BLOCKED_IPV4.some((re) => re.test(client) || re.test(server));
+  }
   // IPv4-mapped ::ffff:a.b.c.d  and  IPv4-compatible ::a.b.c.d (deprecated)
   const mapped = g.slice(0, 5).every((h) => h === '0000') && g[5] === 'ffff';
   const compat = g.slice(0, 6).every((h) => h === '0000') && !(g[6] === '0000' && g[7] === '0000');

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -20,6 +20,7 @@
  *     its own data.
  */
 import Database from 'better-sqlite3';
+import { ensureOwnerOnly } from '../utils/write-atomic.js';
 import type {
   IStorageAdapter,
   DashboardSummary,
@@ -54,8 +55,10 @@ function assertTenant(tenantId: TenantId): void {
 
 export class SqliteAdapter implements IStorageAdapter {
   private db: Database.Database;
+  private readonly dbPath: string;
 
   constructor(dbPath: string) {
+    this.dbPath = dbPath;
     this.db = new Database(dbPath);
   }
 
@@ -64,6 +67,17 @@ export class SqliteAdapter implements IStorageAdapter {
     this.db.pragma('busy_timeout = 5000');
     this.db.pragma('foreign_keys = ON');
     runMigrations(this.db);
+    /*
+     * iris.db holds agent inputs and outputs verbatim, and a tool that
+     * detects PII necessarily stores the PII it found. better-sqlite3
+     * creates the file with the process umask (typically 0644 = readable by
+     * every local account), and WAL mode creates two sidecars that hold the
+     * same data. Narrow all three after the pragmas, since -wal/-shm do not
+     * exist until WAL is enabled. No-op on Windows and on :memory:.
+     */
+    if (this.dbPath !== ':memory:') {
+      ensureOwnerOnly(this.dbPath, `${this.dbPath}-wal`, `${this.dbPath}-shm`);
+    }
   }
 
   async close(): Promise<void> {

--- a/src/utils/write-atomic.ts
+++ b/src/utils/write-atomic.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, renameSync, unlinkSync, chmodSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { randomBytes } from 'node:crypto';
 
@@ -30,6 +30,38 @@ import { randomBytes } from 'node:crypto';
 const TRANSIENT_RENAME_ERRORS = new Set(['EPERM', 'EACCES', 'EBUSY']);
 const MAX_ATTEMPTS = 5;
 
+/*
+ * Owner-only (0600). These files hold agent inputs and outputs verbatim —
+ * and a tool whose job is detecting PII necessarily stores the PII it found.
+ * Node's default is 0666 before umask, so a typical umask leaves them 0644:
+ * world-readable to every local account on a shared POSIX host. The mode is
+ * a no-op on Windows (ACL inheritance governs there), which is exactly why
+ * local testing never surfaces it.
+ *
+ * Set at creation on the temp file, so the bytes are never briefly readable
+ * between write and chmod; rename preserves the mode.
+ */
+export const OWNER_ONLY_FILE_MODE = 0o600;
+
+/*
+ * Narrow an EXISTING file to owner-only. Two cases need this, because a mode
+ * passed at write time only applies when the write creates the file:
+ *   - files written before this change (every install that predates it),
+ *   - files a library creates for us (better-sqlite3 opens iris.db, and WAL
+ *     mode adds iris.db-wal / iris.db-shm on first write).
+ * Best-effort by design: a missing file, a read-only mount, or a
+ * non-POSIX filesystem must never take the server down over permissions.
+ */
+export function ensureOwnerOnly(...paths: string[]): void {
+  for (const p of paths) {
+    try {
+      if (existsSync(p)) chmodSync(p, OWNER_ONLY_FILE_MODE);
+    } catch {
+      // Best effort — see above.
+    }
+  }
+}
+
 function sleepSync(ms: number): void {
   // Synchronous by necessity — writeAtomic is sync, and making it async
   // would ripple through every caller for a Windows-only edge case.
@@ -39,7 +71,7 @@ function sleepSync(ms: number): void {
 export function writeAtomic(targetPath: string, contents: string): void {
   mkdirSync(dirname(targetPath), { recursive: true });
   const tmp = `${targetPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
-  writeFileSync(tmp, contents, 'utf-8');
+  writeFileSync(tmp, contents, { encoding: 'utf-8', mode: OWNER_ONLY_FILE_MODE });
 
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {

--- a/tests/unit/eval/citation-verify/resolve.test.ts
+++ b/tests/unit/eval/citation-verify/resolve.test.ts
@@ -108,6 +108,58 @@ describe('isSafeHost (SSRF guard)', () => {
     expect(isSafeHost('[:::1]')).toBe(false);
     expect(isSafeHost('[gggg::1]')).toBe(false);
   });
+
+  it('blocks carrier-grade NAT (RFC 6598) — the Tailscale/ISP overlay range', () => {
+    expect(isSafeHost('100.64.0.1')).toBe(false);
+    expect(isSafeHost('100.100.100.100')).toBe(false);
+    expect(isSafeHost('100.127.255.255')).toBe(false);
+    // Boundaries: 100.63.x and 100.128.x are ordinary public space.
+    expect(isSafeHost('100.63.255.255')).toBe(true);
+    expect(isSafeHost('100.128.0.1')).toBe(true);
+  });
+
+  it('blocks IETF-assigned, benchmarking, multicast and reserved v4 space', () => {
+    expect(isSafeHost('192.0.0.1')).toBe(false); // RFC 6890
+    expect(isSafeHost('198.18.0.1')).toBe(false); // RFC 2544 benchmarking
+    expect(isSafeHost('198.19.255.1')).toBe(false);
+    expect(isSafeHost('224.0.0.1')).toBe(false); // multicast
+    expect(isSafeHost('239.255.255.250')).toBe(false); // SSDP
+    expect(isSafeHost('240.0.0.1')).toBe(false); // reserved
+    // 192.0.1.x and 198.20.x sit just outside those blocks.
+    expect(isSafeHost('192.0.1.1')).toBe(true);
+    expect(isSafeHost('198.20.0.1')).toBe(true);
+  });
+
+  /*
+   * Transition mechanisms re-encode an IPv4 destination inside an IPv6
+   * literal. Without embedded-address classification, every v4 rule above
+   * is bypassable by rewriting the target in one of these forms.
+   */
+  it('blocks 6to4 (2002::/16) wrapping a private IPv4 destination', () => {
+    expect(isSafeHost('[2002:7f00:0001::]')).toBe(false); // 127.0.0.1
+    expect(isSafeHost('[2002:a9fe:a9fe::]')).toBe(false); // 169.254.169.254 IMDS
+    expect(isSafeHost('[2002:c0a8:0101::]')).toBe(false); // 192.168.1.1
+    expect(isSafeHost('[2002:6440:0001::]')).toBe(false); // 100.64.0.1 CGNAT
+    expect(isSafeHost('[2002:0808:0808::]')).toBe(true); // 8.8.8.8 — public
+  });
+
+  it('blocks Teredo (2001:0::/32) whose de-obfuscated client IPv4 is private', () => {
+    // Client v4 lives in the last two hextets, one's-complemented:
+    // 192.168.1.1 -> ~c0a8:0101 -> 3f57:fefe.
+    expect(isSafeHost('[2001:0:4136:e378:8000:63bf:3f57:fefe]')).toBe(false);
+    // ~7f00:0001 -> 80ff:fffe  == 127.0.0.1
+    expect(isSafeHost('[2001:0:4136:e378:8000:63bf:80ff:fffe]')).toBe(false);
+    // Server field is checked too: 2001:0:7f00:0001:... == server 127.0.0.1
+    expect(isSafeHost('[2001:0:7f00:0001:8000:63bf:1234:5678]')).toBe(false);
+    // ~0808:0808 -> f7f7:f7f7 == public 8.8.8.8 client, public server
+    expect(isSafeHost('[2001:0:4136:e378:8000:63bf:f7f7:f7f7]')).toBe(true);
+  });
+
+  it('does not over-block ordinary 2001: production addresses', () => {
+    // Only 2001:0000::/32 is Teredo — 2001:db8, 2001:4860 etc. are normal.
+    expect(isSafeHost('[2001:4860:4860::8888]')).toBe(true); // Google DNS
+    expect(isSafeHost('[2001:db8::1]')).toBe(true);
+  });
 });
 
 describe('resolveAndCheckHost (DNS rebinding guard)', () => {

--- a/tests/unit/utils/write-atomic.test.ts
+++ b/tests/unit/utils/write-atomic.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, readdirSync, existsSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeAtomic } from '../../../src/utils/write-atomic.js';
+import { writeAtomic, ensureOwnerOnly } from '../../../src/utils/write-atomic.js';
 
 let dir: string;
 
@@ -73,5 +73,40 @@ describe('writeAtomic', () => {
     rmSync(target, { recursive: true, force: true });
     writeAtomic(join(dir, 'seed.json'), 'x');
     expect(() => writeAtomic(join('\0invalid', 'nope.json'), 'x')).toThrow();
+  });
+});
+
+/*
+ * These files hold agent inputs and outputs verbatim, and a PII detector
+ * necessarily stores the PII it found. Windows has no POSIX mode bits
+ * (ACL inheritance governs), so the assertions are POSIX-only — which is
+ * precisely why this class of defect survives local testing on Windows.
+ */
+const posixOnly = process.platform === 'win32' ? describe.skip : describe;
+
+posixOnly('owner-only permissions (POSIX)', () => {
+  it('writeAtomic creates files as 0600, not umask default', () => {
+    const target = join(dir, 'secret.json');
+    writeAtomic(target, '{"ssn":"123-45-6789"}');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('the mode holds when writeAtomic overwrites an existing file', () => {
+    const target = join(dir, 'secret.json');
+    writeAtomic(target, 'first');
+    writeAtomic(target, 'second');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('ensureOwnerOnly repairs a file that was already world-readable', () => {
+    const target = join(dir, 'legacy.json');
+    writeFileSync(target, 'created before the fix', { mode: 0o644 });
+    expect(statSync(target).mode & 0o777).toBe(0o644);
+    ensureOwnerOnly(target);
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('ensureOwnerOnly is silent on missing paths and never throws', () => {
+    expect(() => ensureOwnerOnly(join(dir, 'does-not-exist'), join(dir, 'nor-this'))).not.toThrow();
   });
 });


### PR DESCRIPTION
Two residuals from the S77 security review, both rated *plausible* rather than confirmed at the time and both verified still live on main today.

### 1. Per-user data files were world-readable on POSIX

No `mode:` or `chmod` existed anywhere in `src/`, so `iris.db`, `custom-rules.json`, `audit.log` and `preferences.json` were created with the process umask — typically `0644`, readable by every local account on a shared host. `iris.db` holds agent inputs and outputs verbatim, and a tool whose job is detecting PII necessarily stores the PII it found.

- `writeAtomic` now creates at `0600`, set on the temp file so the bytes are never briefly readable between write and chmod (rename preserves the mode)
- the audit log is moded at creation
- `ensureOwnerOnly()` repairs files created before this change, plus the `-wal`/`-shm` sidecars better-sqlite3 creates for us after WAL is enabled

**Verification:** this is invisible on Windows (ACL inheritance governs), which is exactly why local testing never surfaced it. The vitest assertions are `describe.skip` on win32 by design — so I verified the built module under WSL on real POSIX: new files `0600`, mode survives overwrite, a planted `0644` legacy file repaired to `0600`, missing paths tolerated.

### 2. SSRF blocklist bypassable by re-encoding the target

Added the missing IPv4 ranges: CGNAT `100.64/10` (Tailscale and ISP overlays route real internal hosts there), `192.0.0.0/24`, `198.18/15` benchmarking, multicast and reserved space — each with boundary tests proving neighbouring public space still resolves.

The actual bypass was IPv6 transition mechanisms: **6to4** (`2002::/16`) and **Teredo** (`2001:0::/32`) tunnel an IPv4 destination inside an IPv6 literal, and neither was classified. Both now have their embedded IPv4 extracted and run through the v4 blocklist, with Teredo's client field de-obfuscated (one's-complement) first — otherwise every v4 rule was one rewrite away from irrelevant. `[2002:a9fe:a9fe::]` reached AWS IMDS before this change. Tests confirm ordinary `2001:` production addresses (Google DNS, `2001:db8`) are not over-blocked.

## Tests

630/630 root suite (4 POSIX-only permission tests skip on Windows, pass under WSL), lint + typecheck clean, claims:check + claims:check-hardcoded green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)