### PR TITLE
fix(docker): the published image has been dead on arrival since March

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,47 @@ jobs:
         # injection positives), a dashboard bind and the rebinding guard,
         # then exits non-zero on any failure. Runs as the image's own
         # unprivileged `iris` user, which is how it will actually run.
+        #
+        # NOT sufficient alone: --self-test builds its OWN config and never
+        # calls loadConfig, so it cannot see a broken ENV block. It passes
+        # happily on an image whose shipped CMD exits 1 on a port collision.
+        # The step below is the one that catches that.
         run: docker run --rm iris-eval/mcp-server:ci node dist/index.js --self-test
+
+      - name: Run the image AS SHIPPED — default CMD, both ports answering
+        # The gate the DOA image walked through for four months. This runs no
+        # command of its own: it starts the container exactly as `docker run
+        # ghcr.io/iris-eval/mcp-server` does, publishes the two documented
+        # ports, and requires both servers to answer THROUGH the published
+        # mapping — which also proves the in-container bind address is
+        # reachable, since loopback inside a container is not.
+        run: |
+          set -euo pipefail
+          docker run -d --name iris-ci -p 3000:3000 -p 6920:6920 iris-eval/mcp-server:ci
+          ready=""
+          for _ in $(seq 1 30); do
+            if curl -fsS -o /dev/null "http://127.0.0.1:6920/api/v1/health"; then ready=1; break; fi
+            if [ -z "$(docker ps --filter name=iris-ci --filter status=running -q)" ]; then
+              echo "::error::container exited before becoming ready — as shipped, this image does not start"
+              docker logs iris-ci
+              exit 1
+            fi
+            sleep 2
+          done
+          if [ -z "$ready" ]; then
+            echo "::error::dashboard never answered on the published port"
+            docker logs iris-ci
+            docker rm -f iris-ci
+            exit 1
+          fi
+          echo "--- dashboard health ---"
+          curl -fsS "http://127.0.0.1:6920/api/v1/health"
+          echo ""
+          echo "--- MCP transport must answer on its own port (any HTTP status proves a live listener) ---"
+          code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:3000/mcp" || true)
+          echo "GET /mcp -> $code"
+          docker rm -f iris-ci
+          test "$code" != "000"
 
   e2e:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,14 +61,38 @@ RUN mkdir -p /data && chown iris:iris /data
 
 USER iris
 
+# Two settings here are load-bearing, and both were wrong — which is why
+# every published image since 2026-03 exited 1 on `docker run`.
+#
+# PORTS MUST DIFFER. The MCP transport and the dashboard are two servers.
+# `validatePortConfig` refuses to start when both are aimed at one port, and
+# that check has been in the code since 2026-04-23 while this file kept
+# pointing both at 3000. The container did not "mostly work": it failed fast,
+# before any bind, with no partial function.
+#
+# HOSTS MUST BE 0.0.0.0 INSIDE THE CONTAINER. The process defaults to
+# 127.0.0.1 — correct on a laptop, and 0.4.6 made it the default to close a
+# real LAN-exposure bug. But 127.0.0.1 inside a container's own network
+# namespace is unreachable from `-p`, so the loopback default silently turns
+# every published port into a connection refused. The exposure control here
+# is the container boundary plus whatever the operator publishes with `-p`,
+# not the in-container bind address. The DNS-rebinding guard still applies,
+# and the startup warning for binding beyond loopback without an API key
+# still fires — which is exactly what an operator should see.
 ENV IRIS_TRANSPORT=http \
     IRIS_PORT=3000 \
+    IRIS_HOST=0.0.0.0 \
     IRIS_DB_PATH=/data/iris.db \
     IRIS_DASHBOARD=true \
-    IRIS_DASHBOARD_PORT=3000
+    IRIS_DASHBOARD_PORT=6920 \
+    IRIS_DASHBOARD_HOST=0.0.0.0
 
-EXPOSE 3000
+EXPOSE 3000 6920
 
 VOLUME ["/data"]
 
