### PR TITLE
docs: the four public surfaces still teaching pre-0.5.0 behaviour

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -965,7 +965,9 @@ Used when `eval_type` is `"safety"`. These rules check for PII leakage, blocked 
 - Private key block: `-----BEGIN … PRIVATE KEY-----` armour
 - Seed phrase: recovery/seed/mnemonic framing + a 12-word BIP39-shaped run
 
-Documentation placeholders are suppressed per match, not per pattern: RFC 2606 `example.com`/`example.org` addresses, the 555 fictional phone block, toll-free lines, published payment test cards, the never-issued docs SSN `123-45-6789`, masked keys (`sk-xxxx…`), and bare 10-digit runs (Unix timestamps). Real PII sitting beside a placeholder still fails.
+Documentation placeholders are suppressed per match, not per pattern: RFC 2606 `example.com`/`example.org` addresses, the 555 fictional phone block, toll-free lines, published payment test cards, masked keys (`sk-xxxx…`), and bare 10-digit runs (Unix timestamps). Real PII sitting beside a placeholder still fails.
+
+**`123-45-6789` is deliberately NOT suppressed.** Every other exemption above rests on a formal reservation (RFC 2606, the 555-01XX exchange, issuer-published test cards); the canonical fake SSN has no such status — it is convention. It is also the first string anyone pastes to test a PII detector, so staying silent there reads as "Iris is broken". `no_pii` fires on it, and because `no_pii` is a critical rule the evaluation returns `passed: false`.
 
 **Injection patterns detected (37, in two tiers).** Phrase tier (13) -- matched only OUTSIDE quoted spans, so a security explainer or an injection-detector unit test that quotes the wording is not flagged:
 - `ignore (all )?(previous|above|prior) (instructions|prompts)`
@@ -1024,7 +1026,13 @@ Output must match a regex pattern.
 | `pattern` | `string` | Yes | Regular expression pattern |
 | `flags` | `string` | No | Regex flags (e.g., `"i"` for case-insensitive) |
 
