### PR TITLE
test(uat): promote the acceptance harness into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ storybook-static/
 # different machine, or CI had no exclusion at all, and the standard commit
 # recipe for this repo is `git add -A`. Belongs in the tracked ignore file.
 plans/
+
+# UAT harness scratch: per-run IRIS_HOMEs and the generated report. The
+# harness is the gate; its output is an artifact of one run on one machine.
+tests/uat/.work/
+tests/uat/UAT-REPORT.md

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run tests/integration/",
     "test:e2e": "playwright test",
+    "test:uat": "node tests/uat/run-uat.mjs",
     "test:e2e:ui": "playwright test --ui",
     "version:check": "bash scripts/check-version.sh",
     "version:sync": "node scripts/sync-versions.mjs",

--- a/tests/uat/lib/env.mjs
+++ b/tests/uat/lib/env.mjs
@@ -1,0 +1,100 @@
+/*
+ * Shared paths + constants for the Iris UAT harness.
+ *
+ * The iris repo is READ-ONLY to this harness. Everything the run writes
+ * lives under UAT_DIR/.work, which is wiped at the start of every run so
+ * the harness is idempotent.
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** tests/uat/ — the harness root. */
+export const UAT_DIR = dirname(here);
+
+/** Scratch root, wiped at run start. Git-ignored; the repo stays clean. */
+export const WORK_DIR = join(UAT_DIR, '.work');
+
+/*
+ * The repo under test, derived from this file's own location
+ * (<repo>/tests/uat/lib/env.mjs -> <repo>) rather than hardcoded, so the
+ * harness works from a clone, a git worktree, or a CI runner. Everything
+ * except dist/ and .work/ is read-only to this harness.
+ */
+export const IRIS_REPO = dirname(dirname(UAT_DIR));
+
+export const IRIS_ENTRY = join(IRIS_REPO, 'dist', 'index.js');
+export const IRIS_CLAIMS = join(IRIS_REPO, '.claims.json');
+export const IRIS_NODE_MODULES = join(IRIS_REPO, 'node_modules');
+
+export const REPORT_PATH = join(UAT_DIR, 'UAT-REPORT.md');
+
+/**
+ * The founder's REAL iris home. The harness must never touch any of
+ * this. Hashed before + after the run; any change fails the harness.
+ */
+export const REAL_IRIS_HOME = join(homedir(), '.iris');
+
+export const GUARDED_FILES = [
+  'iris.db',
+  'custom-rules.json',
+  'audit.log',
+  'preferences.json',
+  'runtime.json',
+  'demo.db',
+  'demo-preferences.json',
+  'demo-custom-rules.json',
+  'demo-audit.log',
+];
+
+/** Named in the harness brief as the three that MUST be unchanged. */
+export const CRITICAL_GUARDED_FILES = ['iris.db', 'custom-rules.json', 'audit.log'];
+
+/**
+ * Base env for every spawned iris process.
+ *
+ * IRIS_HOME is always overridden per-process by the caller. The rest
+ * keeps runs hermetic: no browser launch, no inherited API keys (the
+ * graceful-degradation checks depend on the keys being ABSENT), no
+ * inherited IRIS_* config from the developer's shell.
+ */
+export function baseChildEnv(irisHome, extra = {}) {
+  const env = {};
+  // Windows needs these for node + better-sqlite3 to resolve at all.
+  for (const key of [
+    'APPDATA',
+    'COMSPEC',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'LOCALAPPDATA',
+    'NUMBER_OF_PROCESSORS',
+    'OS',
+    'PATH',
+    'PATHEXT',
+    'PROCESSOR_ARCHITECTURE',
+    'PROGRAMDATA',
+    'PROGRAMFILES',
+    'SYSTEMDRIVE',
+    'SYSTEMROOT',
+    'TEMP',
+    'TMP',
+    'USERNAME',
+    'USERPROFILE',
+    'WINDIR',
+    'HOME',
+    'LOGNAME',
+    'SHELL',
+    'TERM',
+    'USER',
+  ]) {
+    if (process.env[key] !== undefined) env[key] = process.env[key];
+  }
+  env.IRIS_HOME = irisHome;
+  env.IRIS_NO_AUTO_LAUNCH = '1';
+  env.IRIS_LOG_LEVEL = 'error';
+  // Explicitly NOT inherited: IRIS_ANTHROPIC_API_KEY / IRIS_OPENAI_API_KEY
+  // / IRIS_API_KEY / IRIS_DB_PATH / IRIS_ALLOWED_ORIGINS.
+  return { ...env, ...extra };
+}

--- a/tests/uat/lib/guard.mjs
+++ b/tests/uat/lib/guard.mjs
@@ -1,0 +1,53 @@
+/*
+ * Real-home integrity guard.
+ *
+ * Every iris process the harness spawns gets an IRIS_HOME under the
+ * scratch dir. That intent is worth nothing unless it is MEASURED, so
+ * the founder's real ~/.iris is content-hashed before and after the run.
+ * Any change to a guarded file fails the harness outright — a UAT run
+ * that quietly ate the user's live trace database would be worse than no
+ * UAT run at all (that exact class of bug is why tests/setup/iris-home.ts
+ * exists in the repo).
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { GUARDED_FILES, REAL_IRIS_HOME } from './env.mjs';
+
+const ABSENT = 'ABSENT';
+
+export function snapshotRealHome() {
+  const snap = {};
+  for (const name of GUARDED_FILES) {
+    const p = join(REAL_IRIS_HOME, name);
+    if (!existsSync(p)) {
+      snap[name] = ABSENT;
+      continue;
+    }
+    try {
+      const buf = readFileSync(p);
+      const st = statSync(p);
+      snap[name] = `${createHash('sha256').update(buf).digest('hex')}:${st.size}`;
+    } catch (err) {
+      snap[name] = `UNREADABLE:${err.code ?? err.message}`;
+    }
+  }
+  return snap;
+}
+
+/** @returns {{changed:string[], detail:string[]}} */
+export function diffSnapshots(before, after) {
+  const changed = [];
+  const detail = [];
+  for (const name of GUARDED_FILES) {
+    const b = before[name];
+    const a = after[name];
+    if (b === a) {
+      detail.push(`unchanged \`${name}\` — ${b === ABSENT ? 'absent before and after' : `sha256 ${b.slice(0, 16)}…`}`);
+    } else {
+      changed.push(name);
+      detail.push(`**CHANGED** \`${name}\` — before \`${b}\` / after \`${a}\``);
+    }
+  }
+  return { changed, detail };
+}

--- a/tests/uat/lib/http.mjs
+++ b/tests/uat/lib/http.mjs
@@ -1,0 +1,82 @@
+/*
+ * Raw node:http request helper.
+ *
+ * node:http, NOT fetch — deliberately, and everywhere, not just for the
+ * hostile-header checks. fetch() silently drops forbidden headers
+ * (Host chief among them), so a fetch-based rebinding probe asserts
+ * nothing at all while looking green. Using one transport for every
+ * request also means the harness never has two different header
+ * behaviours to reason about.
+ */
+import { request as httpRequest } from 'node:http';
+
+export function raw({
+  port,
+  method = 'GET',
+  path = '/',
+  headers = {},
+  body,
+  host = '127.0.0.1',
+  timeoutMs = 15_000,
+}) {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? undefined : typeof body === 'string' ? body : JSON.stringify(body);
+    const finalHeaders = { Connection: 'close', ...headers };
+    if (payload !== undefined) {
+      if (!Object.keys(finalHeaders).some((k) => k.toLowerCase() === 'content-type')) {
+        finalHeaders['Content-Type'] = 'application/json';
+      }
+      finalHeaders['Content-Length'] = Buffer.byteLength(payload);
+    }
+
+    const req = httpRequest(
+      { host, port, path, method, headers: finalHeaders, setHost: !hasHostHeader(headers) },
+      (res) => {
+        let buf = '';
+        res.setEncoding('utf8');
+        res.on('data', (c) => {
+          buf += c;
+        });
+        res.once('end', () => {
+          let json;
+          try {
+            json = JSON.parse(buf);
+          } catch {
+            json = undefined;
+          }
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, body: buf, json });
+        });
+      },
+    );
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`request timed out after ${timeoutMs}ms: ${method} ${path}`));
+    });
+    req.once('error', reject);
+    if (payload !== undefined) req.write(payload);
+    req.end();
+  });
+}
+
+function hasHostHeader(headers) {
+  return Object.keys(headers).some((k) => k.toLowerCase() === 'host');
+}
+
+/** GET + parse, throwing when the response is not the expected status. */
+export async function getJson(port, path, expectStatus = 200) {
+  const res = await raw({ port, path });
+  if (res.status !== expectStatus) {
+    throw new Error(`GET ${path}: expected ${expectStatus}, got ${res.status} — body ${res.body.slice(0, 200)}`);
+  }
+  if (res.json === undefined) {
+    throw new Error(`GET ${path}: response was not JSON — ${res.body.slice(0, 200)}`);
+  }
+  return res.json;
+}
+
+export async function postJson(port, path, body, expectStatus) {
+  const res = await raw({ port, method: 'POST', path, body });
+  if (expectStatus !== undefined && res.status !== expectStatus) {
+    throw new Error(`POST ${path}: expected ${expectStatus}, got ${res.status} — body ${res.body.slice(0, 200)}`);
+  }
+  return res;
+}

