### PR TITLE
ci: packages/init gets PR CI + Dependabot coverage (#335)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,6 +81,25 @@ updates:
         patterns:
           - "@types/*"
 
+  - package-ecosystem: "npm"
+    directory: "/packages/init"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(init)"
+    groups:
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      types:
+        patterns:
+          - "@types/*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,25 @@ jobs:
       - run: cd website && npm run lint
       - run: cd website && npx tsc --noEmit
 
+  # packages/init is a PUBLISHED npm package (@iris-eval/init) that had NO
+  # PR gate at all — breaks landed invisibly and first surfaced inside the
+  # tag-triggered release-init.yml job, which holds the OIDC publishing
+  # identity (issue #335). This job runs the same typecheck + test + build
+  # that release-init.yml depends on, on every PR.
+  init-typecheck-test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: packages/init/package-lock.json
+      - run: cd packages/init && npm ci
+      - run: cd packages/init && npm run typecheck
+      - run: cd packages/init && npm test
+      - run: cd packages/init && npm run build
+
   build:
     runs-on: ubuntu-latest
     needs: [lint-and-typecheck, test]


### PR DESCRIPTION
`packages/init` is a **published npm package with zero PR CI** — no job in ci.yml referenced it, so a break lands on main invisibly and first surfaces inside the tag-triggered release job that holds the OIDC publishing identity. That is the worst possible place to discover it.

- Adds a PR CI job running its typecheck + test + build, matching the repo's existing job conventions (pinned action SHAs, `npm ci`)
- Adds a Dependabot npm entry for `/packages/init` (its lockfile is already drifting: `@types/node ^25.5.2` vs root `^26.1.1`). `/packages/langchain` is deliberately excluded — it has no lockfile yet.

Closes #335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)