-Safety: Patterns longer than 1000 characters are rejected. Patterns vulnerable to catastrophic backtracking are rejected via `safe-regex2`.
+Safety: two layers, and only the second one holds.
+
+**Static checks (fast rejection, best-effort):** patterns longer than 1000 characters are rejected; invalid syntax is rejected; `safe-regex2` rejects exponential *star-height* blowup like `(a+)+$`. It is a heuristic, not a guarantee — `(a|a)*$` (exponential), `a*a*a*a*a*b` and `.*.*.*.*=.*` (polynomial) all pass it. `deploy_rule` additionally test-runs candidate patterns against short adversarial payloads.
+
+**The runtime boundary:** every match of a user-supplied pattern executes in a sandbox worker thread under a hard 100 ms deadline. A match still backtracking at the deadline is terminated mid-execution, so a pattern that survived the static checks — or an output crafted to stall a legitimate pattern — cannot hang the server. Two further bounds: a per-evaluation circuit breaker opens after 3 budget breaches, and `custom_rules` is capped at 10 per call.
+
+**This is fail-open per rule, and a gate should know it.** A budget-killed rule reports `skipped: true` with `budgetExceeded: true` and does **not** judge the output — so it neither scores nor vetoes, and an adversary who knows your pattern can craft output that stalls it into skipping. If your gate must fail closed, treat any `skipped && budgetExceeded` result as a failure; if a *critical* rule was the one killed, the response also carries `critical_skipped`. See [Custom Rules → ReDoS Protection](custom-rules.md#redos-protection).
 
 ```json
 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,9 +176,13 @@ src/
       audit.ts          GET /api/v1/audit — read of the append-only audit log
       preferences.ts    GET/PATCH /api/v1/preferences
 
-    Note: rules and preferences accept writes over HTTP; traces and
-    evaluations are read-only here and can only be created through the MCP
-    tools. Closing that gap is Track 3 in the roadmap.
+    Note: since v0.5.0 traces can also be CREATED over HTTP — POST
+    /api/v1/traces (traces.ts) takes the same body as the log_trace tool,
+    validated against the same exported schema, and with evaluate:true it
+    runs the deterministic engine and writes an eval_result too. That is
+    the no-MCP-client capture path; see docs/http-ingest.md. It is served
+    by the DASHBOARD server, so it requires --dashboard (the dashboard no
+    longer starts implicitly with --transport http).
   types/
     config.ts           IrisConfig interface
     trace.ts            Trace, Span, TokenUsage, ToolCallRecord types
@@ -234,11 +238,15 @@ dashboard/              React SPA (separate Vite build)
 ### Scoring algorithm
 
 ```
-score = SUM(rule[i].score * rule[i].weight) / SUM(rule[i].weight)
-passed = score >= threshold   (default threshold: 0.7)
+score  = SUM(rule[i].score * rule[i].weight) / SUM(rule[i].weight)   # evaluated rules only
+passed = score >= threshold AND no critical rule failed              (default threshold: 0.7)
 ```
 
-Each rule returns a score between 0 and 1. The final score is the weighted average of all rule scores, rounded to three decimal places. Rules that don't apply (e.g., `expected_coverage` when no expected output is given) return `score: 1` with a skip message.
+Each rule returns a score between 0 and 1. The final score is the weighted average across the rules that actually ran, rounded to three decimal places.
+
+**`score` and `passed` answer different questions.** `score` is a quality gradient; `passed` is the ship/no-ship verdict. A failing (non-skipped) **critical** rule forces `passed: false` regardless of how high the weighted score is, and the response names the culprits in `critical_failures`. The critical rules are `no_pii`, `no_injection_patterns` and `no_blocklist_words`, plus any deployed custom rule with severity `high`/`critical`. A leaked SSN scores 0.765 against a 0.7 threshold and still fails — that is the point (see §Scoring semantics in `docs/api-reference.md`).
+
+**Skipped rules are excluded, not scored 1.** A rule that cannot judge the output — `expected_coverage` with no expected output, a missing-context relevance rule, or a regex killed at the sandbox matching budget — returns `score: 0` with `skipped: true` and a `skipReason`, and is left OUT of both the weighted average and the critical-rule veto. A skipped rule therefore neither deflates the score nor vetoes on evidence it never gathered; budget-killed rules additionally carry `budgetExceeded: true` so a gate that must fail closed can treat them as failures.
 
 ### Built-in rule details
 

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -96,7 +96,12 @@ export function getAllPosts(): BlogPost[] {
         description: (meta.description as string) || extractDescription(content),
         content,
         filename,
-        published: meta.published !== false,
+        // parseFrontmatter yields STRINGS, so `meta.published` is the string
+        // "false", never the boolean — `!== false` was therefore always true
+        // and this gate has never withheld anything. A post written with
+        // `published: false` rendered live on the site. Compare the parsed
+        // form instead.
+        published: String(meta.published ?? "true").trim().toLowerCase() !== "false",
         relatedPosts: (meta.relatedPosts as string[]) || undefined,
       };
     })


### PR DESCRIPTION
Post-release audit residue. Every item here is a document a user — or an integrating model — reads, and every one describes the release we replaced. All four were confirmed against source before editing.

| Surface | Said | Ships |
|---|---|---|
| `architecture.md:179-181` | traces "are read-only here and can only be created through the MCP tools. Closing that gap is **Track 3**" | `POST /api/v1/traces` is a v0.5.0 headline feature. This file is linked from the product UI and the public security page. |
| `architecture.md:236-241` | `passed = score >= threshold`; skipped rules "return `score: 1`" | `passed` also requires no critical-rule failure (the release headline); skipped rules return 0 with `skipped:true` and are excluded from the average. The same file states the veto correctly 145 lines earlier. |
| `api-reference.md:1025` | catastrophic backtracking "is rejected via `safe-regex2`" | The exact claim 0.5.0 retired — `safe-regex2` is star-height-only and `(a\|a)*$` walks through it. A gate built from this file alone would not know a regex rule can silently skip. `custom-rules.md` and `architecture.md` were fixed in #380; this file was the miss. |
| `api-reference.md:966` | `123-45-6789` is a suppressed placeholder | Code deliberately does the opposite (17-line rationale comment), and since `no_pii` is critical it now fails the whole eval. The doc taught the inverse. |

Also closes the residual from a **refuted** finding: `website/src/lib/blog.ts:99`'s draft gate is dead code. `parseFrontmatter` yields strings, so `meta.published !== false` compares `"false"` against a boolean and is always true — a post marked `published: false` renders live. No post sets it today, so this changes nothing now and shuts the trapdoor before someone relies on it.

953/953 tests, typecheck + lint green, website lint + `tsc --noEmit` clean, claims unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)