-CMD ["node", "dist/index.js", "--transport", "http", "--port", "3000", "--dashboard"]
+# No --port/--dashboard-port flags baked in: the ENV above is the single
+# source, so an operator overriding IRIS_DASHBOARD_PORT at `docker run` is
+# not silently beaten by a CLI flag in the image (CLI wins over env in the
+# config merge).
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ Iris is a standard stdio MCP server — one `npx @iris-eval/mcp-server` command,
 npm install -g @iris-eval/mcp-server
 iris-mcp --dashboard
 
-# Docker
-docker run -p 3000:3000 -v iris-data:/data ghcr.io/iris-eval/mcp-server
+# Docker — two servers, two ports: 3000 = MCP HTTP transport,
+# 6920 = dashboard (which also serves the POST /api/v1/traces ingest endpoint)
+docker run -p 3000:3000 -p 6920:6920 -v iris-data:/data ghcr.io/iris-eval/mcp-server
 ```
 
 > **Tip:** Global install (`npm install -g`) stores traces persistently at `~/.iris/iris.db`. With `npx`, traces persist in the same location, but startup is slower due to package resolution.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,24 @@
 services:
   iris-mcp:
     build: .
+    # Two servers, two ports: 3000 = MCP HTTP transport, 6920 = dashboard
+    # (which also serves POST /api/v1/traces, the no-MCP-client ingest path).
+    # Publishing only 3000 leaves the dashboard running and unreachable.
     ports:
       - "3000:3000"
+      - "6920:6920"
     volumes:
       - iris-data:/data
     environment:
       - IRIS_TRANSPORT=http
       - IRIS_PORT=3000
+      # 0.0.0.0 inside the container: the process defaults to loopback, which
+      # is unreachable through a published port. See the Dockerfile comment.
+      - IRIS_HOST=0.0.0.0
       - IRIS_DB_PATH=/data/iris.db
       - IRIS_DASHBOARD=true
+      - IRIS_DASHBOARD_PORT=6920
+      - IRIS_DASHBOARD_HOST=0.0.0.0
       - IRIS_LOG_LEVEL=info
     restart: unless-stopped
 


### PR DESCRIPTION
## The defect

`docker run ghcr.io/iris-eval/mcp-server` — **the command in our own README** — exits 1 before binding anything. Both `:latest` and `:v0.5.0` resolve to the same non-starting image, and it has been this way since ~2026-03.

Two independent problems in the `ENV` block:

1. **Port collision.** `IRIS_PORT=3000` and `IRIS_DASHBOARD_PORT=3000`. `validatePortConfig` has refused that combination since 2026-04-23 (F-006), so the container fails fast with no partial function. Dashboard moves to its documented default, 6920.
2. **Loopback bind inside a container.** Both servers default to `127.0.0.1` — correct on a laptop, and 0.4.6 made it the default to close a real LAN-exposure bug — but inside a container's network namespace that is unreachable through `-p`. Even with fix 1, every published port would have been a connection refused. Now `IRIS_HOST` / `IRIS_DASHBOARD_HOST` are `0.0.0.0`, where the exposure control is the container boundary plus what the operator publishes. The DNS-rebinding guard and the bind-beyond-loopback warning still apply.

Verified against the real config loader rather than by reading: the old env throws `Port collision…`; the new env resolves `0.0.0.0:3000` + `0.0.0.0:6920` and passes validation.

## Why nothing caught it — the durable half

`docker-build` ran with `push:false, load:false`: it proved the image **builds** and nothing more. #380 fixed that (`load:true` plus a run step) but the run step is `--self-test`, which **builds its own config and never calls `loadConfig`** — so it passes cleanly on an image whose shipped `CMD` cannot start.

This PR adds a step that runs the container **as shipped**: default `CMD`, both documented ports published, and both servers must answer *through the published mapping* — which is also what proves the in-container bind address is reachable. Same lesson as `gate-coverage-vs-claim`: a gate named "does it actually start?" has to start the thing users start.

Also: `CMD` drops its baked-in `--port`/`--dashboard-port` flags so an operator's `-e IRIS_DASHBOARD_PORT=…` isn't silently beaten by a CLI flag in the image (CLI wins over env in the merge). `docker-compose.yml` and the README command publish both ports.

Found by the post-release acceptance swarm. 953/953 tests, typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)