### PR TITLE
fix(claims): platform-dependent test counts turned the truthbase gate red on main

### DIFF
--- a/.claims.json
+++ b/.claims.json
@@ -57,8 +57,8 @@
       "[ADD "
     ]
   },
-  "generatedAt": "2026-08-12T03:19:07.313Z",
-  "generatedFromCommit": "554cb89",
+  "generatedAt": "2026-08-12T04:29:29.174Z",
+  "generatedFromCommit": "9940ca9",
   "generatorVersion": "1.0.0",
   "llmJudgeTemplates": {
     "count": 5,
@@ -131,7 +131,7 @@
     },
     "vitestRoot": {
       "failed": 0,
-      "passed": 630,
+      "passed": 634,
       "total": 634
     }
   },

--- a/scripts/claims/capture-tests.mjs
+++ b/scripts/claims/capture-tests.mjs
@@ -68,6 +68,26 @@ async function captureScope(scope) {
     console.warn(`[claims:capture-tests] WARN — could not parse vitest report for scope "${scope || 'root'}" (exit ${exitCode}). stderr tail:`);
     console.warn(stderrTail);
   }
+  /*
+   * A skipped test makes the captured counts depend on WHERE capture ran.
+   * .claims.json is derived truth: captured on a developer's machine, then
+   * re-derived by the truthbase CI job on Linux and compared. A suite with
+   * `describe.skip(process.platform === 'win32' ? ... )` captures 630/634 on
+   * Windows and 634/634 in CI — the gate goes red on main for a reason that
+   * lives in nobody's diff. Fail loudly at capture time instead: make the
+   * test run on every platform and branch its assertions.
+   */
+  if (summary.total !== null && summary.passed !== null && summary.failed === 0) {
+    const skipped = summary.total - summary.passed;
+    if (skipped > 0) {
+      throw new Error(
+        `[claims:capture-tests] ${skipped} test(s) skipped in scope "${scope || 'root'}" ` +
+          `(${summary.passed} passed of ${summary.total}). Captured counts must be ` +
+          `platform-invariant — .claims.json is re-derived in CI on Linux and compared. ` +
+          `Make the test run everywhere and branch its assertions instead of skipping it.`,
+      );
+    }
+  }
   return summary;
 }
 

--- a/tests/unit/utils/write-atomic.test.ts
+++ b/tests/unit/utils/write-atomic.test.ts
@@ -78,32 +78,51 @@ describe('writeAtomic', () => {
 
 /*
  * These files hold agent inputs and outputs verbatim, and a PII detector
- * necessarily stores the PII it found. Windows has no POSIX mode bits
- * (ACL inheritance governs), so the assertions are POSIX-only — which is
- * precisely why this class of defect survives local testing on Windows.
+ * necessarily stores the PII it found, so they must not be world-readable.
+ *
+ * Windows has no POSIX mode bits (ACL inheritance governs), so the mode
+ * assertions only mean something there. These tests deliberately RUN on
+ * both platforms anyway, branching the assertion rather than skipping the
+ * case: skipping made the suite's test COUNT platform-dependent, and
+ * .claims.json is derived truth captured on one machine and re-derived in
+ * CI on another — a Windows-captured 630/634 drifted against Linux's
+ * 634/634 and turned the truthbase gate red on main. A gate whose input
+ * changes with the developer's OS is not a gate.
+ *
+ * On Windows the assertion is still real: the write must succeed and the
+ * bytes must be readable back, proving the mode argument is inert there
+ * rather than corrupting the write path.
  */
-const posixOnly = process.platform === 'win32' ? describe.skip : describe;
+const isWindows = process.platform === 'win32';
 
-posixOnly('owner-only permissions (POSIX)', () => {
+function expectOwnerOnly(path: string, contents: string): void {
+  if (isWindows) {
+    expect(readFileSync(path, 'utf-8')).toBe(contents);
+    return;
+  }
+  expect(statSync(path).mode & 0o777).toBe(0o600);
+}
+
+describe('owner-only permissions', () => {
   it('writeAtomic creates files as 0600, not umask default', () => {
     const target = join(dir, 'secret.json');
     writeAtomic(target, '{"ssn":"123-45-6789"}');
-    expect(statSync(target).mode & 0o777).toBe(0o600);
+    expectOwnerOnly(target, '{"ssn":"123-45-6789"}');
   });
 
   it('the mode holds when writeAtomic overwrites an existing file', () => {
     const target = join(dir, 'secret.json');
     writeAtomic(target, 'first');
     writeAtomic(target, 'second');
-    expect(statSync(target).mode & 0o777).toBe(0o600);
+    expectOwnerOnly(target, 'second');
   });
 
   it('ensureOwnerOnly repairs a file that was already world-readable', () => {
     const target = join(dir, 'legacy.json');
     writeFileSync(target, 'created before the fix', { mode: 0o644 });
-    expect(statSync(target).mode & 0o777).toBe(0o644);
+    if (!isWindows) expect(statSync(target).mode & 0o777).toBe(0o644);
     ensureOwnerOnly(target);
-    expect(statSync(target).mode & 0o777).toBe(0o600);
+    expectOwnerOnly(target, 'created before the fix');
   });
 
   it('ensureOwnerOnly is silent on missing paths and never throws', () => {


### PR DESCRIPTION
**Main is currently red on `Truthbase regen vs committed`, and it's my fault.** #349 shipped 4 permission tests behind `describe.skip` on win32. I captured `.claims.json` on Windows (`630 passed / 634 total`); the truthbase job re-derives it on Linux where those tests run (`634/634`), so the gate fails on a drift that appears in nobody's diff.

Two fixes, one root cause:

1. **The tests now run on every platform** and branch their assertions instead of skipping — POSIX asserts `mode 0600`, Windows asserts the write succeeds and reads back intact (proving the mode argument is inert there rather than corrupting the write path). Skipping also hid them from the only machine a developer actually runs them on.

2. **`claims:capture-tests` now fails when any scope reports skipped tests**, naming the count and the reason. Derived truth captured on one machine and compared on another cannot tolerate a platform-conditional input — this makes the next instance impossible instead of mysterious.

Verified: 10/10 in that file with 0 skipped on Windows, and root capture is now `634/634` locally — the same number CI derives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)