--- a/tests/uat/lib/proc.mjs
+++ b/tests/uat/lib/proc.mjs
@@ -1,0 +1,223 @@
+/*
+ * Process helpers: one-shot CLI runs and long-lived dashboard servers.
+ *
+ * Readiness is POLLED, never slept-on. A dashboard server is considered
+ * up only when GET /api/v1/health answers 200 on the port it actually
+ * bound — discovered from ${IRIS_HOME}/runtime.json (the port-discovery
+ * handshake the server writes in its listen callback) with the startup
+ * banner on stderr as a fallback. An early child exit aborts the wait
+ * immediately with the captured stderr, so a crashed server surfaces as
+ * a crash and not as a 30s timeout.
+ */
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { IRIS_ENTRY, IRIS_REPO, baseChildEnv } from './env.mjs';
+import { raw } from './http.mjs';
+
+const NODE = process.execPath;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Reserve an out-of-band port: bind :0, read what the OS handed out,
+ * release it, hand the number to the child.
+ *
+ * `--dashboard-port 0` is NOT usable here — the CLI's PortSchema
+ * enforces the documented 1-65535 range, so the server refuses to start
+ * (exit 2) even though the internals support an ephemeral bind. Hence
+ * OOB reservation plus an EADDRINUSE retry in startServer, which closes
+ * the small window between release and re-bind.
+ */
+export function reservePort() {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.once('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const { port } = s.address();
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Run `node dist/index.js <args>` to completion.
+ * Resolves with {code, signal, stdout, stderr, timedOut} — never rejects
+ * on a non-zero exit, because exit codes are what we assert on.
+ */
+export function runCli(args, { irisHome, extraEnv = {}, timeoutMs = 90_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(NODE, [IRIS_ENTRY, ...args], {
+      cwd: IRIS_REPO,
+      env: baseChildEnv(irisHome, extraEnv),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }, timeoutMs);
+    child.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, stdout, stderr, timedOut });
+    });
+  });
+}
+
+async function killTree(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  const pid = child.pid;
+  const done = new Promise((resolve) => child.once('close', resolve));
+  try {
+    child.kill();
+  } catch {
+    /* already gone */
+  }
+  const settled = await Promise.race([done.then(() => true), sleep(4000).then(() => false)]);
+  if (settled) return;
+  // Windows: SIGTERM is best-effort. Force the whole tree down so no
+  // stray listener survives into the next suite and steals a port.
+  if (process.platform === 'win32' && pid) {
+    await new Promise((resolve) => {
+      const k = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore' });
+      k.once('close', resolve);
+      k.once('error', resolve);
+    });
+  } else {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  }
+  await Promise.race([done, sleep(4000)]);
+}
+
+/**
+ * Start a long-lived iris process that serves the dashboard on a
+ * reserved OOB port, and wait until it actually answers.
+ *
+ * `argsFor(port)` builds the argv; the port is reserved fresh on each
+ * attempt so a lost race just retries instead of failing the suite.
+ *
+ * @returns {Promise<{child, port:number, stop:()=>Promise<void>, stderr:()=>string, stdout:()=>string}>}
+ */
+export async function startServer({ argsFor, args, irisHome, extraEnv = {}, timeoutMs = 60_000, label = 'server', attempts = 3 }) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    const port = argsFor ? await reservePort() : undefined;
+    try {
+      return await startOnce({
+        args: argsFor ? argsFor(port) : args,
+        expectPort: port,
+        irisHome,
+        extraEnv,
+        timeoutMs,
+        label,
+      });
+    } catch (err) {
+      lastErr = err;
+      if (!/EADDRINUSE|already in use/i.test(err.message)) throw err;
+      await sleep(250);
+    }
+  }
+  throw lastErr;
+}
+
+async function startOnce({ args, expectPort, irisHome, extraEnv, timeoutMs, label }) {
+  const runtimeJson = join(irisHome, 'runtime.json');
+  // A stale handshake file from a previous boot would hand us a dead
+  // port; the scratch home is fresh per suite, but be explicit.
+  try {
+    rmSync(runtimeJson, { force: true });
+  } catch {
+    /* nothing to remove */
+  }
+
+  const child = spawn(NODE, [IRIS_ENTRY, ...args], {
+    cwd: IRIS_REPO,
+    env: baseChildEnv(irisHome, extraEnv),
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  let stdout = '';
+  let stderr = '';
+  let exited = null;
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (d) => {
+    stdout += d;
+  });
+  child.stderr.on('data', (d) => {
+    stderr += d;
+  });
+  child.once('close', (code, signal) => {
+    exited = { code, signal };
+  });
+
+  const deadline = Date.now() + timeoutMs;
+  let port = expectPort;
+
+  while (Date.now() < deadline) {
+    if (exited) {
+      throw new Error(
+        `${label} exited before becoming ready (code=${exited.code} signal=${exited.signal}). stderr: ${stderr.slice(-800)}`,
+      );
+    }
+    if (port === undefined && existsSync(runtimeJson)) {
+      try {
+        const parsed = JSON.parse(readFileSync(runtimeJson, 'utf8'));
+        if (Number.isInteger(parsed.dashboardPort) && parsed.dashboardPort > 0) port = parsed.dashboardPort;
+      } catch {
+        /* half-written file; retry */
+      }
+    }
+    if (port === undefined) {
+      const m = (stderr + stdout).match(/http:\/\/(?:localhost|127\.0\.0\.1):(\d{2,5})/);
+      if (m) port = Number(m[1]);
+    }
+    if (port !== undefined) {
+      try {
+        const res = await raw({ port, path: '/api/v1/health', timeoutMs: 4000 });
+        if (res.status === 200) {
+          return {
+            child,
+            port,
+            stderr: () => stderr,
+            stdout: () => stdout,
+            stop: () => killTree(child),
+          };
+        }
+      } catch {
+        /* not listening yet */
+      }
+    }
+    await sleep(120);
+  }
+
+  await killTree(child);
+  throw new Error(
+    `${label} never became ready within ${timeoutMs}ms (port=${port ?? 'undiscovered'}). stderr: ${stderr.slice(-800)}`,
+  );
+}

--- a/tests/uat/lib/report.mjs
+++ b/tests/uat/lib/report.mjs
@@ -1,0 +1,162 @@
+/*
+ * Check recorder + markdown report writer.
+ *
+ * A check never throws out of the recorder: a thrown assertion becomes a
+ * ✗ row with the message as evidence, and the run continues. That is the
+ * whole point of a UAT harness — one broken surface must not hide the
+ * state of the other twenty.
+ */
+
+export function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+export function assertEq(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function oneLine(s, max = 400) {
+  const flat = String(s).replace(/[\r\n]+/g, ' ⏎ ').replace(/\s+/g, ' ').trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+export function createRecorder() {
+  /** @type {{suite:string,id:string,name:string,ok:boolean,evidence:string,ms:number}[]} */
+  const rows = [];
+  const suiteTitles = new Map();
+  let current = 'X';
+
+  function record(suite, id, name, ok, evidence, ms) {
+    rows.push({ suite, id, name, ok, evidence: oneLine(evidence), ms });
+    const mark = ok ? '✓' : '✗';
+    const tail = evidence ? ` :: ${oneLine(evidence, 200)}` : '';
+    process.stdout.write(`  ${mark} ${id}  ${name}${tail}\n`);
+  }
+
+  return {
+    rows,
+    suiteTitles,
+    beginSuite(id, title) {
+      current = id;
+      suiteTitles.set(id, title);
+      process.stdout.write(`\n=== Suite ${id} — ${title} ===\n`);
+    },
+    /**
+     * Run one check. `fn` may return a string, which becomes the
+     * evidence shown next to a ✓ (useful for measured values).
+     */
+    async check(id, name, fn) {
+      const t0 = Date.now();
+      try {
+        const ev = await fn();
+        record(current, id, name, true, typeof ev === 'string' ? ev : '', Date.now() - t0);
+      } catch (err) {
+        record(current, id, name, false, err && err.message ? err.message : String(err), Date.now() - t0);
+      }
+    },
+    /** Record a failure directly (e.g. a whole suite could not start). */
+    fail(id, name, evidence) {
+      record(current, id, name, false, evidence, 0);
+    },
+    /** Record a pass directly. */
+    pass(id, name, evidence = '') {
+      record(current, id, name, true, evidence, 0);
+    },
+    counts() {
+      const bySuite = new Map();
+      for (const r of rows) {
+        const c = bySuite.get(r.suite) ?? { pass: 0, fail: 0 };
+        if (r.ok) c.pass += 1;
+        else c.fail += 1;
+        bySuite.set(r.suite, c);
+      }
+      const pass = rows.filter((r) => r.ok).length;
+      return { bySuite, pass, fail: rows.length - pass, total: rows.length };
+    },
+  };
+}
+
+export function renderReport(recorder, meta) {
+  const { bySuite, pass, fail, total } = recorder.counts();
+  const lines = [];
+  const verdict = fail === 0 ? 'PASS' : 'FAIL';
+
+  lines.push('# Iris UAT Report');
+  lines.push('');
+  lines.push(`**Result: ${verdict} — ${pass} passed / ${fail} failed / ${total} checks**`);
+  lines.push('');
+  lines.push('| Field | Value |');
+  lines.push('| --- | --- |');
+  lines.push(`| Run started | ${meta.startedAt} |`);
+  lines.push(`| Duration | ${(meta.durationMs / 1000).toFixed(1)}s |`);
+  lines.push(`| Repo | \`${meta.repo}\` |`);
+  lines.push(`| Branch | \`${meta.branch}\` |`);
+  lines.push(`| Commit | \`${meta.commit}\` |`);
+  lines.push(`| Working tree | ${meta.dirty ? `DIRTY (${meta.dirtyCount} file(s))` : 'clean'} |`);
+  lines.push(`| Package version | ${meta.pkgVersion} |`);
+  lines.push(`| Node | ${meta.node} |`);
+  lines.push(`| Platform | ${meta.platform} |`);
+  lines.push(`| Real ~/.iris guard | ${meta.guardVerdict} |`);
+  lines.push('');
+
+  if (meta.buildNotes && meta.buildNotes.length > 0) {
+    lines.push('Artifacts rebuilt before the run (both write only into `dist/`):');
+    lines.push('');
+    for (const n of meta.buildNotes) lines.push(`- ${n}`);
+    lines.push('');
+  }
+
+  lines.push('## Per-suite totals');
+  lines.push('');
+  lines.push('| Suite | Surface | Pass | Fail |');
+  lines.push('| --- | --- | ---: | ---: |');
+  for (const [id, title] of recorder.suiteTitles) {
+    const c = bySuite.get(id) ?? { pass: 0, fail: 0 };
+    lines.push(`| ${id} | ${title} | ${c.pass} | ${c.fail} |`);
+  }
+  lines.push(`| **All** | | **${pass}** | **${fail}** |`);
+  lines.push('');
+
+  const failures = recorder.rows.filter((r) => !r.ok);
+  if (failures.length > 0) {
+    lines.push('## Findings (failed checks)');
+    lines.push('');
+    for (const r of failures) {
+      lines.push(`- ✗ **${r.id} — ${r.name}**`);
+      lines.push(`  - ${r.evidence || '(no evidence captured)'}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## All checks');
+  lines.push('');
+  for (const [id, title] of recorder.suiteTitles) {
+    lines.push(`### Suite ${id} — ${title}`);
+    lines.push('');
+    for (const r of recorder.rows.filter((x) => x.suite === id)) {
+      const mark = r.ok ? '✓' : '✗';
+      const ev = r.evidence ? ` — ${r.evidence}` : '';
+      lines.push(`- ${mark} \`${r.id}\` ${r.name}${ev}`);
+    }
+    lines.push('');
+  }
+
+  if (meta.guardDetail && meta.guardDetail.length > 0) {
+    lines.push('## Real ~/.iris integrity');
+    lines.push('');
+    for (const line of meta.guardDetail) lines.push(`- ${line}`);
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push('Re-run with:');
+  lines.push('');
+  lines.push('```bash');
+  lines.push(`node "${meta.runCommandPath}"`);
+  lines.push('```');
+  lines.push('');
+  return lines.join('\n');
+}

--- a/tests/uat/run-uat.mjs
+++ b/tests/uat/run-uat.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/*
+ * Iris UAT harness — one command, four suites, one report.
+ *
+ *   node run-uat.mjs                 # everything
+ *   node run-uat.mjs --suite A,C     # a subset
+ *
+ * Contract:
+ *   - The iris repo is READ-ONLY. The only thing this harness may cause
+ *     to be written inside it is dist/ (via `npm run build`, and only
+ *     when dist is missing).
+ *   - Every spawned server gets its own scratch IRIS_HOME under .work/,
+ *     which is wiped at the start of each run. The founder's real
+ *     ~/.iris is content-hashed before and after; any change fails the
+ *     run outright.
+ *   - Exit code 0 = every check passed, 1 = at least one ✗.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CRITICAL_GUARDED_FILES,
+  IRIS_CLAIMS,
+  IRIS_ENTRY,
+  IRIS_REPO,
+  REPORT_PATH,
+  WORK_DIR,
+} from './lib/env.mjs';
+import { createRecorder, renderReport } from './lib/report.mjs';
+import { diffSnapshots, snapshotRealHome } from './lib/guard.mjs';
+import { runSuiteA } from './suites/a-cli.mjs';
+import { runSuiteB } from './suites/b-mcp.mjs';
+import { runSuiteC } from './suites/c-http.mjs';
+import { runSuiteD } from './suites/d-dashboard.mjs';
+
+const SELF = fileURLToPath(import.meta.url);
+
+function git(args, fallback = 'unknown') {
+  try {
+    return execFileSync('git', args, { cwd: IRIS_REPO, encoding: 'utf8' }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+/** Newest mtime under a directory tree (ms). 0 when the path is absent. */
+function newestMtime(paths) {
+  let newest = 0;
+  const visit = (p) => {
+    let st;
+    try {
+      st = statSync(p);
+    } catch {
+      return;
+    }
+    if (st.isDirectory()) {
+      for (const entry of readdirSync(p)) visit(join(p, entry));
+    } else if (st.mtimeMs > newest) {
+      newest = st.mtimeMs;
+    }
+  };
+  for (const p of paths) visit(p);
+  return newest;
+}
+
+function mtimeOf(p) {
+  try {
+    return statSync(p).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/*
+ * Artifact freshness.
+ *
+ * The whole suite runs against dist/ — the artifact that actually ships.
+ * This harness is re-run after fix branches merge, so a dist/ left over
+ * from before the merge would report on code that is no longer main and
+ * every check would be a lie told confidently. Compare mtimes and
+ * rebuild when stale. Both builds write ONLY into dist/ (tsc via
+ * tsconfig.build.json, vite via outDir ../dist/dashboard with
+ * emptyOutDir:false, so neither clobbers the other).
+ */
+function ensureFreshArtifacts(notes) {
+  const r = (p) => join(IRIS_REPO, p);
+
+  const serverSrc = newestMtime([r('src'), r('package.json'), r('tsconfig.build.json')]);
+  if (!existsSync(IRIS_ENTRY) || mtimeOf(IRIS_ENTRY) < serverSrc) {
+    const why = existsSync(IRIS_ENTRY) ? 'older than src/' : 'missing';
+    process.stdout.write(`  dist/ server bundle ${why} — running \`npm run build\`\n`);
+    execFileSync('npm', ['run', 'build'], { cwd: IRIS_REPO, stdio: 'inherit', shell: true });
+    notes.push(`Rebuilt the server bundle: \`npm run build\` (dist/ was ${why}).`);
+  }
+
+  const uiIndex = r('dist/dashboard/index.html');
+  const uiSrc = newestMtime([
+    r('dashboard/src'),
+    r('dashboard/index.html'),
+    r('dashboard/vite.config.ts'),
+    r('dashboard/package.json'),
+    r('package.json'),
+    r('.claims.json'),
+  ]);
+  if (!existsSync(uiIndex) || mtimeOf(uiIndex) < uiSrc) {
+    const why = existsSync(uiIndex) ? 'older than dashboard/src/' : 'missing';
+    process.stdout.write(`  dashboard UI bundle ${why} — running \`npm run build\` in dashboard/\n`);
+    execFileSync('npm', ['run', 'build'], { cwd: join(IRIS_REPO, 'dashboard'), stdio: 'inherit', shell: true });
+    notes.push(`Rebuilt the dashboard UI bundle: \`cd dashboard && npm run build\` (dist/dashboard was ${why}).`);
+  }
+
+  return {
+    serverFresh: mtimeOf(IRIS_ENTRY) >= serverSrc,
+    uiFresh: mtimeOf(uiIndex) >= uiSrc,
+  };
+}
+
+function parseSuites() {
+  const idx = process.argv.indexOf('--suite');
+  if (idx === -1) return ['A', 'B', 'C', 'D'];
+  const raw = process.argv[idx + 1] ?? '';
+  const wanted = raw
+    .split(',')
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean);
+  return wanted.length > 0 ? wanted : ['A', 'B', 'C', 'D'];
+}
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+  const suites = parseSuites();
+
+  process.stdout.write('Iris UAT harness\n');
+  process.stdout.write(`  repo    ${IRIS_REPO}\n`);
+  process.stdout.write(`  suites  ${suites.join(', ')}\n`);
+
+  // dist/ is the artifact under test, and the ONE thing this harness may
+  // cause to be written inside the repo.
+  const buildNotes = [];
+  const freshness = ensureFreshArtifacts(buildNotes);
+
+  const claims = JSON.parse(readFileSync(IRIS_CLAIMS, 'utf8'));
+
+  // Idempotence: every run starts from an empty scratch tree.
+  rmSync(WORK_DIR, { recursive: true, force: true });
+  mkdirSync(WORK_DIR, { recursive: true });
+
+  const before = snapshotRealHome();
+  const commitAtStart = git(['rev-parse', '--short', 'HEAD']);
+  const t = createRecorder();
+
+  const runners = { A: runSuiteA, B: (r) => runSuiteB(r, claims), C: runSuiteC, D: runSuiteD };
+  for (const id of suites) {
+    const run = runners[id];
+    if (!run) {
+      process.stdout.write(`  (no such suite: ${id})\n`);
+      continue;
+    }
+    try {
+      await run(t);
+    } catch (err) {
+      t.fail(`${id}00`, `suite ${id} ran to completion`, `unhandled error: ${err && err.stack ? err.stack.split('\n')[0] : err}`);
+    }
+  }
+
+  // ---- Artifact freshness + real-home integrity ------------------------
+  t.beginSuite('G', 'Harness isolation + artifact freshness');
+
+  await t.check('G0', 'the suite ran against a dist/ that is not older than the sources', () => {
+    if (!freshness.serverFresh) throw new Error('dist/index.js is still older than src/ after the build step');
+    if (!freshness.uiFresh) throw new Error('dist/dashboard/index.html is still older than dashboard/src/ after the build step');
+    return buildNotes.length > 0 ? `rebuilt: ${buildNotes.length} bundle(s)` : 'both bundles already current';
+  });
+
+  const after = snapshotRealHome();
+  const { changed, detail } = diffSnapshots(before, after);
+  const criticalChanged = changed.filter((f) => CRITICAL_GUARDED_FILES.includes(f));
+
+  await t.check('G1', 'the real ~/.iris/iris.db, custom-rules.json and audit.log are byte-identical after the run', () => {
+    if (criticalChanged.length > 0) {
+      throw new Error(`the harness modified real user data: ${criticalChanged.join(', ')}`);
+    }
+    return 'all three unchanged';
+  });
+
+  await t.check('G2', 'no other file in the real ~/.iris changed either', () => {
+    const others = changed.filter((f) => !CRITICAL_GUARDED_FILES.includes(f));
+    if (others.length > 0) throw new Error(`changed: ${others.join(', ')}`);
+    return 'no incidental writes';
+  });
+
+  const counts = t.counts();
+  const guardVerdict =
+    changed.length === 0 ? 'CLEAN — no guarded file changed' : `**VIOLATED** — changed: ${changed.join(', ')}`;
+
+  const commitAtEnd = git(['rev-parse', '--short', 'HEAD']);
+  const meta = {
+    startedAt,
+    durationMs: Date.now() - t0,
+    repo: IRIS_REPO,
+    branch: git(['rev-parse', '--abbrev-ref', 'HEAD']),
+    commit: commitAtEnd === commitAtStart ? commitAtEnd : `${commitAtStart} → ${commitAtEnd} (HEAD MOVED MID-RUN)`,
+    buildNotes,
+    dirty: git(['status', '--porcelain']).length > 0,
+    dirtyCount: git(['status', '--porcelain']).split('\n').filter(Boolean).length,
+    pkgVersion: JSON.parse(readFileSync(`${IRIS_REPO}/package.json`, 'utf8')).version,
+    node: process.version,
+    platform: `${process.platform} ${process.arch}`,
+    guardVerdict,
+    guardDetail: detail,
+    runCommandPath: SELF,
+  };
+
+  writeFileSync(REPORT_PATH, renderReport(t, meta), 'utf8');
+
+  process.stdout.write('\n');
+  process.stdout.write(`RESULT: ${counts.fail === 0 ? 'PASS' : 'FAIL'} — ${counts.pass} passed / ${counts.fail} failed / ${counts.total} checks\n`);
+  for (const [id, c] of counts.bySuite) {
+    process.stdout.write(`  suite ${id}: ${c.pass} pass / ${c.fail} fail\n`);
+  }
+  process.stdout.write(`report: ${REPORT_PATH}\n`);
+
+  process.exit(counts.fail === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`UAT harness crashed: ${err && err.stack ? err.stack : err}\n`);
+  process.exit(2);
+});

--- a/tests/uat/suites/a-cli.mjs
+++ b/tests/uat/suites/a-cli.mjs
@@ -1,0 +1,198 @@
+/*
+ * Suite A — CLI surface.
+ *
+ * Everything here spawns the real shipped artifact (node dist/index.js)
+ * and asserts on exit codes + output. Nothing is imported in-process:
+ * the exit-code contract IS the surface a user meets first.
+ */
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runCli, startServer } from '../lib/proc.mjs';
+import { getJson } from '../lib/http.mjs';
+import { assert, assertEq } from '../lib/report.mjs';
+import { IRIS_ENTRY, WORK_DIR } from '../lib/env.mjs';
+
+/** Flags the README/--help contract promises. Hard-coded on purpose: this list is the acceptance criteria. */
+const DOCUMENTED_FLAGS = [
+  '--transport',
+  '--port',
+  '--config',
+  '--db-path',
+  '--api-key',
+  '--dashboard',
+  '--dashboard-port',
+  '--dashboard-host',
+  '--demo',
+  '--demo-clear',
+  '--self-test',
+  '--help',
+];
+
+/** Self-test step labels (src/self-test.ts SELF_TEST_STEPS) — every one must show a ✓. */
+const SELF_TEST_STEPS = [
+  'create isolated temp home',
+  'initialize storage',
+  'log a trace',
+  'eval: PII positive (planted SSN)',
+  'eval: injection positive (planted override text)',
+  'eval: clean output passes',
+  'read back persisted results',
+  'start dashboard on ephemeral loopback port',
+  'health endpoint answers',
+  'stats endpoint answers',
+  'rebinding guard rejects hostile Origin',
+  'clean up temp home',
+];
+
+/** Pull the real parseArgs option names out of the shipped bundle. */
+function parseArgsOptionNames() {
+  const src = readFileSync(IRIS_ENTRY, 'utf8');
+  const start = src.indexOf('parseArgs({');
+  assert(start > -1, 'could not locate parseArgs({ in dist/index.js');
+  const optStart = src.indexOf('options: {', start);
+  const end = src.indexOf('strict: true', optStart);
+  assert(optStart > -1 && end > optStart, 'could not locate the parseArgs options block in dist/index.js');
+  const block = src.slice(optStart, end);
+  const names = [];
+  for (const m of block.matchAll(/^\s*'?([a-zA-Z][a-zA-Z0-9-]*)'?:\s*\{\s*type:/gm)) names.push(m[1]);
+  return names;
+}
+
+export async function runSuiteA(t) {
+  t.beginSuite('A', 'CLI surface');
+
+  const homeHelp = join(WORK_DIR, 'a-help');
+  const homeSelfTest = join(WORK_DIR, 'a-selftest');
+  const homeDemo = join(WORK_DIR, 'a-demo');
+  const homeArgs = join(WORK_DIR, 'a-args');
+  for (const d of [homeHelp, homeSelfTest, homeDemo, homeArgs]) mkdirSync(d, { recursive: true });
+
+  // ---- A1 --help -------------------------------------------------------
+  const help = await runCli(['--help'], { irisHome: homeHelp, timeoutMs: 45_000 });
+  const helpText = `${help.stdout}\n${help.stderr}`;
+
+  await t.check('A1', '--help exits 0', () => {
+    assertEq(help.code, 0, '--help exit code');
+    return 'exit 0';
+  });
+
+  await t.check('A2', '--help lists every documented flag', () => {
+    const missing = DOCUMENTED_FLAGS.filter((f) => !helpText.includes(f));
+    assert(missing.length === 0, `--help omits: ${missing.join(', ')}`);
+    return `${DOCUMENTED_FLAGS.length}/${DOCUMENTED_FLAGS.length} flags documented`;
+  });
+
+  await t.check('A3', '--help documents every flag the parser actually accepts (drift guard)', () => {
+    const parserFlags = parseArgsOptionNames();
+    assert(parserFlags.length > 0, 'extracted zero parseArgs options — the drift guard is inert');
+    const undocumented = parserFlags.filter((n) => !helpText.includes(`--${n}`));
+    assert(undocumented.length === 0, `accepted but undocumented: ${undocumented.map((n) => `--${n}`).join(', ')}`);
+    return `${parserFlags.length} parser flags, all documented`;
+  });
+
+  // ---- A4 --self-test --------------------------------------------------
+  const selfTest = await runCli(['--self-test'], { irisHome: homeSelfTest, timeoutMs: 90_000 });
+  const selfText = `${selfTest.stdout}\n${selfTest.stderr}`;
+
+  await t.check('A4', '--self-test exits 0', () => {
+    assert(!selfTest.timedOut, '--self-test timed out');
+    assertEq(selfTest.code, 0, '--self-test exit code');
+    return 'exit 0';
+  });
+
+  await t.check('A5', '--self-test reports a ✓ for every documented step and no ✗', () => {
+    const missing = SELF_TEST_STEPS.filter((s) => !selfText.includes(`✓ ${s}`));
+    assert(missing.length === 0, `steps without a ✓: ${missing.join(' | ')}`);
+    assert(!selfText.includes('✗'), `self-test output contains a ✗: ${selfText.split('\n').filter((l) => l.includes('✗')).join(' | ')}`);
+    assert(selfText.includes('PASS — this install works'), 'missing the PASS verdict line');
+    return `${SELF_TEST_STEPS.length} steps ✓, PASS verdict present`;
+  });
+
+  await t.check('A6', '--self-test leaves no scratch home behind', () => {
+    const m = selfText.match(/✓ create isolated temp home — (.+)/);
+    assert(m, 'self-test did not report its temp home path');
+    const tempHome = m[1].trim();
+    assert(!existsSync(tempHome), `self-test temp home still exists: ${tempHome}`);
+    return 'temp home removed';
+  });
+
+  // ---- A7..A10 --demo / --demo-clear ----------------------------------
+  const demoFiles = ['demo.db', 'demo-preferences.json', 'demo-custom-rules.json', 'demo-audit.log'];
+  let demo;
+  try {
+    demo = await startServer({
+      argsFor: (p) => ['--demo', '--dashboard-port', String(p)],
+      irisHome: homeDemo,
+      label: '--demo server',
+      timeoutMs: 90_000,
+    });
+  } catch (err) {
+    t.fail('A7', '--demo seeds a demo database and serves the dashboard', err.message);
+    t.fail('A8', '--demo serves seeded data over the API', 'skipped — --demo never became ready');
+  }
+
+  if (demo) {
+    await t.check('A7', '--demo seeds a demo database and serves the dashboard', async () => {
+      assert(existsSync(join(homeDemo, 'demo.db')), 'demo.db was not created under the scratch IRIS_HOME');
+      const health = await getJson(demo.port, '/api/v1/health');
+      assertEq(health.status, 'ok', 'demo /health status');
+      return `demo.db present, health ok on port ${demo.port}`;
+    });
+
+    await t.check('A8', '--demo serves seeded data over the API', async () => {
+      const traces = await getJson(demo.port, '/api/v1/traces?limit=5');
+      assert(traces.total > 0, `expected seeded traces, got total=${traces.total}`);
+      assert(Array.isArray(traces.traces) && traces.traces.length > 0, 'traces array was empty');
+      return `${traces.total} seeded traces`;
+    });
+
+    await t.check('A9', '--demo writes ONLY demo-scoped files into IRIS_HOME (no real store shape)', () => {
+      // iris.db / custom-rules.json / audit.log are the REAL store's file
+      // names. Demo mode promises in its banner that it never mixes with
+      // them; the scratch home makes that assertable.
+      const leaked = ['iris.db', 'custom-rules.json', 'audit.log'].filter((f) => existsSync(join(homeDemo, f)));
+      assert(leaked.length === 0, `--demo created real-store files: ${leaked.join(', ')}`);
+      return 'no real-store files created';
+    });
+
+    await demo.stop();
+  }
+
+  await t.check('A10', '--demo-clear exits 0 and removes every demo file', async () => {
+    const before = demoFiles.filter((f) => existsSync(join(homeDemo, f)));
+    assert(before.length > 0, 'no demo files existed to clear — the check would be vacuous');
+    const res = await runCli(['--demo-clear'], { irisHome: homeDemo, timeoutMs: 45_000 });
+    assertEq(res.code, 0, '--demo-clear exit code');
+    const after = demoFiles.filter((f) => existsSync(join(homeDemo, f)));
+    assert(after.length === 0, `--demo-clear left files behind: ${after.join(', ')}`);
+    return `cleared ${before.length} file(s): ${before.join(', ')}`;
+  });
+
+  // ---- A11..A13 refused flag combinations ------------------------------
+  await t.check('A11', '--demo + --demo-clear exits 2', async () => {
+    const res = await runCli(['--demo', '--demo-clear'], { irisHome: homeArgs, timeoutMs: 45_000 });
+    assertEq(res.code, 2, 'exit code');
+    assert(/cannot be combined/i.test(res.stderr), `expected an explanatory stderr message, got: ${res.stderr.slice(0, 200)}`);
+    return 'exit 2 with explanation';
+  });
+
+  await t.check('A12', '--demo + --db-path exits 2', async () => {
+    const res = await runCli(['--demo', '--db-path', join(homeArgs, 'nope.db')], { irisHome: homeArgs, timeoutMs: 45_000 });
+    assertEq(res.code, 2, 'exit code');
+    assert(!existsSync(join(homeArgs, 'nope.db')), 'a refused combination still created the database file');
+    return 'exit 2, no file created';
+  });
+
+  await t.check('A13', 'an unknown flag exits 2', async () => {
+    const res = await runCli(['--not-a-real-flag'], { irisHome: homeArgs, timeoutMs: 45_000 });
+    assertEq(res.code, 2, 'exit code');
+    assert(/--help/.test(res.stderr), 'stderr did not point the user at --help');
+    return 'exit 2, points at --help';
+  });
+
+  await t.check('A14', 'an out-of-range --port exits 2', async () => {
+    const res = await runCli(['--port', '99999'], { irisHome: homeArgs, timeoutMs: 45_000 });
+    assertEq(res.code, 2, 'exit code');
+    return 'exit 2';
+  });
+}

--- a/tests/uat/suites/b-mcp.mjs
+++ b/tests/uat/suites/b-mcp.mjs
@@ -1,0 +1,358 @@
+/*
+ * Suite B — MCP tool surface over REAL stdio.
+ *
+ * Uses the MCP SDK client shipped in the iris repo's node_modules, so
+ * the harness speaks the same protocol version the server was built
+ * against. Every tool is invoked through the transport — no in-process
+ * shortcuts — because the thing under test is the tool CONTRACT (name,
+ * schema, result shape), not the function behind it.
+ *
+ * Two sessions run against ONE scratch IRIS_HOME. The second is a
+ * deliberate restart: it separates "a deployed rule never fires" from
+ * "a deployed rule needs a restart to fire", which are different bugs
+ * with different fixes.
+ */
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { assert, assertEq } from '../lib/report.mjs';
+import { IRIS_ENTRY, IRIS_NODE_MODULES, IRIS_REPO, WORK_DIR, baseChildEnv } from '../lib/env.mjs';
+
+const SDK = join(IRIS_NODE_MODULES, '@modelcontextprotocol', 'sdk', 'dist', 'esm', 'client');
+const CALL_TIMEOUT_MS = 20_000;
+
+/** Marker string the deployed UAT rule forbids. Unique so nothing else can match it. */
+const FORBIDDEN = 'UAT-FORBIDDEN-TOKEN-9f3a';
+const RULE_NAME = 'uat-forbidden-token';
+
+const DETERMINISTIC_OUTPUT =
+  'The quarterly report shows 18% revenue growth. Operating margins improved to 23%. ' +
+  'Enterprise retention held steady across every measured segment this period.';
+
+async function connect(irisHome, label) {
+  const { Client } = await import(pathToFileURL(join(SDK, 'index.js')).href);
+  const { StdioClientTransport } = await import(pathToFileURL(join(SDK, 'stdio.js')).href);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [IRIS_ENTRY],
+    cwd: IRIS_REPO,
+    env: baseChildEnv(irisHome),
+    stderr: 'pipe',
+  });
+  let stderr = '';
+  const client = new Client({ name: `iris-uat-${label}`, version: '1.0.0' }, { capabilities: {} });
+  await client.connect(transport);
+  if (transport.stderr) {
+    transport.stderr.on('data', (d) => {
+      stderr += String(d);
+    });
+  }
+  return {
+    client,
+    stderr: () => stderr,
+    async close() {
+      try {
+        await client.close();
+      } catch {
+        /* transport already down */
+      }
+    },
+  };
+}
+
+/** Call a tool and return {isError, text, json}. Never throws on a tool-level error. */
+async function call(client, name, args) {
+  const res = await client.callTool({ name, arguments: args }, undefined, { timeout: CALL_TIMEOUT_MS });
+  const text = (res.content ?? [])
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = undefined;
+  }
+  return { isError: res.isError === true, text, json, raw: res };
+}
+
+/** Call a tool expecting success; throws with the tool's own error text otherwise. */
+async function callOk(client, name, args) {
+  const r = await call(client, name, args);
+  assert(!r.isError, `${name} returned isError — ${r.text.slice(0, 300)}`);
+  assert(r.json !== undefined, `${name} result was not JSON: ${r.text.slice(0, 300)}`);
+  return r.json;
+}
+
+export async function runSuiteB(t, claims) {
+  t.beginSuite('B', 'MCP tool surface (stdio)');
+
+  const home = join(WORK_DIR, 'b-mcp');
+  mkdirSync(home, { recursive: true });
+
+  const expectedTools = [...claims.mcpTools.names].sort();
+  const state = { traceId: undefined, ruleId: undefined, baselineScore: undefined };
+
+  let s1;
+  try {
+    s1 = await connect(home, 'session1');
+  } catch (err) {
+    t.fail('B1', 'MCP stdio session connects', err.message);
+    return;
+  }
+
+  await t.check('B1', 'advertised tool list exactly matches .claims.json mcpTools.names', async () => {
+    const { tools } = await s1.client.listTools();
+    const actual = tools.map((x) => x.name).sort();
+    const missing = expectedTools.filter((n) => !actual.includes(n));
+    const extra = actual.filter((n) => !expectedTools.includes(n));
+    assert(
+      missing.length === 0 && extra.length === 0,
+      `tool-list drift — missing: [${missing.join(', ')}] extra: [${extra.join(', ')}]`,
+    );
+    return `${actual.length} tools, exact match`;
+  });
+
+  await t.check('B2', 'every advertised tool carries a description and an input schema', async () => {
+    const { tools } = await s1.client.listTools();
+    const bad = tools
+      .filter((x) => !x.description || !x.inputSchema || x.inputSchema.type !== 'object')
+      .map((x) => x.name);
+    assert(bad.length === 0, `tools with a missing description or malformed inputSchema: ${bad.join(', ')}`);
+    return `${tools.length} tools well-formed`;
+  });
+
+  await t.check('B3', 'log_trace stores a trace and returns a 32-hex trace_id', async () => {
+    const out = await callOk(s1.client, 'log_trace', {
+      agent_name: 'uat-agent',
+      framework: 'uat',
+      input: 'What are the quarterly numbers?',
+      output: DETERMINISTIC_OUTPUT,
+      latency_ms: 42,
+      cost_usd: 0.0012,
+      token_usage: { prompt_tokens: 120, completion_tokens: 80, total_tokens: 200 },
+      metadata: { suite: 'uat-b' },
+    });
+    assertEq(out.status, 'stored', 'log_trace status');
+    assert(/^[a-f0-9]{32}$/.test(out.trace_id), `trace_id is not 32-hex: ${out.trace_id}`);
+    state.traceId = out.trace_id;
+    return `trace ${out.trace_id.slice(0, 12)}…`;
+  });
+
+  await t.check('B4', 'get_traces returns the trace just logged', async () => {
+    assert(state.traceId, 'no trace_id from B3 — cannot query');
+    const out = await callOk(s1.client, 'get_traces', { agent_name: 'uat-agent', limit: 10 });
+    assert(Array.isArray(out.traces), `expected a traces array, got ${JSON.stringify(out).slice(0, 200)}`);
+    const found = out.traces.find((x) => x.trace_id === state.traceId);
+    assert(found, `logged trace ${state.traceId} not returned by get_traces (total=${out.total})`);
+    assertEq(found.agent_name, 'uat-agent', 'round-tripped agent_name');
+    assertEq(found.output, DETERMINISTIC_OUTPUT, 'round-tripped output text');
+    return `found, total=${out.total}`;
+  });
+
+  await t.check('B5', 'evaluate_output returns a well-formed score + rule_results', async () => {
+    const out = await callOk(s1.client, 'evaluate_output', {
+      output: DETERMINISTIC_OUTPUT,
+      eval_type: 'completeness',
+      trace_id: state.traceId,
+    });
+    assert(typeof out.score === 'number' && out.score >= 0 && out.score <= 1, `score out of range: ${out.score}`);
+    assert(typeof out.passed === 'boolean', `passed is not a boolean: ${out.passed}`);
+    assert(Array.isArray(out.rule_results) && out.rule_results.length > 0, 'rule_results was empty');
+    const malformed = out.rule_results.filter(
+      (r) => typeof r.ruleName !== 'string' || typeof r.passed !== 'boolean' || typeof r.score !== 'number',
+    );
+    assert(malformed.length === 0, `malformed rule_results entries: ${JSON.stringify(malformed).slice(0, 200)}`);
+    assertEq(out.rules_evaluated, out.rule_results.filter((r) => !r.skipped).length, 'rules_evaluated vs rule_results');
+    state.baselineScore = out.score;
+    return `score ${out.score.toFixed(4)}, ${out.rule_results.length} rules`;
+  });
+
+  await t.check('B6', 'evaluate_output is deterministic across repeated calls', async () => {
+    assert(state.baselineScore !== undefined, 'no baseline score from B5');
+    const a = await callOk(s1.client, 'evaluate_output', { output: DETERMINISTIC_OUTPUT, eval_type: 'completeness' });
+    const b = await callOk(s1.client, 'evaluate_output', { output: DETERMINISTIC_OUTPUT, eval_type: 'completeness' });
+    assertEq(a.score, state.baselineScore, 'repeat call 1 score');
+    assertEq(b.score, state.baselineScore, 'repeat call 2 score');
+    assert(a.id !== b.id, 'two evaluations reused the same eval id');
+    return `score stable at ${a.score.toFixed(4)} over 3 calls`;
+  });
+
+  await t.check('B7', 'evaluate_output safety rules catch a planted PII string', async () => {
+    const out = await callOk(s1.client, 'evaluate_output', {
+      output: 'Sure — the customer SSN is 123-45-6789 and I have emailed it to the vendor.',
+      eval_type: 'safety',
+    });
+    const pii = out.rule_results.find((r) => /pii/i.test(r.ruleName));
+    assert(pii, `no PII rule in rule_results: ${out.rule_results.map((r) => r.ruleName).join(', ')}`);
+    assertEq(pii.passed, false, 'planted SSN should fail the PII rule');
+    return `${pii.ruleName} failed as expected`;
+  });
+
+  await t.check('B8', 'get_traces include_summary returns consistent aggregate stats', async () => {
+    const out = await callOk(s1.client, 'get_traces', { agent_name: 'uat-agent', limit: 10, include_summary: true });
+    assert(out.summary, `no summary block in response: ${JSON.stringify(out).slice(0, 200)}`);
+    assert(typeof out.summary.total_traces === 'number', 'summary.total_traces is not a number');
+    assert(typeof out.summary.eval_pass_rate === 'number', 'summary.eval_pass_rate is not a number');
+    assert(out.summary.total_traces >= out.traces.length, `summary.total_traces (${out.summary.total_traces}) < returned traces (${out.traces.length})`);
+    return `total_traces=${out.summary.total_traces}, pass_rate=${out.summary.eval_pass_rate}`;
+  });
+
+  await t.check('B9', 'deploy_rule persists a valid custom rule and returns its id', async () => {
+    const out = await callOk(s1.client, 'deploy_rule', {
+      name: RULE_NAME,
+      description: 'UAT harness rule — forbids a unique marker token.',
+      evalType: 'custom',
+      severity: 'high',
+      definition: { name: RULE_NAME, type: 'regex_no_match', config: { pattern: FORBIDDEN } },
+    });
+    assert(out.rule, `no rule in response: ${JSON.stringify(out).slice(0, 200)}`);
+    assert(/^rule-[a-z0-9]+$/.test(out.rule.id), `rule id has the wrong shape: ${out.rule.id}`);
+    assertEq(out.rule.enabled, true, 'newly deployed rule should be enabled');
+    assertEq(out.rule.version, 1, 'newly deployed rule version');
+    state.ruleId = out.rule.id;
+    return `${out.rule.id}`;
+  });
+
+  await t.check('B10', 'list_rules includes the deployed rule', async () => {
+    assert(state.ruleId, 'no rule id from B9');
+    const out = await callOk(s1.client, 'list_rules', {});
+    const found = (out.rules ?? []).find((r) => r.id === state.ruleId);
+    assert(found, `deployed rule not listed (total=${out.total})`);
+    assertEq(found.name, RULE_NAME, 'listed rule name');
+    return `listed, total=${out.total}, enabled=${out.enabled_count}`;
+  });
+
+  await t.check('B11', 'a rule deployed via deploy_rule FIRES on a matching evaluate_output (same session)', async () => {
+    assert(state.ruleId, 'no rule id from B9');
+    const out = await callOk(s1.client, 'evaluate_output', {
+      output: `Here is the summary. ${FORBIDDEN} appears in this output.`,
+      eval_type: 'custom',
+    });
+    const hit = (out.rule_results ?? []).find((r) => r.ruleName === RULE_NAME);
+    assert(
+      hit,
+      `the deployed rule did not fire — rule_results=${JSON.stringify(out.rule_results)}, ` +
+        `rules_evaluated=${out.rules_evaluated}, insufficient_data=${out.insufficient_data}`,
+    );
+    assertEq(hit.passed, false, 'forbidden token present, so the rule must fail');
+    return `${RULE_NAME} fired and failed as expected`;
+  });
+
+  await s1.close();
+
+  // ---- Session 2: restart against the same IRIS_HOME --------------------
+  let s2;
+  try {
+    s2 = await connect(home, 'session2');
+  } catch (err) {
+    t.fail('B12', 'deployed rule survives a server restart', err.message);
+    return;
+  }
+
+  await t.check('B12', 'a deployed rule survives a restart and fires after it', async () => {
+    assert(state.ruleId, 'no rule id from B9');
+    const listed = await callOk(s2.client, 'list_rules', {});
+    const found = (listed.rules ?? []).find((r) => r.id === state.ruleId);
+    assert(found, 'the deployed rule did not survive the restart');
+    const out = await callOk(s2.client, 'evaluate_output', {
+      output: `Here is the summary. ${FORBIDDEN} appears in this output.`,
+      eval_type: 'custom',
+    });
+    const hit = (out.rule_results ?? []).find((r) => r.ruleName === RULE_NAME);
+    assert(hit, `after restart the rule still did not fire — rule_results=${JSON.stringify(out.rule_results)}`);
+    assertEq(hit.passed, false, 'forbidden token present, so the rule must fail');
+    return 'persisted and fires after restart';
+  });
+
+  await t.check('B13', 'delete_rule removes the rule and list_rules stops returning it', async () => {
+    assert(state.ruleId, 'no rule id from B9');
+    const del = await callOk(s2.client, 'delete_rule', { rule_id: state.ruleId });
+    assertEq(del.deleted, true, 'delete_rule deleted flag');
+    const listed = await callOk(s2.client, 'list_rules', {});
+    const still = (listed.rules ?? []).find((r) => r.id === state.ruleId);
+    assert(!still, 'rule is still listed after delete_rule');
+    return 'deleted and delisted';
+  });
+
+  await t.check('B14', 'delete_rule on an unknown id reports deleted=false rather than crashing', async () => {
+    const del = await call(s2.client, 'delete_rule', { rule_id: 'rule-deadbeef' });
+    assert(!del.isError, `delete_rule on a missing id errored: ${del.text.slice(0, 200)}`);
+    assertEq(del.json.deleted, false, 'deleted flag for an unknown rule');
+    return 'deleted=false';
+  });
+
+  await t.check('B15', 'delete_trace removes the trace and get_traces stops returning it', async () => {
+    assert(state.traceId, 'no trace id from B3');
+    const del = await callOk(s2.client, 'delete_trace', { trace_id: state.traceId });
+    assertEq(del.deleted, true, 'delete_trace deleted flag');
+    const out = await callOk(s2.client, 'get_traces', { agent_name: 'uat-agent', limit: 10 });
+    const still = (out.traces ?? []).find((x) => x.trace_id === state.traceId);
+    assert(!still, 'trace is still returned after delete_trace');
+    return 'deleted and no longer queryable';
+  });
+
+  await t.check('B16', 'evaluate_with_llm_judge without an API key fails gracefully and fast', async () => {
+    const t0 = Date.now();
+    const r = await call(s2.client, 'evaluate_with_llm_judge', {
+      output: DETERMINISTIC_OUTPUT,
+      template: 'accuracy',
+      model: 'claude-haiku-4-5-20251001',
+    });
+    const ms = Date.now() - t0;
+    assert(r.isError, `expected a tool error with no API key, got a success result: ${r.text.slice(0, 200)}`);
+    assert(
+      /IRIS_ANTHROPIC_API_KEY/.test(r.text),
+      `error message is not actionable (should name the env var): ${r.text.slice(0, 300)}`,
+    );
+    assert(ms < CALL_TIMEOUT_MS, `took ${ms}ms — it should fail immediately, not hang`);
+    return `errored in ${ms}ms naming IRIS_ANTHROPIC_API_KEY`;
+  });
+
+  await t.check('B17', 'evaluate_with_llm_judge rejects an unknown template rather than crashing', async () => {
+    const r = await call(s2.client, 'evaluate_with_llm_judge', {
+      output: DETERMINISTIC_OUTPUT,
+      template: 'not-a-template',
+      model: 'claude-haiku-4-5-20251001',
+    });
+    assert(r.isError, 'an invalid template was accepted');
+    assert(r.text.length > 0, 'validation failure produced no message');
+    return 'rejected with a message';
+  });
+
+  await t.check('B18', 'verify_citations with fetch enabled but no API key fails gracefully and fast', async () => {
+    const t0 = Date.now();
+    const r = await call(s2.client, 'verify_citations', {
+      output: 'As shown in https://example.com/paper and doi:10.1000/xyz123, the effect is robust.',
+      model: 'claude-haiku-4-5-20251001',
+      allow_fetch: true,
+      max_citations: 2,
+      per_source_timeout_ms: 3000,
+    });
+    const ms = Date.now() - t0;
+    assert(r.isError, `expected a tool error with no API key, got a success result: ${r.text.slice(0, 200)}`);
+    assert(
+      /IRIS_ANTHROPIC_API_KEY/.test(r.text),
+      `error message is not actionable (should name the env var): ${r.text.slice(0, 300)}`,
+    );
+    assert(ms < CALL_TIMEOUT_MS, `took ${ms}ms — it should fail immediately, not hang`);
+    return `errored in ${ms}ms naming IRIS_ANTHROPIC_API_KEY`;
+  });
+
+  await t.check('B19', 'an unknown tool name is refused, not silently accepted', async () => {
+    let refused = false;
+    let detail = '';
+    try {
+      const r = await call(s2.client, 'not_a_real_tool', {});
+      refused = r.isError;
+      detail = r.text.slice(0, 200);
+    } catch (err) {
+      refused = true;
+      detail = err.message.slice(0, 200);
+    }
+    assert(refused, `an unknown tool call was not refused: ${detail}`);
+    return 'refused';
+  });
+
+  await s2.close();
+}

--- a/tests/uat/suites/c-http.mjs
+++ b/tests/uat/suites/c-http.mjs
@@ -1,0 +1,384 @@
+/*
+ * Suite C — HTTP surface.
+ *
+ * A real `node dist/index.js --dashboard --dashboard-port 0` process on
+ * an ephemeral loopback port, seeded through its own ingest endpoint so
+ * the totals the harness asserts on are ones it can compute exactly.
+ *
+ * Every request goes through node:http (see lib/http.mjs) — required for
+ * the Host/Origin probes, and used uniformly so there is only one header
+ * behaviour in play.
+ */
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { startServer } from '../lib/proc.mjs';
+import { getJson, postJson, raw } from '../lib/http.mjs';
+import { assert, assertEq } from '../lib/report.mjs';
+import { WORK_DIR } from '../lib/env.mjs';
+
+/** Absolute-path shapes that must never appear in an HTTP response body. */
+const ABS_PATH_RE = /(?:[A-Za-z]:[\\/][^"'\s]{3,})|(?:\/(?:home|Users|root|var|opt)\/[^"'\s]{3,})/;
+
+const SEED_AGENT = 'uat-http-agent';
+const SEED_COUNT = 6;
+
+function seedTrace(i) {
+  return {
+    agent_name: SEED_AGENT,
+    framework: 'uat',
+    input: `UAT prompt ${i}`,
+    output:
+      i % 3 === 0
+        ? 'short'
+        : `UAT output ${i}. This response is long enough to satisfy the minimum-length rule and contains two sentences.`,
+    latency_ms: 100 + i,
+    cost_usd: 0.001 * (i + 1),
+    token_usage: { prompt_tokens: 100 + i, completion_tokens: 50 + i, total_tokens: 150 + 2 * i },
+    metadata: { suite: 'uat-c', index: i },
+  };
+}
+
+export async function runSuiteC(t) {
+  t.beginSuite('C', 'HTTP surface');
+
+  const home = join(WORK_DIR, 'c-http');
+  mkdirSync(home, { recursive: true });
+
+  let srv;
+  try {
+    srv = await startServer({
+      argsFor: (p) => ['--dashboard', '--dashboard-port', String(p)],
+      irisHome: home,
+      label: '--dashboard server',
+      timeoutMs: 60_000,
+    });
+  } catch (err) {
+    t.fail('C1', 'dashboard HTTP server starts on an ephemeral port', err.message);
+    return;
+  }
+  const port = srv.port;
+  const state = { traceIds: [], evalCount: 0, ruleId: undefined };
+
+  try {
+    await t.check('C1', 'GET /api/v1/health returns 200 with a connected store', async () => {
+      const res = await raw({ port, path: '/api/v1/health' });
+      assertEq(res.status, 200, 'health status');
+      assertEq(res.json.status, 'ok', 'health.status');
+      assertEq(res.json.storage, 'connected', 'health.storage');
+      assert(typeof res.json.version === 'string' && res.json.version.length > 0, 'health.version missing');
+      return `v${res.json.version}, storage connected`;
+    });
+
+    await t.check('C2', 'POST /api/v1/traces with a valid body returns 201 and the trace is queryable', async () => {
+      for (let i = 0; i < SEED_COUNT; i++) {
+        const res = await postJson(port, '/api/v1/traces', seedTrace(i), 201);
+        assertEq(res.json.status, 'stored', `seed ${i} status`);
+        assert(/^[a-f0-9]{32}$/.test(res.json.trace_id), `seed ${i} trace_id shape: ${res.json.trace_id}`);
+        state.traceIds.push(res.json.trace_id);
+      }
+      const listed = await getJson(port, `/api/v1/traces?agent_name=${SEED_AGENT}&limit=50`);
+      assertEq(listed.total, SEED_COUNT, 'queryable trace count');
+      const ids = new Set(listed.traces.map((x) => x.trace_id));
+      const missing = state.traceIds.filter((id) => !ids.has(id));
+      assert(missing.length === 0, `posted but not queryable: ${missing.join(', ')}`);
+      return `${SEED_COUNT} posted, ${listed.total} queryable`;
+    });
+
+    await t.check('C3', 'POST /api/v1/traces with an invalid body returns 400 JSON', async () => {
+      const res = await postJson(port, '/api/v1/traces', {});
+      assertEq(res.status, 400, 'status for a body missing agent_name');
+      assert(res.json !== undefined, `400 body was not JSON: ${res.body.slice(0, 200)}`);
+      assert(res.json.error, '400 body carried no error field');
+      const typed = await postJson(port, '/api/v1/traces', { agent_name: 12345 });
+      assertEq(typed.status, 400, 'status for a wrongly-typed agent_name');
+      return 'both malformed bodies rejected with JSON 400';
+    });
+
+    await t.check('C4', 'POST /api/v1/traces?evaluate=true returns an evaluation block', async () => {
+      const pass = await postJson(
+        port,
+        '/api/v1/traces',
+        {
+          agent_name: SEED_AGENT,
+          output: 'This evaluated output is comfortably long enough. It also contains a second sentence.',
+          evaluate: true,
+          eval_type: 'completeness',
+        },
+        201,
+      );
+      state.traceIds.push(pass.json.trace_id);
+      state.evalCount += 1;
+      const ev = pass.json.evaluation;
+      assert(ev, `no evaluation block: ${JSON.stringify(pass.json).slice(0, 200)}`);
+      assert(typeof ev.score === 'number' && ev.score >= 0 && ev.score <= 1, `score out of range: ${ev.score}`);
+      assert(Array.isArray(ev.rule_results) && ev.rule_results.length > 0, 'evaluation.rule_results was empty');
+      assertEq(ev.eval_type, 'completeness', 'evaluation.eval_type');
+      assertEq(ev.passed, true, 'a comfortably long two-sentence output should pass completeness');
+
+      // A deliberately failing eval too, so the /failures ranking below
+      // has something real to rank. A ranked list asserted only for
+      // shape against an empty result set proves nothing.
+      const fail = await postJson(
+        port,
+        '/api/v1/traces',
+        { agent_name: SEED_AGENT, output: 'no.', evaluate: true, eval_type: 'completeness' },
+        201,
+      );
+      state.traceIds.push(fail.json.trace_id);
+      state.evalCount += 1;
+      state.failingTraceId = fail.json.trace_id;
+      assertEq(fail.json.evaluation.passed, false, 'a 3-character output should fail completeness');
+      return `pass ${ev.score.toFixed(3)} / fail ${fail.json.evaluation.score.toFixed(3)}`;
+    });
+
+    await t.check('C5', 'POST /api/v1/traces with evaluate=true but no output returns 400', async () => {
+      const res = await postJson(port, '/api/v1/traces', { agent_name: SEED_AGENT, evaluate: true });
+      assertEq(res.status, 400, 'status');
+      assert(/output/i.test(res.body), `400 body did not name the offending field: ${res.body.slice(0, 200)}`);
+      return 'rejected, names "output"';
+    });
+
+    await t.check('C6', 'GET /api/v1/summary totals agree with /traces and /health', async () => {
+      const expected = state.traceIds.length;
+      const summary = await getJson(port, '/api/v1/summary?hours=1');
+      const traces = await getJson(port, '/api/v1/traces?limit=200');
+      const health = await getJson(port, '/api/v1/health');
+      assertEq(summary.total_traces, expected, 'summary.total_traces');
+      assertEq(traces.total, expected, 'traces.total');
+      assertEq(health.trace_count, expected, 'health.trace_count');
+      assert(Array.isArray(summary.top_agents) && summary.top_agents[0]?.agent_name === SEED_AGENT, 'summary.top_agents did not surface the seeded agent');
+      return `all three report ${expected}`;
+    });
+
+    await t.check('C7', 'GET /api/v1/eval-stats reports the evaluations that were actually created', async () => {
+      const stats = await getJson(port, '/api/v1/eval-stats?period=all');
+      assertEq(stats.totalEvals, state.evalCount, 'eval-stats.totalEvals');
+      assert(typeof stats.passRate === 'number' || typeof stats.avgScore === 'number', `unexpected eval-stats shape: ${JSON.stringify(stats).slice(0, 200)}`);
+      return `totalEvals=${stats.totalEvals}`;
+    });
+
+    await t.check('C8', 'GET /api/v1/failures ranks the trace that actually failed its eval', async () => {
+      const out = await getJson(port, '/api/v1/failures?limit=20');
+      const list = Array.isArray(out) ? out : (out.failures ?? out.moments);
+      assert(Array.isArray(list), `no failures array in response: ${JSON.stringify(out).slice(0, 200)}`);
+      assert(list.length > 0, 'ranked list was empty despite a deliberately failing eval');
+      const found = list.find((f) => (f.traceId ?? f.trace_id ?? f.trace?.trace_id) === state.failingTraceId);
+      assert(found, `the failing trace ${state.failingTraceId} is not in the ranked list of ${list.length}`);
+      assert(typeof found.rankScore === 'number', 'ranked entry carries no rankScore');
+      return `${list.length} ranked, failing trace present (rankScore ${found.rankScore.toFixed(3)})`;
+    });
+
+    await t.check('C9', 'GET /api/v1/traces/:id returns trace + spans + evals; an unknown id 404s', async () => {
+      const id = state.traceIds[0];
+      const detail = await getJson(port, `/api/v1/traces/${id}`);
+      assertEq(detail.trace.trace_id, id, 'detail.trace.trace_id');
+      assert(Array.isArray(detail.spans), 'detail.spans is not an array');
+      assert(Array.isArray(detail.evals), 'detail.evals is not an array');
+      const missing = await raw({ port, path: '/api/v1/traces/00000000000000000000000000000000' });
+      assertEq(missing.status, 404, 'unknown trace id status');
+      assert(missing.json?.error, '404 body carried no JSON error field');
+      return 'detail 200, unknown id 404';
+    });
+
+    await t.check('C10', 'every read endpoint answers 200 with JSON', async () => {
+      const paths = [
+        '/api/v1/health',
+        '/api/v1/summary',
+        '/api/v1/traces',
+        '/api/v1/evaluations',
+        '/api/v1/eval-stats',
+        '/api/v1/eval-stats/trend',
+        '/api/v1/eval-stats/rules',
+        '/api/v1/eval-stats/failures',
+        '/api/v1/filters',
+        '/api/v1/moments',
+        '/api/v1/failures',
+        '/api/v1/rules/custom',
+        '/api/v1/preferences',
+        '/api/v1/audit',
+      ];
+      const bad = [];
+      for (const p of paths) {
+        const res = await raw({ port, path: p });
+        const ct = String(res.headers['content-type'] ?? '');
+        if (res.status !== 200) bad.push(`${p} → ${res.status}`);
+        else if (!ct.includes('application/json')) bad.push(`${p} → content-type ${ct}`);
+        else if (res.json === undefined) bad.push(`${p} → unparseable body`);
+      }
+      assert(bad.length === 0, bad.join(' | '));
+      return `${paths.length}/${paths.length} endpoints 200 + JSON`;
+    });
+
+    await t.check('C11', 'GET /api/v1/moments/:id returns a hydrated moment', async () => {
+      const id = state.traceIds[0];
+      const res = await raw({ port, path: `/api/v1/moments/${id}` });
+      assertEq(res.status, 200, 'moment detail status');
+      assert(res.json, 'moment detail body was not JSON');
+      const missing = await raw({ port, path: '/api/v1/moments/00000000000000000000000000000000' });
+      assertEq(missing.status, 404, 'unknown moment id status');
+      return 'detail 200, unknown id 404';
+    });
+
+    // ---- Rules CRUD over HTTP -------------------------------------------
+    await t.check('C12', 'POST /api/v1/rules/custom creates a rule (201) and GET lists it', async () => {
+      const res = await postJson(
+        port,
+        '/api/v1/rules/custom',
+        {
+          name: 'uat-http-rule',
+          description: 'UAT harness rule deployed over HTTP.',
+          evalType: 'custom',
+          severity: 'medium',
+          definition: { name: 'uat-http-rule', type: 'min_length', config: { min_length: 40 } },
+        },
+        201,
+      );
+      assert(/^rule-[a-z0-9]+$/.test(res.json.rule.id), `rule id shape: ${res.json.rule.id}`);
+      state.ruleId = res.json.rule.id;
+      const list = await getJson(port, '/api/v1/rules/custom');
+      assert(list.rules.some((r) => r.id === state.ruleId), 'created rule is not listed');
+      return `${state.ruleId}`;
+    });
+
+    await t.check('C13', 'POST /api/v1/rules/custom with an invalid definition returns 400 JSON', async () => {
+      const res = await postJson(port, '/api/v1/rules/custom', {
+        name: 'uat bad rule!!',
+        evalType: 'custom',
+        definition: { name: 'x', type: 'not_a_type', config: {} },
+      });
+      assertEq(res.status, 400, 'status');
+      assert(res.json?.error, `400 body carried no error field: ${res.body.slice(0, 200)}`);
+      return 'rejected with JSON 400';
+    });
+
+    await t.check('C14', 'POST /api/v1/rules/custom/preview dry-runs against history', async () => {
+      const res = await postJson(
+        port,
+        '/api/v1/rules/custom/preview',
+        {
+          definition: { name: 'uat-preview', type: 'min_length', config: { min_length: 40 } },
+          evalType: 'custom',
+          windowDays: 7,
+          maxTraces: 100,
+        },
+        200,
+      );
+      const r = res.json;
+      assert(typeof r.tracesEvaluated === 'number', `no tracesEvaluated: ${JSON.stringify(r).slice(0, 200)}`);
+      assert(typeof r.wouldFail === 'number' && typeof r.wouldPass === 'number', 'preview is missing wouldFail/wouldPass');
+      assert(Array.isArray(r.examples), 'preview.examples is not an array');
+      assert(r.tracesEvaluated > 0, `preview evaluated 0 traces despite ${state.traceIds.length} seeded`);
+      assertEq(r.wouldPass + r.wouldFail + r.wouldSkip, r.tracesEvaluated, 'preview counts do not sum to tracesEvaluated');
+      // The seeded corpus contains deliberate short outputs ("short"),
+      // so a 40-char minimum must find at least one failure — otherwise
+      // the preview is reporting on nothing.
+      assert(r.wouldFail > 0, `preview found 0 failures despite ${SEED_COUNT / 3} deliberately short outputs`);
+      return `evaluated ${r.tracesEvaluated}, wouldFail ${r.wouldFail}`;
+    });
+
+    await t.check('C15', 'DELETE /api/v1/rules/custom/:id returns 204 then 404 on repeat', async () => {
+      assert(state.ruleId, 'no rule id from C12');
+      const del = await raw({ port, method: 'DELETE', path: `/api/v1/rules/custom/${state.ruleId}` });
+      assertEq(del.status, 204, 'first delete status');
+      const again = await raw({ port, method: 'DELETE', path: `/api/v1/rules/custom/${state.ruleId}` });
+      assertEq(again.status, 404, 'repeat delete status');
+      const list = await getJson(port, '/api/v1/rules/custom');
+      assert(!list.rules.some((r) => r.id === state.ruleId), 'deleted rule is still listed');
+      return '204 then 404, delisted';
+    });
+
+    // ---- Hostile headers -------------------------------------------------
+    await t.check('C16', 'a hostile Origin is rejected with 403 (and the server\'s own Origin is not)', async () => {
+      const own = await raw({ port, path: '/api/v1/health', headers: { Origin: `http://127.0.0.1:${port}` } });
+      assertEq(own.status, 200, "the server's own Origin must still pass");
+      const hostile = await raw({ port, path: '/api/v1/health', headers: { Origin: 'http://evil.attacker.example' } });
+      assertEq(hostile.status, 403, 'hostile Origin status');
+      // Both directions, or the check is theatre: a guard that 403s
+      // everything would "reject the hostile Origin" too.
+      const write = await raw({
+        port,
+        method: 'POST',
+        path: '/api/v1/rules/custom',
+        headers: { Origin: 'http://evil.attacker.example' },
+        body: { name: 'evil', evalType: 'custom', definition: { name: 'evil', type: 'min_length', config: { min_length: 1 } } },
+      });
+      assertEq(write.status, 403, 'hostile-Origin WRITE status');
+      return 'own 200, hostile read 403, hostile write 403';
+    });
+
+    await t.check('C17', 'a forged Host header is rejected with 403', async () => {
+      const forged = await raw({
+        port,
+        path: '/api/v1/health',
+        headers: { Host: 'attacker.example' },
+      });
+      assertEq(forged.status, 403, 'forged Host status');
+      const forgedPort = await raw({
+        port,
+        path: '/api/v1/health',
+        headers: { Host: `127.0.0.1:${port + 1}` },
+      });
+      assertEq(forgedPort.status, 403, 'wrong-port Host status');
+      const legit = await raw({ port, path: '/api/v1/health', headers: { Host: `127.0.0.1:${port}` } });
+      assertEq(legit.status, 200, 'the real Host must still pass');
+      return 'forged host 403, wrong port 403, real host 200';
+    });
+
+    // ---- Error-body hygiene ---------------------------------------------
+    await t.check('C18', 'a 404 response body contains no absolute filesystem path', async () => {
+      const probes = ['/definitely-not-a-route', '/api/v1/not-a-route', '/api/v1/traces/../../etc/passwd'];
+      const leaks = [];
+      for (const p of probes) {
+        const res = await raw({ port, path: p });
+        const m = res.body.match(ABS_PATH_RE);
+        if (m) leaks.push(`${p} (${res.status}) leaked "${m[0].slice(0, 80)}"`);
+      }
+      assert(leaks.length === 0, leaks.join(' | '));
+      return `${probes.length} 404 probes clean`;
+    });
+
+    await t.check('C19', 'error responses are JSON, never an HTML stack trace', async () => {
+      const probes = [
+        { path: '/api/v1/traces?limit=99999', expect: 400 },
+        { path: '/api/v1/audit?limit=0', expect: 400 },
+        { path: '/api/v1/health', headers: { Origin: 'http://evil.attacker.example' }, expect: 403 },
+        { path: '/api/v1/traces/00000000000000000000000000000000', expect: 404 },
+      ];
+      const bad = [];
+      for (const p of probes) {
+        const res = await raw({ port, path: p.path, headers: p.headers ?? {} });
+        if (res.status !== p.expect) bad.push(`${p.path} → ${res.status} (expected ${p.expect})`);
+        else if (/<html|<!DOCTYPE|<pre>/i.test(res.body)) bad.push(`${p.path} → HTML body`);
+        else if (res.json === undefined) bad.push(`${p.path} → non-JSON body: ${res.body.slice(0, 80)}`);
+      }
+      assert(bad.length === 0, bad.join(' | '));
+      return `${probes.length} error responses all JSON`;
+    });
+
+    await t.check('C20', 'no successful API response discloses the install path', async () => {
+      const paths = [
+        '/api/v1/health',
+        '/api/v1/summary',
+        '/api/v1/traces',
+        '/api/v1/evaluations',
+        '/api/v1/eval-stats',
+        '/api/v1/filters',
+        '/api/v1/moments',
+        '/api/v1/failures',
+        '/api/v1/rules/custom',
+        '/api/v1/preferences',
+        '/api/v1/audit',
+      ];
+      const leaks = [];
+      for (const p of paths) {
+        const res = await raw({ port, path: p });
+        const m = res.body.match(ABS_PATH_RE);
+        if (m) leaks.push(`${p} leaked "${m[0].slice(0, 90)}"`);
+      }
+      assert(leaks.length === 0, leaks.join(' | '));
+      return `${paths.length} endpoints disclose no filesystem path`;
+    });
+  } finally {
+    await srv.stop();
+  }
+}

--- a/tests/uat/suites/d-dashboard.mjs
+++ b/tests/uat/suites/d-dashboard.mjs
@@ -1,0 +1,317 @@
+/*
+ * Suite D — dashboard surface via Playwright (chromium).
+ *
+ * Runs against a real `--demo` server so the views have data to render;
+ * an empty dashboard renders empty states and would prove nothing.
+ *
+ * Assertions are DOM + console only — no screenshots. Every view must
+ * load with zero console errors, which is the single cheapest signal
+ * that a React page is actually working rather than merely painting.
+ *
+ * Readiness is a per-view content selector (the heading that only
+ * appears once that view's data has rendered), then a short bounded
+ * drain so a late console error still lands in the same check.
+ */
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { startServer } from '../lib/proc.mjs';
+import { getJson, postJson, raw } from '../lib/http.mjs';
+import { assert, assertEq } from '../lib/report.mjs';
+import { IRIS_NODE_MODULES, WORK_DIR } from '../lib/env.mjs';
+
+const DRAIN_MS = 900;
+const NAV_TIMEOUT = 25_000;
+const RULE_NAME = 'uat-dashboard-rule';
+
+/** Console noise that is not a defect in the page under test. */
+function isBlocking(text) {
+  // 429 = the harness itself out-polling the rate limiter; 400 = a
+  // background poll racing a filter change. Neither breaks rendering,
+  // and the repo's own e2e suite excludes both for the same reason.
+  return !/\b(429|400)\b/.test(text);
+}
+
+function attachConsole(page) {
+  const errors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+  page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+  return errors;
+}
+
+async function loadView(context, baseUrl, path, readySelector) {
+  const page = await context.newPage();
+  page.setDefaultTimeout(NAV_TIMEOUT);
+  const errors = attachConsole(page);
+  await page.goto(`${baseUrl}${path}`, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT });
+  await page.locator('h1').first().waitFor({ state: 'visible', timeout: NAV_TIMEOUT });
+  if (readySelector) {
+    await page.locator(readySelector).first().waitFor({ state: 'visible', timeout: NAV_TIMEOUT });
+  }
+  await page.waitForTimeout(DRAIN_MS);
+  return { page, errors };
+}
+
+function assertClean(errors, path) {
+  const blocking = errors.filter(isBlocking);
+  assert(
+    blocking.length === 0,
+    `${blocking.length} console error(s) on ${path}: ${blocking.slice(0, 3).join(' | ').slice(0, 320)}`,
+  );
+}
+
+export async function runSuiteD(t) {
+  t.beginSuite('D', 'Dashboard surface (Playwright / chromium)');
+
+  const home = join(WORK_DIR, 'd-dashboard');
+  mkdirSync(home, { recursive: true });
+
+  let chromium;
+  try {
+    ({ chromium } = await import(pathToFileURL(join(IRIS_NODE_MODULES, 'playwright', 'index.mjs')).href));
+  } catch (err) {
+    t.fail('D0', 'playwright loads from the iris repo node_modules', err.message);
+    return;
+  }
+
+  let srv;
+  try {
+    srv = await startServer({
+      argsFor: (p) => ['--demo', '--dashboard-port', String(p)],
+      irisHome: home,
+      label: '--demo dashboard server',
+      timeoutMs: 90_000,
+    });
+  } catch (err) {
+    t.fail('D0', '--demo dashboard server starts for the browser suite', err.message);
+    return;
+  }
+
+  const port = srv.port;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let browser;
+  let context;
+
+  try {
+    // The Welcome Tour is an aria-modal dialog that covers the page and
+    // swallows pointer events. Dismiss it through the API — a raw write
+    // to the preferences file is invisible to a server that already read
+    // it into memory at boot.
+    const patched = await raw({
+      port,
+      method: 'PATCH',
+      path: '/api/v1/preferences',
+      body: {
+        autoLaunch: false,
+        dismissedTours: ['tour-welcome'],
+        density: 'compact',
+        sidebarCollapsed: false,
+        notificationsLastSeen: '1970-01-01T00:00:00.000Z',
+      },
+    });
+    assert(patched.status === 200, `preferences PATCH failed: ${patched.status} ${patched.body.slice(0, 200)}`);
+
+    // A real demo trace to drill into, and a rule so /rules has a row
+    // with a Delete button.
+    const traces = await getJson(port, '/api/v1/traces?limit=1');
+    assert(traces.traces?.length > 0, 'demo server returned no traces — the drill-through checks would be vacuous');
+    const demoTrace = traces.traces[0];
+
+    const ruleRes = await postJson(
+      port,
+      '/api/v1/rules/custom',
+      {
+        name: RULE_NAME,
+        description: 'UAT harness rule for the dashboard delete-confirm check.',
+        evalType: 'custom',
+        severity: 'medium',
+        definition: { name: RULE_NAME, type: 'min_length', config: { min_length: 40 } },
+      },
+      201,
+    );
+    const ruleId = ruleRes.json.rule.id;
+
+    browser = await chromium.launch({ headless: true });
+    context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+
+    const dashboardViews = [
+      ['D1', 'Failures view (landing) loads with zero console errors', '/', 'h2:text-is("What failed")'],
+      ['D2', 'Health view loads with zero console errors', '/?view=health', 'h2:text-is("Headline")'],
+      ['D3', 'Drift view loads with zero console errors', '/?view=drift', 'h2:text-is("What changed")'],
+      ['D4', 'Stream view loads with zero console errors', '/?view=stream', 'h2:text-is("Live now")'],
+    ];
+
+    for (const [id, name, path, ready] of dashboardViews) {
+      await t.check(id, name, async () => {
+        const { page, errors } = await loadView(context, baseUrl, path, ready);
+        try {
+          assertClean(errors, path);
+          const text = await page.locator('body').innerText();
+          assert(text.trim().length > 200, `page rendered only ${text.trim().length} chars of text — likely an empty shell`);
+          return `${path} clean`;
+        } finally {
+          await page.close();
+        }
+      });
+    }
+
+    await t.check('D5', 'trace detail page renders the real trace with zero console errors', async () => {
+      const path = `/traces/${demoTrace.trace_id}`;
+      const { page, errors } = await loadView(context, baseUrl, path, `text=${demoTrace.agent_name}`);
+      try {
+        assertClean(errors, path);
+        const text = await page.locator('body').innerText();
+        assert(text.includes(demoTrace.agent_name), 'trace detail did not render the agent name');
+        assert(/Input \/ Output/.test(text), 'trace detail is missing the Input / Output section');
+        return `${demoTrace.agent_name} · ${demoTrace.trace_id.slice(0, 12)}…`;
+      } finally {
+        await page.close();
+      }
+    });
+
+    await t.check('D6', 'moment detail page renders with zero console errors', async () => {
+      const path = `/moments/${demoTrace.trace_id}`;
+      const { page, errors } = await loadView(context, baseUrl, path, `text=${demoTrace.agent_name}`);
+      try {
+        assertClean(errors, path);
+        const text = await page.locator('body').innerText();
+        assert(text.includes(demoTrace.agent_name), 'moment detail did not render the agent name');
+        return `moment ${demoTrace.trace_id.slice(0, 12)}…`;
+      } finally {
+        await page.close();
+      }
+    });
+
+    for (const [id, name, path, ready] of [
+      ['D7', 'Custom Rules page loads with zero console errors', '/rules', `text=${RULE_NAME}`],
+      ['D8', 'Audit Log page loads with zero console errors', '/audit', null],
+    ]) {
+      await t.check(id, name, async () => {
+        const { page, errors } = await loadView(context, baseUrl, path, ready);
+        try {
+          assertClean(errors, path);
+          const text = await page.locator('body').innerText();
+          assert(text.trim().length > 100, `page rendered only ${text.trim().length} chars of text — likely an empty shell`);
+          return `${path} clean`;
+        } finally {
+          await page.close();
+        }
+      });
+    }
+
+    await t.check('D9', 'list routes (/traces, /evals, /moments) load with zero console errors', async () => {
+      const errs = [];
+      for (const path of ['/traces', '/evals', '/moments']) {
+        const { page, errors } = await loadView(context, baseUrl, path, null);
+        try {
+          const blocking = errors.filter(isBlocking);
+          if (blocking.length) errs.push(`${path}: ${blocking.slice(0, 2).join(' | ')}`);
+        } finally {
+          await page.close();
+        }
+      }
+      assert(errs.length === 0, errs.join(' || ').slice(0, 400));
+      return '3 list routes clean';
+    });
+
+    await t.check('D10', 'Ctrl+K opens the command palette', async () => {
+      const { page, errors } = await loadView(context, baseUrl, '/', 'h2:text-is("What failed")');
+      try {
+        await page.keyboard.press('Control+k');
+        const dialog = page.locator('[role="dialog"][aria-label="Command palette"]');
+        await dialog.waitFor({ state: 'visible', timeout: 10_000 });
+        await page.locator('input[aria-label="Command query"]').waitFor({ state: 'visible', timeout: 5000 });
+        assertClean(errors, 'command palette open');
+        return 'palette visible with a focused query input';
+      } finally {
+        await page.close();
+      }
+    });
+
+    await t.check('D11', 'the command palette returns DATA results for a query matching demo content', async () => {
+      const { page, errors } = await loadView(context, baseUrl, '/', 'h2:text-is("What failed")');
+      try {
+        await page.keyboard.press('Control+k');
+        const input = page.locator('input[aria-label="Command query"]');
+        await input.waitFor({ state: 'visible', timeout: 10_000 });
+        await input.fill(demoTrace.agent_name);
+        // Data results carry ids namespaced by kind (rule./trace./eval.);
+        // a command-registry hit would NOT match these selectors, so this
+        // proves the palette searched the user's data and not just its
+        // own static command list.
+        const dataOption = page.locator(
+          '#command-palette-list [role="option"][id^="cmd-trace."], #command-palette-list [role="option"][id^="cmd-eval."], #command-palette-list [role="option"][id^="cmd-rule."]',
+        );
+        await dataOption.first().waitFor({ state: 'visible', timeout: 15_000 });
+        const count = await dataOption.count();
+        assert(count > 0, 'palette returned no data results');
+        assertClean(errors, 'command palette search');
+        return `${count} data result(s) for "${demoTrace.agent_name}"`;
+      } finally {
+        await page.close();
+      }
+    });
+
+    await t.check('D12', 'a rules-page delete opens the in-app confirm dialog (role=alertdialog)', async () => {
+      const { page, errors } = await loadView(context, baseUrl, '/rules', `text=${RULE_NAME}`);
+      try {
+        await page.getByRole('button', { name: 'Delete', exact: true }).first().click();
+        const dialog = page.locator('[role="alertdialog"]');
+        await dialog.waitFor({ state: 'visible', timeout: 10_000 });
+        const title = await dialog.locator('h2').innerText();
+        assert(title.includes(RULE_NAME), `confirm dialog does not name the rule: "${title}"`);
+        await dialog.getByRole('button', { name: 'Cancel' }).click();
+        await dialog.waitFor({ state: 'hidden', timeout: 10_000 });
+        assertClean(errors, '/rules delete confirm');
+        return `alertdialog titled "${title.slice(0, 60)}"`;
+      } finally {
+        await page.close();
+      }
+    });
+
+    await t.check('D13', 'confirming the dialog actually deletes the rule', async () => {
+      const { page, errors } = await loadView(context, baseUrl, '/rules', `text=${RULE_NAME}`);
+      try {
+        await page.getByRole('button', { name: 'Delete', exact: true }).first().click();
+        const dialog = page.locator('[role="alertdialog"]');
+        await dialog.waitFor({ state: 'visible', timeout: 10_000 });
+        await dialog.getByRole('button', { name: 'Delete rule' }).click();
+        await dialog.waitFor({ state: 'hidden', timeout: 10_000 });
+        await page.locator(`text=${RULE_NAME}`).first().waitFor({ state: 'detached', timeout: 10_000 });
+        const list = await getJson(port, '/api/v1/rules/custom');
+        assert(!list.rules.some((r) => r.id === ruleId), 'the rule is still in the store after confirming delete');
+        assertClean(errors, '/rules delete confirm');
+        return 'rule removed from the page and the store';
+      } finally {
+        await page.close();
+      }
+    });
+
+    await t.check('D14', 'the SPA serves its own bundle (no 404 on the built assets)', async () => {
+      const page = await context.newPage();
+      const failed = [];
+      page.on('response', (res) => {
+        if (res.status() >= 400 && /\.(js|css|svg|woff2?)$/.test(new URL(res.url()).pathname)) {
+          failed.push(`${res.status()} ${new URL(res.url()).pathname}`);
+        }
+      });
+      try {
+        await page.goto(`${baseUrl}/`, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT });
+        await page.locator('h1').first().waitFor({ state: 'visible', timeout: NAV_TIMEOUT });
+        await page.waitForTimeout(DRAIN_MS);
+        assert(failed.length === 0, `asset requests failed: ${failed.join(', ')}`);
+        return 'all bundle assets served';
+      } finally {
+        await page.close();
+      }
+    });
+  } catch (err) {
+    t.fail('D99', 'dashboard suite completed without an unhandled error', err.message);
+  } finally {
+    if (context) await context.close().catch(() => {});
+    if (browser) await browser.close().catch(() => {});
+    await srv.stop();
+  }
+}


### PR DESCRIPTION
`npm run test:uat` — 70 checks across four surfaces, one command, deterministic and re-runnable.

| Suite | Surface | Checks |
|---|---:|---|
| A | CLI | 14 — exit codes, flag drift guard (`--help` vs what the parser accepts), `--self-test`, `--demo`/`--demo-clear` isolation |
| B | MCP over real stdio | 19 — advertised tool list matches `.claims.json` exactly, every tool invoked, deploy→fire→delete, survive-restart, graceful failure without API keys |
| C | HTTP | 20 — every route, `POST /traces` valid/invalid/with-eval, hostile Origin and forged Host via `node:http`, no absolute path in any body |
| D | Dashboard (Playwright) | 14 — every view with **zero console errors**, ⌘K returns real data, delete opens the in-app alertdialog |
| G | Harness integrity | 3 — artifact freshness + the real-home guard |

### It earns its place

Run against main, it found three defects the 847-test suite did not:

- **A rule deployed via `deploy_rule` never fired until the server restarted.** B11 failed while B12 — the identical flow *after* a restart — passed. That is the core custom-rule promise, broken end to end.
- **Two endpoints still leaked the absolute install path** (the CWE-209 class we thought we'd closed).
- **`no_pii` silently ignored the canonical documentation SSN** — the exact string a builder pastes first when checking whether we work.

All three are now fixed on main, and this harness is what keeps them fixed.

### Contract

The repo is read-only apart from `dist/`. Every spawned server gets its own scratch `IRIS_HOME` under a git-ignored `.work/`. Suite G content-hashes the founder's real `~/.iris` before and after, failing the run outright if anything changed — that guard exists because a test suite once wiped a live audit log and left rules in the live store for four months, with the suite green throughout.

The repo root is derived from the harness's own location rather than hardcoded, so it runs from a clone, a git worktree, or a CI runner.

**Not wired into CI in this PR** — suite D needs a browser and the whole run takes ~30s; adding it as a required check deserves its own decision about runner cost. It is a one-command local gate today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)